### PR TITLE
Improve Objective-C property attributes

### DIFF
--- a/Source/IGListBatchUpdateData.h
+++ b/Source/IGListBatchUpdateData.h
@@ -34,22 +34,22 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Clean section moves.
  */
-@property (nonatomic, strong, readonly) NSSet<IGListMoveIndex *> *moveSections;
+@property (nonatomic, copy, readonly) NSSet<IGListMoveIndex *> *moveSections;
 
 /**
  Clean item insert index paths.
  */
-@property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *insertIndexPaths;
+@property (nonatomic, copy, readonly) NSSet<NSIndexPath *> *insertIndexPaths;
 
 /**
  Clean item delete index paths.
  */
-@property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *deleteIndexPaths;
+@property (nonatomic, copy, readonly) NSSet<NSIndexPath *> *deleteIndexPaths;
 
 /**
  Clean item reload index paths.
  */
-@property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *reloadIndexPaths;
+@property (nonatomic, copy, readonly) NSSet<NSIndexPath *> *reloadIndexPaths;
 
 /**
  Create a new batch update object with section and item operations.

--- a/Source/IGListCollectionView.m
+++ b/Source/IGListCollectionView.m
@@ -12,7 +12,7 @@
 @interface IGListCollectionView ()
 
 @property (nonatomic, assign, readonly) BOOL requiresManualWillDisplay;
-@property (nonatomic, strong) NSSet *ig_visibleIndexPaths;
+@property (nonatomic, copy) NSSet *ig_visibleIndexPaths;
 
 @end
 

--- a/Source/IGListDiffable.h
+++ b/Source/IGListDiffable.h
@@ -11,7 +11,7 @@
 
 /**
  The IGListDiffable protocol provides the base methods needed to compare the identity and equality of two objects using
- one of the IGKAlgorithm functions.
+ one of the IGListDiff functions.
  */
 @protocol IGListDiffable
 

--- a/Source/IGListSingleSectionController.m
+++ b/Source/IGListSingleSectionController.m
@@ -17,8 +17,8 @@
 @property (nonatomic, strong, readonly) NSBundle *bundle;
 @property (nonatomic, strong, readonly) NSString *identifier;
 @property (nonatomic, strong, readonly) Class cellClass;
-@property (nonatomic, strong, readonly) IGListSingleSectionCellConfigureBlock configureBlock;
-@property (nonatomic, strong, readonly) IGListSingleSectionCellSizeBlock sizeBlock;
+@property (nonatomic, copy, readonly) IGListSingleSectionCellConfigureBlock configureBlock;
+@property (nonatomic, copy, readonly) IGListSingleSectionCellSizeBlock sizeBlock;
 
 @property (nonatomic, strong) id item;
 

--- a/Source/IGListSingleSectionController.m
+++ b/Source/IGListSingleSectionController.m
@@ -15,7 +15,7 @@
 
 @property (nonatomic, copy, readonly) NSString *nibName;
 @property (nonatomic, strong, readonly) NSBundle *bundle;
-@property (nonatomic, strong, readonly) NSString *identifier;
+@property (nonatomic, copy, readonly) NSString *identifier;
 @property (nonatomic, strong, readonly) Class cellClass;
 @property (nonatomic, copy, readonly) IGListSingleSectionCellConfigureBlock configureBlock;
 @property (nonatomic, copy, readonly) IGListSingleSectionCellSizeBlock sizeBlock;

--- a/Source/IGListSingleSectionController.m
+++ b/Source/IGListSingleSectionController.m
@@ -13,7 +13,7 @@
 
 @interface IGListSingleSectionController ()
 
-@property (nonatomic, strong, readonly) NSString *nibName;
+@property (nonatomic, copy, readonly) NSString *nibName;
 @property (nonatomic, strong, readonly) NSBundle *bundle;
 @property (nonatomic, strong, readonly) NSString *identifier;
 @property (nonatomic, strong, readonly) Class cellClass;
@@ -48,7 +48,7 @@
     IGParameterAssert(configureBlock != nil);
     IGParameterAssert(sizeBlock != nil);
     if (self = [super init]) {
-        _nibName = nibName;
+        _nibName = [nibName copy];
         _bundle = bundle;
         _configureBlock = [configureBlock copy];
         _sizeBlock = [sizeBlock copy];

--- a/Source/Internal/IGListSectionMap.m
+++ b/Source/Internal/IGListSectionMap.m
@@ -17,7 +17,7 @@
 @property (nonatomic, strong, readonly) NSMapTable<IGListSectionController<IGListSectionType> *, id> *sectionControllerToObjectMap;
 @property (nonatomic, strong, readonly) NSMapTable<IGListSectionController<IGListSectionType> *, NSNumber *> *sectionControllerToSectionMap;
 
-@property (nonatomic, strong, readwrite) NSArray *objects;
+@property (nonatomic, copy, readwrite) NSArray *objects;
 
 @end
 
@@ -55,7 +55,7 @@
 - (void)updateWithObjects:(NSArray *)objects sectionControllers:(NSArray *)sectionControllers {
     IGParameterAssert(objects.count == sectionControllers.count);
 
-    self.objects = [objects copy];
+    self.objects = objects;
 
     [self reset];
 


### PR DESCRIPTION
## Changes in this pull request
In this PR, we changed all properties with the type like `NSSet`, `NSString`, `NSArray` or Block to `copy`. 

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)
