### PR TITLE
Working Range example

### DIFF
--- a/Example/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Example/IGListKitExamples.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		2961B3AE1D68B0B5001C9451 /* SpinnerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2961B3A81D68B0B5001C9451 /* SpinnerCell.swift */; };
 		2961B3B01D68B28E001C9451 /* SearchCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2961B3AF1D68B28E001C9451 /* SearchCell.swift */; };
 		29628F141D91905A0026B15A /* DetailLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29628F131D91905A0026B15A /* DetailLabelCell.swift */; };
+		2981BA351DB868A500A987F9 /* ImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2981BA341DB868A500A987F9 /* ImageCell.swift */; };
+		2981BA371DB869FF00A987F9 /* WorkingRangeSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2981BA361DB869FF00A987F9 /* WorkingRangeSectionController.swift */; };
+		2981BA391DB874BB00A987F9 /* WorkingRangeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2981BA381DB874BB00A987F9 /* WorkingRangeViewController.swift */; };
 		299068281D75BFEC00A62888 /* MixedDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299068271D75BFEC00A62888 /* MixedDataViewController.swift */; };
 		2991F9191D7BADC900B0C58F /* CenterLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2991F9181D7BADC900B0C58F /* CenterLabelCell.swift */; };
 		2991F91E1D7BB30C00B0C58F /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2991F91D1D7BB30C00B0C58F /* User.swift */; };
@@ -63,6 +66,9 @@
 		2961B3A81D68B0B5001C9451 /* SpinnerCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpinnerCell.swift; sourceTree = "<group>"; };
 		2961B3AF1D68B28E001C9451 /* SearchCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchCell.swift; sourceTree = "<group>"; };
 		29628F131D91905A0026B15A /* DetailLabelCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailLabelCell.swift; sourceTree = "<group>"; };
+		2981BA341DB868A500A987F9 /* ImageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCell.swift; sourceTree = "<group>"; };
+		2981BA361DB869FF00A987F9 /* WorkingRangeSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkingRangeSectionController.swift; sourceTree = "<group>"; };
+		2981BA381DB874BB00A987F9 /* WorkingRangeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkingRangeViewController.swift; sourceTree = "<group>"; };
 		299068271D75BFEC00A62888 /* MixedDataViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MixedDataViewController.swift; sourceTree = "<group>"; };
 		2991F9181D7BADC900B0C58F /* CenterLabelCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CenterLabelCell.swift; sourceTree = "<group>"; };
 		2991F91D1D7BB30C00B0C58F /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -108,6 +114,7 @@
 				2942FF891D9F39E00015D24B /* RemoveSectionController.swift */,
 				2942FF8A1D9F39E00015D24B /* SearchSectionController.swift */,
 				2942FF8B1D9F39E00015D24B /* UserSectionController.swift */,
+				2981BA361DB869FF00A987F9 /* WorkingRangeSectionController.swift */,
 			);
 			path = SectionControllers;
 			sourceTree = "<group>";
@@ -155,6 +162,7 @@
 				2991F9231D7BB89F00B0C58F /* NestedAdapterViewController.swift */,
 				299B53FF1D6BD6630074A202 /* SearchViewController.swift */,
 				26271C8D1DAE9D3F0073E116 /* SingleSectionViewController.swift */,
+				2981BA381DB874BB00A987F9 /* WorkingRangeViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -171,6 +179,7 @@
 				2961B3A81D68B0B5001C9451 /* SpinnerCell.swift */,
 				26271C931DAE9F050073E116 /* NibCell.swift */,
 				26271C911DAE9EFC0073E116 /* NibCell.xib */,
+				2981BA341DB868A500A987F9 /* ImageCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -321,8 +330,10 @@
 				2961B3AE1D68B0B5001C9451 /* SpinnerCell.swift in Sources */,
 				2961B3B01D68B28E001C9451 /* SearchCell.swift in Sources */,
 				2942FF8C1D9F39E00015D24B /* DemoSectionController.swift in Sources */,
