### PR TITLE
Use bundler to manage CocoaPods and xcpretty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ playground.xcworkspace
 # Carthage/Checkouts
 
 Carthage/Build
+
+# Bundler
+.bundle
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ env:
    - DESTINATION="OS=9.3,name=iPad Air"       SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
    - DESTINATION="OS=10.0,name=iPhone 7"      SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
 
-install: bundle install --path vendor/bundle
+# Do this in before_install, so that gems are installed
+# before travis prints package version info and avoid a
+# warning about missing gems.
+before_install: bundle install --path vendor/bundle
 
 script:
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 script:
 - if [ $POD_LINT == "YES" ]; then
-      bundle exec pod spec lint;
+      bundle exec pod lib lint;
   fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ script:
 
 
 - if [ $BUILD_EXAMPLE == "YES" ]; then
-      xcodebuild clean build -workspace Example/IGListKitExamples.xcworkspace -scheme IGListKitExamples -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
+      xcodebuild clean build -workspace Example/IGListKitExamples.xcworkspace -scheme IGListKitExamples -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
   fi
 
 
 - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
+      xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
   else
-      xcodebuild clean build -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
+      xcodebuild clean build -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 osx_image: xcode8
+gemfile: Gemfile
 
 env:
    global:
@@ -20,11 +21,6 @@ env:
    - DESTINATION="OS=9.2,name=iPhone 6s Plus" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
    - DESTINATION="OS=9.3,name=iPad Air"       SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
    - DESTINATION="OS=10.0,name=iPhone 7"      SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-
-# Do this in before_install, so that gems are installed
-# before travis prints package version info and avoid a
-# warning about missing gems.
-before_install: bundle install --path vendor/bundle
 
 script:
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ script:
 
 
 - if [ $BUILD_EXAMPLE == "YES" ]; then
-      xcodebuild clean build -workspace Example/IGListKitExamples.xcworkspace -scheme IGListKitExamples -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
+      xcodebuild clean build -workspace Example/IGListKitExamples.xcworkspace -scheme IGListKitExamples -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
   fi
 
 
 - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
+      xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
   else
-      xcodebuild clean build -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
+      xcodebuild clean build -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,22 @@ env:
    - DESTINATION="OS=9.3,name=iPad Air"       SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
    - DESTINATION="OS=10.0,name=iPhone 7"      SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
 
+install: bundle install --path vendor/bundle
+
 script:
 - if [ $POD_LINT == "YES" ]; then
-      pod spec lint;
+      bundle exec pod spec lint;
   fi
 
 
 - if [ $BUILD_EXAMPLE == "YES" ]; then
-      xcodebuild clean build -workspace Example/IGListKitExamples.xcworkspace -scheme IGListKitExamples -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO | xcpretty -c;
+      xcodebuild clean build -workspace Example/IGListKitExamples.xcworkspace -scheme IGListKitExamples -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
   fi
 
 
 - if [ $RUN_TESTS == "YES" ]; then
-      xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | xcpretty -c;
+      xcodebuild test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
   else
-      xcodebuild clean build -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | xcpretty -c;
+      xcodebuild clean build -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO | bundle exec xcpretty -c;
   fi
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'cocoapods', '1.1.0.rc.3'
+gem 'xcpretty', '0.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.1.0.rc.3)
-  xcpretty
+  xcpretty (= 0.2.4)
 
 BUNDLED WITH
    1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,73 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.7.1)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (1.0.1)
+    cocoapods (1.1.0.rc.3)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.1, < 2.0)
+      cocoapods-core (= 1.1.0.rc.3)
+      cocoapods-deintegrate (>= 1.0.1, < 2.0)
+      cocoapods-downloader (>= 1.1.1, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (= 1.1.0.beta.1)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      fourflusher (~> 2.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.5.1)
+      nap (~> 1.0)
+      xcodeproj (>= 1.3.2, < 2.0)
+    cocoapods-core (1.1.0.rc.3)
+      activesupport (>= 4.0.2, < 5)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.1)
+    cocoapods-downloader (1.1.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.0.0)
+    cocoapods-trunk (1.1.0.beta.1)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (1.1.0)
+    colored (1.2)
+    escape (0.0.4)
+    fourflusher (2.0.0)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.0.2)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.9.1)
+    molinillo (0.5.1)
+    nap (1.1.0)
+    netrc (0.7.8)
+    rouge (1.11.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (1.3.2)
+      activesupport (>= 3)
+      claide (>= 1.0.1, < 2.0)
+      colored (~> 1.2)
+    xcpretty (0.2.4)
+      rouge (~> 1.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (= 1.1.0.rc.3)
+  xcpretty
+
+BUNDLED WITH
+   1.13.1


### PR DESCRIPTION
## Changes in this pull request

- Travis appears to be using CocoaPods 1.1.0.beta.2, which is missing some fixes for Xcode 8 (see [sample failing build](https://travis-ci.org/Instagram/IGListKit/jobs/166935850) from #51).
- This change will ensure that a consistent CocoaPods version is used by Travis
- In the added Gemfile, I picked the latest CocoaPods 1.1.0 RC (matches version in Podfile.lock) and the latest xcpretty.
- Changed `pod spec lint` to `pod lib lint` to verify local files instead of files from the version specified in the spec.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)