### PR TITLE
Fix example where collectionview starts from wrong position

### DIFF
--- a/Example/IGListKitExamples/Views/EmbeddedCollectionViewCell.swift
+++ b/Example/IGListKitExamples/Views/EmbeddedCollectionViewCell.swift
@@ -32,5 +32,10 @@ class EmbeddedCollectionViewCell: UICollectionViewCell {
         super.layoutSubviews()
         collectionView.frame = contentView.frame
     }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        collectionView.contentOffset = .zero
+    }
 
 }


### PR DESCRIPTION
## Changes in this pull request

- Reset the collectionView offset when the cell is reused
- Fixes #133 

Note: If you scroll the first collection view, then take it off screen, when you go back to the top the collection view offset will be back to the beginning. I believe this to be the correct behaviour unless we either stop reuse of cells, or store the offset of each section and set it once it loads.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)

