### PR TITLE
Add edge-case unit tests

### DIFF
--- a/Source/IGListAdapterUpdater.m
+++ b/Source/IGListAdapterUpdater.m
@@ -221,17 +221,6 @@ static NSArray *objectsWithDuplicateIdentifiersRemoved(NSArray<id<IGListDiffable
     }
 }
 
-- (NSSet *)filterIndexPaths:(NSSet<NSIndexPath *> *)indexPaths removingSections:(NSIndexSet *)sections {
-    NSMutableSet *filteredIndexPaths = [indexPaths mutableCopy];
-    for (NSIndexPath *indexPath in indexPaths) {
-        const NSUInteger section = indexPath.section;
-        if ([sections containsIndex:section]) {
-            [filteredIndexPaths removeObject:indexPath];
-        }
-    }
-    return filteredIndexPaths;
-}
-
 void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
                                  NSMutableIndexSet *deletes,
                                  NSMutableIndexSet *inserts,
@@ -298,16 +287,6 @@ void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
 
 - (void)endPerformBatchUpdates {
     self.batchUpdateOrReloadInProgress = NO;
-}
-
-- (NSArray *)trimmedIndexPaths:(NSArray <NSIndexPath *> *)indexPaths inSections:(NSIndexSet *)sections {
-    NSMutableArray *paths = [indexPaths mutableCopy];
-    for (NSInteger i = 0; i < paths.count; i++) {
-        if ([sections containsIndex:[paths[i] section]]) {
-            [paths removeObjectAtIndex:i];
-        }
-    }
-    return paths;
 }
 
 - (void)cleanupState {

--- a/Source/IGListBatchUpdateData.mm
+++ b/Source/IGListBatchUpdateData.mm
@@ -40,21 +40,6 @@ static void convertMoveToDeleteAndInsert(NSMutableSet<IGListMoveIndex *> *moves,
 
 @implementation IGListBatchUpdateData
 
-// Converts all moves that have section operations into a section delete + insert.
-+ (void)cleanIndexSetWithMap:(const std::unordered_map<NSUInteger, IGListMoveIndex*> &)map
-                       moves:(NSMutableSet<IGListMoveIndex *> *)moves
-                    sections:(NSMutableIndexSet *)sections
-                     deletes:(NSMutableIndexSet *)deletes
-                     inserts:(NSMutableIndexSet *)inserts {
-    for(const auto &i : map) {
-        const NSUInteger index = i.first;
-        if ([sections containsIndex:index]) {
-            [sections removeIndex:index];
-            convertMoveToDeleteAndInsert(moves, i.second, deletes, inserts);
-        }
-    }
-}
-
 // Converts all section moves that have index path operations into a section delete + insert.
 + (void)cleanIndexPathsWithMap:(const std::unordered_map<NSUInteger, IGListMoveIndex*> &)map
                          moves:(NSMutableSet<IGListMoveIndex *> *)moves

--- a/Source/Internal/IGListAdapterInternal.h
+++ b/Source/Internal/IGListAdapterInternal.h
@@ -32,7 +32,8 @@ IGListCollectionContext
     __weak UICollectionView *_collectionView;
 }
 
-@property (nonatomic, strong, readonly) id <IGListUpdatingDelegate> updatingDelegate;
+@property (nonatomic, strong) id <IGListUpdatingDelegate> updatingDelegate;
+
 @property (nonatomic, strong, readonly) IGListSectionMap *sectionMap;
 @property (nonatomic, strong, readonly) IGListDisplayHandler *displayHandler;
 @property (nonatomic, strong, readonly) IGListWorkingRangeHandler *workingRangeHandler;
@@ -61,6 +62,7 @@ IGListCollectionContext
 - (NSArray *)indexPathsFromSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                      indexes:(NSIndexSet *)indexes
                         adjustForUpdateBlock:(BOOL)adjustForUpdateBlock;
+- (NSIndexPath *)indexPathForSectionController:(IGListSectionController *)controller index:(NSInteger)index;
 
 @end
 

--- a/Tests/IGListDiffTests.m
+++ b/Tests/IGListDiffTests.m
@@ -428,4 +428,9 @@ static NSArray *sorted(NSArray *arr) {
     XCTAssertEqualObjects(sorted(result.inserts), expectedInserts);
 }
 
+- (void)test_whenComparingDiffableObjects_withDefaultCategory_thatPointersAreAlwaysEqual {
+    NSObject *object = [NSObject new];
+    XCTAssertTrue([object isEqualToDiffableObject:object]);
+}
+
 @end


### PR DESCRIPTION
## Changes in this pull request

- Removed dead code in batch data and updater
- Tested updating with empty index sets
- Tested updating with not-found section controller
- Tested reloading when collection view or data source are not set
- Tested `-[IGListAdapter sectionForObject:]`
- Tested index path return for not-found section controller
- Tested pointer comparison with `NSObject+IGListDiffable` category

Fixes #190, #189

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)

