### PR TITLE
Unit test moves in containers

### DIFF
--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		290486211DCD02750007F41D /* IGTestNibSupplementaryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */; };
 		2914BEE91DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
 		2914BEEA1DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
+		294AC6321DDE4C19002FCE5D /* IGListDiffResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */; };
 		296176F71D9D54C100F40F34 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 296176EF1D9D54C100F40F34 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		296176F81D9D54C100F40F34 /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 296176F01D9D54C100F40F34 /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		296176F91D9D54C100F40F34 /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 296176F11D9D54C100F40F34 /* IGListSectionController.m */; };
@@ -229,6 +230,7 @@
 		2904861E1DCD02750007F41D /* IGTestNibSupplementaryView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGTestNibSupplementaryView.h; sourceTree = "<group>"; };
 		2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGTestNibSupplementaryView.m; sourceTree = "<group>"; };
 		294369B01DB1B7AE0025F6E7 /* IGTestNibCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IGTestNibCell.xib; sourceTree = "<group>"; };
+		294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGListDiffResultTests.m; sourceTree = "<group>"; };
 		296176EF1D9D54C100F40F34 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGListScrollDelegate.h; sourceTree = "<group>"; };
 		296176F01D9D54C100F40F34 /* IGListSectionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGListSectionController.h; sourceTree = "<group>"; };
 		296176F11D9D54C100F40F34 /* IGListSectionController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGListSectionController.m; sourceTree = "<group>"; };
@@ -562,18 +564,19 @@
 			children = (
 				294369AF1DB1B7AE0025F6E7 /* Assets */,
 				88144EE21D870EDC007C7F66 /* IGListAdapterE2ETests.m */,
-				88144EE31D870EDC007C7F66 /* IGListAdapterTests.m */,
 				8240C7F11DC284C300B3AAE7 /* IGListAdapterStoryboardTests.m */,
+				88144EE31D870EDC007C7F66 /* IGListAdapterTests.m */,
 				88144EE41D870EDC007C7F66 /* IGListAdapterUpdaterTests.m */,
 				88144EE51D870EDC007C7F66 /* IGListBatchUpdateDataTests.m */,
+				294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */,
 				88144EE61D870EDC007C7F66 /* IGListDiffSwiftTests.swift */,
 				88144EE81D870EDC007C7F66 /* IGListDiffTests.m */,
 				88144EE91D870EDC007C7F66 /* IGListDisplayHandlerTests.m */,
 				88144EEB1D870EDC007C7F66 /* IGListKitTests-Bridging-Header.h */,
+				829D7BA81DD1816400549816 /* IGListSectionMapTests.m */,
 				26271C8B1DAE96740073E116 /* IGListSingleNibItemControllerTests.m */,
 				88144EED1D870EDC007C7F66 /* IGListSingleSectionControllerTests.m */,
 				821BC4BE1DB8C95300172ED0 /* IGListSingleStoryboardItemControllerTests.m */,
-				829D7BA81DD1816400549816 /* IGListSectionMapTests.m */,
 				88144EEE1D870EDC007C7F66 /* IGListStackSectionControllerTests.m */,
 				88144EEF1D870EDC007C7F66 /* IGListWorkingRangeHandlerTests.m */,
 				887D0B571D870E1E009E01F7 /* Info.plist */,
@@ -1054,6 +1057,7 @@
 				88144F1B1D870EDC007C7F66 /* IGTestSingleItemDataSource.m in Sources */,
 				88144F171D870EDC007C7F66 /* IGTestCell.m in Sources */,
 				821BC4C01DB8C9D500172ED0 /* IGListSingleStoryboardItemControllerTests.m in Sources */,
+				294AC6321DDE4C19002FCE5D /* IGListDiffResultTests.m in Sources */,
 				88144F141D870EDC007C7F66 /* IGListTestOffsettingLayout.m in Sources */,
 				8240C7FB1DC2F6CF00B3AAE7 /* IGListTestAdapterStoryboardDataSource.m in Sources */,
 				88144F131D870EDC007C7F66 /* IGListTestAdapterDataSource.m in Sources */,

