### PR TITLE
Call copy method to avoid a potential issue for an NSString property

### DIFF
--- a/Source/IGListDiffable.h
+++ b/Source/IGListDiffable.h
@@ -11,7 +11,7 @@
 
 /**
  The IGListDiffable protocol provides the base methods needed to compare the identity and equality of two objects using
- one of the IGKAlgorithm functions.
+ one of the IGListDiff functions.
  */
 @protocol IGListDiffable
 

--- a/Source/IGListSingleSectionController.m
+++ b/Source/IGListSingleSectionController.m
@@ -48,7 +48,7 @@
     IGParameterAssert(configureBlock != nil);
     IGParameterAssert(sizeBlock != nil);
     if (self = [super init]) {
-        _nibName = nibName;
+        _nibName = [nibName copy];
         _bundle = bundle;
         _configureBlock = [configureBlock copy];
         _sizeBlock = [sizeBlock copy];


### PR DESCRIPTION
## Changes in this pull request

According to @rnystrom 's comment on #125 , we leave only two small changes in this PR.
1. Call copy method to avoid a potential issue for an `NSString` property.
2. fix a typo.

close #125 

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)
