### PR TITLE
Support supplementaryViews created from nibs (continued)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit
 
 ### Enhancements
 
+- Added support for supplementaryViews created from nibs. [Rawlinxx](https://github.com/rawlinxx) [(#90)](https://github.com/Instagram/IGListKit/pull/90)
 - Added support for cells created from nibs. [Sven Bacia](https://github.com/svenbacia) [(#56)](https://github.com/Instagram/IGListKit/pull/56)
 - Added an additional initializer for `IGListSingleSectionController` to be able to support single sections created from nibs. An example can be found [here](Example/IGListKitExamples/ViewControllers/SingleSectionViewController.swift).
 - Fixed `-[IGListAdapter reloadDataWithCompletion:]` not returning early when `collectionView` or `dataSource` is nil and `completion` is nil. [Ben Asher](https://github.com/benasher44) [(#51)](https://github.com/Instagram/IGListKit/pull/51)

--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		01E12EE2D2F55E9DE8928E1E /* Pods_IGListKit_tvOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 529C388FDB3DF79737F3496A /* Pods_IGListKit_tvOSTests.framework */; };
 		26271C8A1DAE94E40073E116 /* IGTestSingleNibItemDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C891DAE94E40073E116 /* IGTestSingleNibItemDataSource.m */; };
 		26271C8C1DAE96740073E116 /* IGListSingleNibItemControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C8B1DAE96740073E116 /* IGListSingleNibItemControllerTests.m */; };
+		290486201DCD02750007F41D /* IGTestNibSupplementaryView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2904861E1DCD02750007F41D /* IGTestNibSupplementaryView.h */; };
+		290486211DCD02750007F41D /* IGTestNibSupplementaryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */; };
+		2914BEE91DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
+		2914BEEA1DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
 		296176F71D9D54C100F40F34 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 296176EF1D9D54C100F40F34 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		296176F81D9D54C100F40F34 /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 296176F01D9D54C100F40F34 /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		296176F91D9D54C100F40F34 /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 296176F11D9D54C100F40F34 /* IGListSectionController.m */; };
@@ -194,7 +198,7 @@
 		885FE2401DC51B86009CE2B4 /* IGTestSingleItemDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144F021D870EDC007C7F66 /* IGTestSingleItemDataSource.m */; };
 		885FE2411DC51B86009CE2B4 /* IGTestSingleNibItemDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C891DAE94E40073E116 /* IGTestSingleNibItemDataSource.m */; };
 		885FE2421DC51B86009CE2B4 /* IGTestSingleStoryboardItemDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4D21DB981AB00172ED0 /* IGTestSingleStoryboardItemDataSource.m */; };
-		885FE2431DC51B86009CE2B4 /* IGTestSingleStoryboardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4C81DB8D5B200172ED0 /* IGTestSingleStoryboardViewController.m */; };
+		885FE2431DC51B86009CE2B4 /* IGTestStoryboardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4C81DB8D5B200172ED0 /* IGTestStoryboardViewController.m */; };
 		885FE2441DC51B86009CE2B4 /* IGTestStackedDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144F041D870EDC007C7F66 /* IGTestStackedDataSource.m */; };
 		885FE2451DC51B86009CE2B4 /* IGTestStoryboardCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4CD1DB8D8C500172ED0 /* IGTestStoryboardCell.m */; };
 		885FE2461DC51B86009CE2B4 /* IGTestSupplementarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144F061D870EDC007C7F66 /* IGTestSupplementarySource.m */; };
@@ -226,6 +230,9 @@
 		26271C881DAE94E40073E116 /* IGTestSingleNibItemDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGTestSingleNibItemDataSource.h; sourceTree = "<group>"; };
 		26271C891DAE94E40073E116 /* IGTestSingleNibItemDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGTestSingleNibItemDataSource.m; sourceTree = "<group>"; };
 		26271C8B1DAE96740073E116 /* IGListSingleNibItemControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGListSingleNibItemControllerTests.m; sourceTree = "<group>"; };
+		2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IGTestNibSupplementaryView.xib; sourceTree = "<group>"; };
+		2904861E1DCD02750007F41D /* IGTestNibSupplementaryView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGTestNibSupplementaryView.h; sourceTree = "<group>"; };
+		2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGTestNibSupplementaryView.m; sourceTree = "<group>"; };
 		294369B01DB1B7AE0025F6E7 /* IGTestNibCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IGTestNibCell.xib; sourceTree = "<group>"; };
 		296176EF1D9D54C100F40F34 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGListScrollDelegate.h; sourceTree = "<group>"; };
 		296176F01D9D54C100F40F34 /* IGListSectionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGListSectionController.h; sourceTree = "<group>"; };
@@ -394,6 +401,7 @@
 			isa = PBXGroup;
 			children = (
 				294369B01DB1B7AE0025F6E7 /* IGTestNibCell.xib */,