--- a/Tests/IGListDiffResultTests.m
+++ b/Tests/IGListDiffResultTests.m
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <IGListKit/IGListKit.h>
+
+#import "IGListMoveIndexInternal.h"
+#import "IGListMoveIndexPathInternal.h"
+
+@interface IGListDiffResultTests : XCTestCase
+
+@end
+
+@implementation IGListDiffResultTests
+
+- (void)test_whenDuplicateMoves_withIndexPaths_thatSetCountCorrect {
+    IGListMoveIndexPath *move = [[IGListMoveIndexPath alloc] initWithFrom:[NSIndexPath indexPathForItem:4 inSection:2]
+                                                                       to:[NSIndexPath indexPathForItem:7 inSection:5]];
+    IGListMoveIndexPath *other = [[IGListMoveIndexPath alloc] initWithFrom:[NSIndexPath indexPathForItem:4 inSection:2]
+                                                                        to:[NSIndexPath indexPathForItem:7 inSection:5]];
+    NSSet *set = [NSSet setWithObjects:move, other, nil];
+    XCTAssertEqual(set.count, 1);
+}
+
+- (void)test_whenUniqueMoves_withIndexPaths_whenFlippedIndexPaths_thatSetCountCorrect {
+    IGListMoveIndexPath *move = [[IGListMoveIndexPath alloc] initWithFrom:[NSIndexPath indexPathForItem:4 inSection:2]
+                                                                       to:[NSIndexPath indexPathForItem:7 inSection:5]];
+    IGListMoveIndexPath *other = [[IGListMoveIndexPath alloc] initWithFrom:[NSIndexPath indexPathForItem:7 inSection:5]
+                                                                        to:[NSIndexPath indexPathForItem:4 inSection:4]];
+    NSSet *set = [NSSet setWithObjects:move, other, nil];
+    XCTAssertEqual(set.count, 2);
+}
+
+- (void)test_whenUniqueMoves_withIndexPaths_thatSetCountCorrect {
+    IGListMoveIndexPath *move = [[IGListMoveIndexPath alloc] initWithFrom:[NSIndexPath indexPathForItem:4 inSection:2]
+                                                                       to:[NSIndexPath indexPathForItem:7 inSection:5]];
+    IGListMoveIndexPath *other = [[IGListMoveIndexPath alloc] initWithFrom:[NSIndexPath indexPathForItem:10 inSection:2]
+                                                                        to:[NSIndexPath indexPathForItem:6 inSection:11]];
+    NSSet *set = [NSSet setWithObjects:move, other, nil];
+    XCTAssertEqual(set.count, 2);
+}
+
+- (void)test_whenDuplicateMoves_withIndexes_thatSetCountCorrect {
+    IGListMoveIndex *move = [[IGListMoveIndex alloc] initWithFrom:4 to:2];
+    IGListMoveIndex *other = [[IGListMoveIndex alloc] initWithFrom:4 to:2];
+    NSSet *set = [NSSet setWithObjects:move, other, nil];
+    XCTAssertEqual(set.count, 1);
+}
+
+- (void)test_whenUniqueMoves_withIndexes_whenFlippedIndexes_thatSetCountCorrect {
+    IGListMoveIndex *move = [[IGListMoveIndex alloc] initWithFrom:4 to:2];
+    IGListMoveIndex *other = [[IGListMoveIndex alloc] initWithFrom:2 to:4];
+    NSSet *set = [NSSet setWithObjects:move, other, nil];
+    XCTAssertEqual(set.count, 2);
+}
+
+- (void)test_whenUniqueMoves_withIndexes_thatSetCountCorrect {
+    IGListMoveIndex *move = [[IGListMoveIndex alloc] initWithFrom:4 to:2];
+    IGListMoveIndex *other = [[IGListMoveIndex alloc] initWithFrom:5 to:7];
+    NSSet *set = [NSSet setWithObjects:move, other, nil];
+    XCTAssertEqual(set.count, 2);
+}
+
+@end


### PR DESCRIPTION
## Changes in this pull request

Unit testing moves in sets so their `hash` and `isEqual` functions provide uniqueness.

Fixes #187, #188

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/CONTRIBUTING.md)