+				2981BA351DB868A500A987F9 /* ImageCell.swift in Sources */,
 				2942FF931D9F39E00015D24B /* SearchSectionController.swift in Sources */,
 				2942FF911D9F39E00015D24B /* LabelSectionController.swift in Sources */,
+				2981BA391DB874BB00A987F9 /* WorkingRangeViewController.swift in Sources */,
 				2961B3AC1D68B0B5001C9451 /* LoadMoreViewController.swift in Sources */,
 				26271C941DAE9F050073E116 /* NibCell.swift in Sources */,
 				2991F9191D7BADC900B0C58F /* CenterLabelCell.swift in Sources */,
@@ -340,6 +351,7 @@
 				26271C8E1DAE9D3F0073E116 /* SingleSectionViewController.swift in Sources */,
 				2961B3AD1D68B0B5001C9451 /* LabelCell.swift in Sources */,
 				2942FF901D9F39E00015D24B /* HorizontalSectionController.swift in Sources */,
+				2981BA371DB869FF00A987F9 /* WorkingRangeSectionController.swift in Sources */,
 				2961B3AB1D68B0B5001C9451 /* DemosViewController.swift in Sources */,
 				2942FF8E1D9F39E00015D24B /* ExpandableSectionController.swift in Sources */,
 			);