+				2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */,
 				821BC4C21DB8CAE900172ED0 /* IGTestStoryboard.storyboard */,
 			);
 			path = Assets;
@@ -431,6 +439,8 @@
 				88144EFC1D870EDC007C7F66 /* IGTestDelegateController.m */,
 				88144EFD1D870EDC007C7F66 /* IGTestDelegateDataSource.h */,
 				88144EFE1D870EDC007C7F66 /* IGTestDelegateDataSource.m */,
+				2904861E1DCD02750007F41D /* IGTestNibSupplementaryView.h */,
+				2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */,
 				88144EFF1D870EDC007C7F66 /* IGTestObject.h */,
 				88144F001D870EDC007C7F66 /* IGTestObject.m */,
 				88144F011D870EDC007C7F66 /* IGTestSingleItemDataSource.h */,
@@ -439,18 +449,18 @@
 				26271C891DAE94E40073E116 /* IGTestSingleNibItemDataSource.m */,
 				821BC4D11DB9816E00172ED0 /* IGTestSingleStoryboardItemDataSource.h */,
 				821BC4D21DB981AB00172ED0 /* IGTestSingleStoryboardItemDataSource.m */,
-				821BC4C71DB8D5B200172ED0 /* IGTestStoryboardViewController.h */,
-				821BC4C81DB8D5B200172ED0 /* IGTestStoryboardViewController.m */,
 				88144F031D870EDC007C7F66 /* IGTestStackedDataSource.h */,
 				88144F041D870EDC007C7F66 /* IGTestStackedDataSource.m */,
 				821BC4CC1DB8D8C500172ED0 /* IGTestStoryboardCell.h */,
 				821BC4CD1DB8D8C500172ED0 /* IGTestStoryboardCell.m */,
-				88144F051D870EDC007C7F66 /* IGTestSupplementarySource.h */,
-				88144F061D870EDC007C7F66 /* IGTestSupplementarySource.m */,
 				8240C7F31DC2D99300B3AAE7 /* IGTestStoryboardSupplementarySource.h */,
 				8240C7F41DC2D99300B3AAE7 /* IGTestStoryboardSupplementarySource.m */,
 				8240C7EE1DC272CA00B3AAE7 /* IGTestStoryboardSupplementaryView.h */,
 				8240C7EF1DC272CA00B3AAE7 /* IGTestStoryboardSupplementaryView.m */,
+				821BC4C71DB8D5B200172ED0 /* IGTestStoryboardViewController.h */,
+				821BC4C81DB8D5B200172ED0 /* IGTestStoryboardViewController.m */,
+				88144F051D870EDC007C7F66 /* IGTestSupplementarySource.h */,
+				88144F061D870EDC007C7F66 /* IGTestSupplementarySource.m */,
 			);
 			path = Objects;
 			sourceTree = "<group>";
@@ -658,6 +668,7 @@
 				88144F6C1D870F3E007C7F66 /* IGListDisplayDelegate.h in Headers */,
 				88144F811D870F3E007C7F66 /* IGListUpdatingDelegate.h in Headers */,
 				88144F6D1D870F3E007C7F66 /* IGListExperiments.h in Headers */,
+				290486201DCD02750007F41D /* IGTestNibSupplementaryView.h in Headers */,
 				88144F5E1D870F3E007C7F66 /* IGListAdapterDataSource.h in Headers */,
 				88144F621D870F3E007C7F66 /* IGListAdapterUpdaterDelegate.h in Headers */,
 				88144F971D870F3E007C7F66 /* NSObject+IGListDiffable.h in Headers */,
@@ -837,6 +848,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2914BEEA1DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */,
 				885FE2471DC51B90009CE2B4 /* IGTestNibCell.xib in Resources */,
 				885FE2481DC51B90009CE2B4 /* IGTestStoryboard.storyboard in Resources */,
 			);
