### PR TITLE
Replace reusable identifier methods with a C function (#40)

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -443,15 +443,6 @@
     _collectionView.backgroundView.hidden = itemCount > 0;
 }
 
-// use the string representation of a reusable view class when registering with a UICollectionView
-- (NSString *)reusableViewIdentifierForClass:(Class)viewClass {
-    return NSStringFromClass(viewClass);
-}
-
-- (NSString *)reusableViewIdentifierForClass:(Class)viewClass elementKind:(NSString *)elementKind {
-    return [elementKind stringByAppendingString:NSStringFromClass(viewClass)];
-}
-
 - (IGListSectionMap *)sectionMapAdjustForUpdateBlock:(BOOL)adjustForUpdateBlock {
     // if we are inside an update block, we may have to use the /previous/ item map for some operations
     if (adjustForUpdateBlock && self.isInUpdateBlock && self.previoussectionMap != nil) {
@@ -720,7 +711,7 @@
     IGParameterAssert(cellClass != nil);
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Reloading adapter without a collection view.");
-    NSString *identifier = [self reusableViewIdentifierForClass:cellClass];
+    NSString *identifier = IGListReusableViewIdentifier(cellClass, nil);
     NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
     if (![self.registeredCellClasses containsObject:cellClass]) {
         [self.registeredCellClasses addObject:cellClass];
@@ -736,7 +727,7 @@
     IGAssertMainThread();
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Reloading adapter without a collection view.");
-    NSString *identifier = [self reusableViewIdentifierForClass:viewClass elementKind:elementKind];
+    NSString *identifier = IGListReusableViewIdentifier(viewClass, elementKind);
     NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
     if (![self.registeredSupplementaryViewIdentifiers containsObject:identifier]) {
         [self.registeredSupplementaryViewIdentifiers addObject:identifier];

--- a/Source/Internal/IGListAdapterInternal.h
+++ b/Source/Internal/IGListAdapterInternal.h
@@ -17,6 +17,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/// Generate a string representation of a reusable view class when registering with a UICollectionView.
+NS_INLINE NSString *IGListReusableViewIdentifier(Class viewClass, NSString * _Nullable kind) {
+  return [NSString stringWithFormat:@"%@%@", kind ?: @"", NSStringFromClass(viewClass)];
+}
+
 @interface IGListAdapter ()
 <
 UICollectionViewDataSource,
@@ -54,8 +59,6 @@ IGListCollectionContext
 - (NSArray *)indexPathsFromSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                      indexes:(NSIndexSet *)indexes
                         adjustForUpdateBlock:(BOOL)adjustForUpdateBlock;
-
-- (NSString *)reusableViewIdentifierForClass:(Class)viewClass;
 
 @end
 

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -143,8 +143,13 @@
 }
 
 - (void)test_whenQueryingReusableIdentifier_thatIdentifierEqualsClassName {
-    NSString *identifier = [self.adapter reusableViewIdentifierForClass:UICollectionViewCell.class];
+    NSString *identifier = IGListReusableViewIdentifier(UICollectionViewCell.class, nil);
     XCTAssertEqualObjects(identifier, @"UICollectionViewCell");
+}
+
+- (void)test_whenQueryingReusableIdentifier_thatIdentifierEqualsClassNameAndSupplimentaryKind {
+    NSString *identifier = IGListReusableViewIdentifier(UICollectionViewCell.class, UICollectionElementKindSectionFooter);
+    XCTAssertEqualObjects(identifier, @"UICollectionElementKindSectionFooterUICollectionViewCell");
 }
 
 - (void)test_whenDataSourceChanges_thatBackgroundViewVisibilityChanges {


### PR DESCRIPTION
## Changes in this pull request

Replaced the two methods for generating a reusable identifier with an inline C function (as per #40) which has 3 parameters: `viewClass` (unchanged), `nibName` (for when #1 is added), and `kind`. The string is generated following the same pattern as before.

A few things:
- The current test only tests one of the options. May want to add more tests for each.
- Not sure if you guys prefer `NS_INLINE` vs `static inline`. 
- Not sure if we want to add assertions for empty strings for nibName/kind parameters.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)
