### PR TITLE
Workaround Jazzy script bug

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -3,6 +3,12 @@
 # Docs by jazzy
 # https://github.com/realm/jazzy
 # ------------------------------
+SOURCE=Source
+SOURCE_TMP=IGListKit
+
+# temporary workaround when using SPM dir format
+# https://github.com/realm/jazzy/issues/667
+mv $SOURCE $SOURCE_TMP
 
 jazzy \
 	--objc \
@@ -13,6 +19,9 @@ jazzy \
     --sdk iphonesimulator \
     --module 'IGListKit' \
     --framework-root . \
-    --umbrella-header Source/IGListKit.h \
+    --umbrella-header $SOURCE_TMP/IGListKit.h \
     --readme README.md \
     --output docs/
+
+# restore the dir per the jazzy issue
+mv $SOURCE_TMP $SOURCE


### PR DESCRIPTION
## Changes in this pull request

Temporary fix for the doc generation bug. Works now by simply running `$ ./build_docs.sh`.

cc @jessesquires that this fix is good for now

Fixes #55

Jazzy bug at realm/jazzy#667