### PR TITLE
IGListAdapter: Fix not returning early when collectionView/dataSource is nil and completion is nil

### DIFF
--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -103,14 +103,14 @@ IGLK_SUBCLASSING_RESTRICTED
 - (void)performUpdatesAnimated:(BOOL)animated completion:(nullable IGListUpdaterCompletion)completion;
 
 /**
- Perform an immediate reload of the data in the data source, discarding the old objectss.
+ Perform an immediate reload of the data in the data source, discarding the old objects.
 
  @param completion A block executed when the reload completes.
  */
 - (void)reloadDataWithCompletion:(nullable IGListUpdaterCompletion)completion;
 
 /**
- Reload the infra for specific objectss only.
+ Reload the infra for specific objects only.
 
  @param objects The objects to reload.
  */

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -248,8 +248,8 @@
     if (dataSource == nil || collectionView == nil) {
         if (completion) {
             completion(NO);
-            return;
         }
+        return;
     }
 
     NSArray *newItems = [[dataSource objectsForListAdapter:self] copy];


### PR DESCRIPTION
## Changes in this pull request

- I ran the static analyzer, and it found a case in `performUpdatesAnimated:completion:` where it looks like we meant to bail out early if the `collectionView` or `dataSource` is nil, but it only does so if `completion` is provided.
- Fixed a spelling error in nearby documentation

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)

### Notes
- There is one other analyzer warning, but it seems to be making an incorrect assumption. In any case, it's not something I can fix quickly (requires more time spent staring at IGListDiff.mm).
- A ticket should be opened to add static analysis to .travis.yml. I'lll do this soonish, unless someone beats me to it!

### Questions
- I could add a test for this, but this project is annotated well enough with nullability annotations that it's easy for the analyzer to catch bugs like this (it could tell there was a case where the nil `collectionView` might make it somewhere it shouldn't have). Should I add a test anyway?
- I had to add the IGListKitTests scheme manually to run the tests. Should I make it a shared scheme and commit it?