@@ -853,6 +865,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2914BEE91DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */,
 				29EA6C491DB43A8000957A88 /* IGTestNibCell.xib in Resources */,
 				821BC4C41DB8CEF800172ED0 /* IGTestStoryboard.storyboard in Resources */,
 			);
@@ -1010,7 +1023,7 @@
 				885FE2411DC51B86009CE2B4 /* IGTestSingleNibItemDataSource.m in Sources */,
 				885FE2441DC51B86009CE2B4 /* IGTestStackedDataSource.m in Sources */,
 				885FE2461DC51B86009CE2B4 /* IGTestSupplementarySource.m in Sources */,
-				885FE2431DC51B86009CE2B4 /* IGTestSingleStoryboardViewController.m in Sources */,
+				885FE2431DC51B86009CE2B4 /* IGTestStoryboardViewController.m in Sources */,
 				885FE23A1DC51B86009CE2B4 /* IGListTestSection.m in Sources */,
 				885FE23E1DC51B86009CE2B4 /* IGTestDelegateDataSource.m in Sources */,
 			);
@@ -1034,6 +1047,7 @@
 				296176FC1D9D54C100F40F34 /* IGListSingleSectionController.m in Sources */,
 				296177051D9D54E300F40F34 /* IGListSectionMap.m in Sources */,
 				88144F771D870F3E007C7F66 /* IGListMoveIndex.m in Sources */,
+				290486211DCD02750007F41D /* IGTestNibSupplementaryView.m in Sources */,
 				88144F921D870F3E007C7F66 /* IGListWorkingRangeHandler.mm in Sources */,
 				88144F5D1D870F3E007C7F66 /* IGListAdapter.m in Sources */,
 				88144F611D870F3E007C7F66 /* IGListAdapterUpdater.m in Sources */,

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -74,6 +74,7 @@
         _registeredCellClasses = [NSMutableSet new];
         _registeredNibNames = [NSMutableSet new];
         _registeredSupplementaryViewIdentifiers = [NSMutableSet new];
+        _registeredSupplementaryViewNibNames = [NSMutableSet new];
 
         _collectionView = collectionView;
         _collectionView.dataSource = self;
@@ -706,7 +707,7 @@
 }
 
 - (__kindof UICollectionViewCell *)dequeueReusableCellOfClass:(Class)cellClass
