### PR TITLE
Extension only API flag

### DIFF
--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -795,6 +795,7 @@
 		887D0B4B1D870D7F009E01F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -816,6 +817,7 @@
 		887D0B4C1D870D7F009E01F7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
## Changes in this pull request

Adds `APPLICATION_EXTENSION_API_ONLY = YES` to Xcode project.