### PR TITLE
Ignore Xcode dir in coverage reports

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -4,3 +4,5 @@ xcodeproj: IGListKit.xcodeproj
 workspace: IGListKit.xcworkspace
 scheme: IGListKit
 source_directory: Source
+ignore:
+  - "../**/*/Xcode*"


### PR DESCRIPTION
Getting rid of objc files included in test coverage.