-                                         forSectionController:(IGListSectionController <IGListSectionType> *)sectionController
+                                         forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                       atIndex:(NSInteger)index {
     IGAssertMainThread();
     IGParameterAssert(sectionController != nil);
@@ -740,7 +741,7 @@
                                     forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                  atIndex:(NSInteger)index {
     IGAssertMainThread();
-    IGParameterAssert(nibName != nil);
+    IGParameterAssert([nibName length] > 0);
     IGParameterAssert(sectionController != nil);
     IGParameterAssert(index >= 0);
     UICollectionView *collectionView = self.collectionView;
@@ -755,7 +756,7 @@
 }
 
 - (__kindof UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
-                                                         forSectionController:(IGListSectionController <IGListSectionType> *)sectionController
+                                                         forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                                         class:(Class)viewClass
                                                                       atIndex:(NSInteger)index {
     IGAssertMainThread();
@@ -787,6 +788,25 @@
     IGAssert(collectionView != nil, @"Dequeueing Supplementary View from storyboard of kind %@ with identifier %@ for section controller %@ without a collection view at index %zi", elementKind, identifier, sectionController, index);
     NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
     return [collectionView dequeueReusableSupplementaryViewOfKind:elementKind withReuseIdentifier:identifier forIndexPath:indexPath];
+}
+
+- (__kindof UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
+                                                         forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                                                      nibName:(NSString *)nibName
+                                                                       bundle:(NSBundle *)bundle
+                                                                      atIndex:(NSInteger)index {
+    IGAssertMainThread();
+    IGParameterAssert([nibName length] > 0);
+    IGParameterAssert([elementKind length] > 0);
+    UICollectionView *collectionView = self.collectionView;
+    IGAssert(collectionView != nil, @"Reloading adapter without a collection view.");
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    if (![self.registeredSupplementaryViewNibNames containsObject:nibName]) {
+        [self.registeredSupplementaryViewNibNames addObject:nibName];
+        UINib *nib = [UINib nibWithNibName:nibName bundle:bundle];
+        [collectionView registerNib:nib forSupplementaryViewOfKind:elementKind withReuseIdentifier:nibName];
+    }
+    return [collectionView dequeueReusableSupplementaryViewOfKind:elementKind withReuseIdentifier:nibName forIndexPath:indexPath];
 }
 
 - (void)reloadInSectionController:(IGListSectionController<IGListSectionType> *)sectionController atIndexes:(NSIndexSet *)indexes {

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -152,6 +152,24 @@ NS_ASSUME_NONNULL_BEGIN
                                                                              withIdentifier:(NSString *)identifier
                                                                        forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                                                     atIndex:(NSInteger)index;
+/**
+ Dequeues a supplementary view from the UICollectionView reuse pool.
+ 
+ @param elementKind       The kind of supplementary veiw.
+ @param sectionController The section controller requesting this information.
+ @param nibName           The name of the nib file.
+ @param bundle            The bundle in which to search for the nib file. If nil, this method looks for the nib file in the main bundle.
+ @param index             The index of the supplementary vew.
+ 
+ @return A supplementary view dequeued from the reuse pool or newly created.
+ 
+ @note This method uses a string representation of the view class as the identifier.
+ */
+- (__kindof UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
+                                                         forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                                                      nibName:(NSString *)nibName
+                                                                       bundle:(nullable NSBundle *)bundle
+                                                                      atIndex:(NSInteger)index;
 
 /**
  Reloads cells in the section controller.

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -238,6 +238,19 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
                                                                                                                 atIndex:(index + offset)];
 }
 
+- (UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
+                                                forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                                             nibName:(NSString *)nibName
+                                                              bundle:(NSBundle *)bundle
+                                                             atIndex:(NSInteger)index {
+    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableSupplementaryViewOfKind:elementKind
+                                                                                     forSectionController:self
+                                                                                                  nibName:nibName
+                                                                                                   bundle:bundle
+                                                                                                  atIndex:(index + offset)];
+}
+
 - (void)reloadInSectionController:(IGListSectionController<IGListSectionType> *)sectionController atIndexes:(NSIndexSet *)indexes {
     NSIndexSet *itemIndexes = [self itemIndexesForSectionController:sectionController indexes:indexes];
     [self.collectionContext reloadInSectionController:self atIndexes:itemIndexes];

--- a/Source/Internal/IGListAdapterInternal.h
+++ b/Source/Internal/IGListAdapterInternal.h
@@ -56,6 +56,7 @@ IGListCollectionContext
 @property (nonatomic, strong) NSMutableSet<Class> *registeredCellClasses;
 @property (nonatomic, strong) NSMutableSet<NSString *> *registeredNibNames;
 @property (nonatomic, strong) NSMutableSet<NSString *> *registeredSupplementaryViewIdentifiers;
+@property (nonatomic, strong) NSMutableSet<NSString *> *registeredSupplementaryViewNibNames;
 
 - (NSArray *)indexPathsFromSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                      indexes:(NSIndexSet *)indexes

--- a/Tests/Assets/IGTestNibSupplementaryView.xib
+++ b/Tests/Assets/IGTestNibSupplementaryView.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="E6X-wR-K42" customClass="IGTestNibSupplementaryView">
+            <rect key="frame" x="0.0" y="0.0" width="323" height="50"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="323" height="50"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JfJ-QL-zHN">
+                        <rect key="frame" x="140" y="15" width="42" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <constraints>
+                <constraint firstItem="JfJ-QL-zHN" firstAttribute="centerY" secondItem="E6X-wR-K42" secondAttribute="centerY" id="1ag-hy-63j"/>
+                <constraint firstItem="JfJ-QL-zHN" firstAttribute="centerX" secondItem="E6X-wR-K42" secondAttribute="centerX" id="ZVq-Ww-Gjf"/>
+            </constraints>
+            <size key="customSize" width="323" height="50"/>
+            <connections>
+                <outlet property="label" destination="JfJ-QL-zHN" id="Mc2-VH-7FL"/>
+            </connections>
+            <point key="canvasLocation" x="280" y="-152"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -19,6 +19,7 @@
 #import "IGListTestAdapterDataSource.h"
 #import "IGListTestSection.h"
 #import "IGTestSupplementarySource.h"
+#import "IGTestNibSupplementaryView.h"
 
 @interface IGListAdapterTests : XCTestCase
 
@@ -375,6 +376,30 @@
     [self.adapter performUpdatesAnimated:NO completion:nil];
 
     XCTAssertNotNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+    XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+    XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]]);
+    XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]]);
+}
+
+- (void)test_whenSupplementarySourceSupportsFooter_withNibs_thatHeaderViewsAreNil {
+    self.dataSource.objects = @[@1, @2];
+    [self.adapter reloadDataWithCompletion:nil];
+
+    IGTestSupplementarySource *supplementarySource = [IGTestSupplementarySource new];
+    supplementarySource.dequeueFromNib = YES;
+    supplementarySource.collectionContext = self.adapter;
+    supplementarySource.supportedElementKinds = @[UICollectionElementKindSectionFooter];
+
+    IGListSectionController<IGListSectionType> *controller = [self.adapter sectionControllerForObject:@1];
+    controller.supplementaryViewSource = supplementarySource;
+    supplementarySource.sectionController = controller;
+
+    [self.adapter performUpdatesAnimated:NO completion:nil];
+
+    id view = [self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+    XCTAssertTrue([view isKindOfClass:IGTestNibSupplementaryView.class]);
+    XCTAssertEqualObjects([[(IGTestNibSupplementaryView *)view label] text], @"Foo bar baz");
+
     XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]]);
     XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]]);

--- a/Tests/Objects/IGTestNibSupplementaryView.h
+++ b/Tests/Objects/IGTestNibSupplementaryView.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface IGTestNibSupplementaryView : UICollectionViewCell
+
+@property (nonatomic, weak) id delegate;
+
+@property (nonatomic, strong) IBOutlet UILabel *label;
+
+@end

--- a/Tests/Objects/IGTestNibSupplementaryView.m
+++ b/Tests/Objects/IGTestNibSupplementaryView.m
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "IGTestNibSupplementaryView.h"
+
+@implementation IGTestNibSupplementaryView
+
+@end

--- a/Tests/Objects/IGTestSupplementarySource.h
+++ b/Tests/Objects/IGTestSupplementarySource.h
@@ -13,6 +13,8 @@
 
 @interface IGTestSupplementarySource : NSObject <IGListSupplementaryViewSource>
 
+@property (nonatomic, assign) BOOL dequeueFromNib;
+
 @property (nonatomic, strong, readwrite) NSArray<NSString *> *supportedElementKinds;
 
 @property (nonatomic, weak) id<IGListCollectionContext> collectionContext;

--- a/Tests/Objects/IGTestSupplementarySource.m
+++ b/Tests/Objects/IGTestSupplementarySource.m
@@ -9,16 +9,28 @@
 
 #import "IGTestSupplementarySource.h"
 
+#import "IGTestNibSupplementaryView.h"
+
 @implementation IGTestSupplementarySource
 
 #pragma mark - IGListSupplementaryViewSource
 
 - (UICollectionReusableView *)viewForSupplementaryElementOfKind:(NSString *)elementKind
                                                         atIndex:(NSInteger)index {
-    return [self.collectionContext dequeueReusableSupplementaryViewOfKind:elementKind
-                                                  forSectionController:self.sectionController
-                                                                  class:[UICollectionReusableView class]
-                                                                atIndex:index];
+    if (self.dequeueFromNib) {
+        IGTestNibSupplementaryView *view = [self.collectionContext dequeueReusableSupplementaryViewOfKind:elementKind
+                                                                                     forSectionController:self.sectionController
+                                                                                                  nibName:@"IGTestNibSupplementaryView"
+                                                                                                   bundle:[NSBundle bundleForClass:self.class]
+                                                                                                  atIndex:index];
+        view.label.text = @"Foo bar baz";
+        return view;
+    } else {
+        return [self.collectionContext dequeueReusableSupplementaryViewOfKind:elementKind
+                                                         forSectionController:self.sectionController
+                                                                        class:[UICollectionReusableView class]
+                                                                      atIndex:index];
+    }
 }
 
 - (CGSize)sizeForSupplementaryViewOfKind:(NSString *)elementKind atIndex:(NSInteger)index {


### PR DESCRIPTION
Continuing the work on #90. I don't believe I can push directly to that PR since the origin is `master` of a repo I don't have access to.

https://help.github.com/articles/checking-out-pull-requests-locally/

I went ahead and added another supplementary view test copying the old one we had.

cc @jessesquires in case there's something else I can do here. I believe this will still give @rawlinxx credit?