@@ -452,12 +464,15 @@
 			baseConfigurationReference = FE05AB853448A0705AF80427 /* Pods-IGListKitExamples.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IGListKitExamples/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
@@ -467,12 +482,14 @@
 			baseConfigurationReference = 4125DCD99578FDEF3C373BA0 /* Pods-IGListKitExamples.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IGListKitExamples/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/Example/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
+++ b/Example/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
@@ -1,0 +1,96 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+ The examples provided by Facebook are for non-commercial testing and evaluation
+ purposes only. Facebook reserves all rights not expressly granted.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+import IGListKit
+
+class WorkingRangeSectionController: IGListSectionController, IGListSectionType, IGListWorkingRangeDelegate {
+
+    var height: Int?
+    var downloadedImage: UIImage?
+    var task: URLSessionDataTask?
+
+    var urlString: String? {
+        guard let height = height,
+            let width = collectionContext?.containerSize.width
+            else { return nil }
+        return "https://unsplash.it/" + width.description + "/" + height.description
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    override init() {
+        super.init()
+        workingRangeDelegate = self
+    }
+
+    func numberOfItems() -> Int {
+        return 2
+    }
+
+    func sizeForItem(at index: Int) -> CGSize {
+        let width: CGFloat = collectionContext?.containerSize.width ?? 0
+        let height: CGFloat = CGFloat(index == 0 ? 55 : (self.height ?? 0))
+        return CGSize(width: width, height: height)
+    }
+
+    func cellForItem(at index: Int) -> UICollectionViewCell {
+        let cellClass: AnyClass = index == 0 ? LabelCell.self : ImageCell.self
+        let cell = collectionContext!.dequeueReusableCell(of: cellClass, for: self, at: index)
+        if let cell = cell as? LabelCell {
+            cell.label.text = urlString
+        } else if let cell = cell as? ImageCell {
+            cell.setImage(image: downloadedImage)
+        }
+        return cell
+    }
+
+    func didUpdate(to object: Any) {
+        self.height = object as? Int
+    }
+
+    func didSelectItem(at index: Int) {}
+
+    //MARK: IGListWorkingRangeDelegate
+
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerWillEnterWorkingRange sectionController: IGListSectionController) {
+        guard downloadedImage == nil,
+            task == nil,
+            let urlString = urlString,
+            let url = URL(string: urlString)
+            else { return }
+
+        let section = collectionContext?.section(for: self) ?? 0
+        print("Downloading image \(urlString) for section \(section)")
+
+        task = URLSession.shared.dataTask(with: url, completionHandler: { data, response, err in
+            if let data = data, let image = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    self.downloadedImage = image
+                    if let cell = self.collectionContext?.cellForItem(at: 1, sectionController: self) as? ImageCell {
+                        cell.setImage(image: image)
+                    }
+                }
+            } else {
+                print("Error downloading \(urlString): \(err)")
+            }
+        })
+        task?.resume()
+    }
+
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerDidExitWorkingRange sectionController: IGListSectionController) {}
+
+}

--- a/Example/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Example/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -28,7 +28,8 @@ class DemosViewController: UIViewController, IGListAdapterDataSource {
         DemoItem(name: "Mixed Data", controllerClass: MixedDataViewController.self),
         DemoItem(name: "Nested Adapter", controllerClass: NestedAdapterViewController.self),
         DemoItem(name: "Empty View", controllerClass: EmptyViewController.self),
-        DemoItem(name: "Single Section Controller", controllerClass: SingleSectionViewController.self)
+        DemoItem(name: "Single Section Controller", controllerClass: SingleSectionViewController.self),
+        DemoItem(name: "Working Range", controllerClass: WorkingRangeViewController.self)
     ]
 
     override func viewDidLoad() {

--- a/Example/IGListKitExamples/ViewControllers/WorkingRangeViewController.swift
+++ b/Example/IGListKitExamples/ViewControllers/WorkingRangeViewController.swift
@@ -1,0 +1,59 @@
+//
+//  WorkingRangeViewController.swift
+//  IGListKitExamples
+//
+//  Created by Ryan Nystrom on 10/20/16.
+//  Copyright © 2016 Instagram. All rights reserved.
+//
+
+import UIKit
+import IGListKit
+
+class WorkingRangeViewController: UIViewController, IGListAdapterDataSource {
+
+    lazy var adapter: IGListAdapter = {
+        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 2)
+    }()
+
+    let collectionView = IGListCollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
+
+    let data: [Int] = {
+        var arr = [Int]()
+        while arr.count < 20 {
+            let int = Int(arc4random_uniform(200)) + 200
+            // only use unique values
+            if !arr.contains(int) {
+                arr.append(int)
+            }
+        }
+        return arr
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(collectionView)
+        adapter.collectionView = collectionView
+        adapter.dataSource = self
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        collectionView.frame = view.bounds
+    }
+
+    //MARK: IGListAdapterDataSource
+
+    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+        return data as [NSNumber]
+    }
+
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+        return WorkingRangeSectionController()
+    }
+
+    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+        return nil
+    }
+
+}

--- a/Example/IGListKitExamples/Views/ImageCell.swift
+++ b/Example/IGListKitExamples/Views/ImageCell.swift
@@ -1,0 +1,53 @@
+//
+//  ImageCell.swift
+//  IGListKitExamples
+//
+//  Created by Ryan Nystrom on 10/20/16.
+//  Copyright © 2016 Instagram. All rights reserved.
+//
+
+import UIKit
+
+class ImageCell: UICollectionViewCell {
+
+    fileprivate let imageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
+        view.backgroundColor = UIColor(white: 0.95, alpha: 1)
+        return view
+    }()
+
+    fileprivate let activityView: UIActivityIndicatorView = {
+        let view = UIActivityIndicatorView(activityIndicatorStyle: .gray)
+        view.startAnimating()
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(imageView)
+        contentView.addSubview(activityView)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let bounds = contentView.bounds
+        activityView.center = CGPoint(x: bounds.width/2.0, y: bounds.height/2.0)
+        imageView.frame = bounds
+    }
+
+    func setImage(image: UIImage?) {
+        imageView.image = image
+        if image != nil {
+            activityView.stopAnimating()
+        } else {
+            activityView.startAnimating()
+        }
+    }
+    
+}


### PR DESCRIPTION
## Changes in this pull request

Adding a working range example to the example app. This example:

- Displays a list of images downloaded from unsplash.it
- Create 20 uniquely-random sized objects
- When section controllers enter the range, create a data task to download the image
  - When finished, store image in `downloadedImage`
  - Set in cell if cell is visible
  - Don't create task if already downloaded or task created
- Cancel task when section controller is destroyed
- Show a spinner cell while downloading the image

Fixes #84

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)
