### PR TITLE
Fixed set creation in batch update index path results

### DIFF
--- a/Source/IGListIndexPathResult.m
+++ b/Source/IGListIndexPathResult.m
@@ -37,9 +37,9 @@
 }
 
 - (IGListIndexPathResult *)resultForBatchUpdates {
-    NSMutableSet<NSIndexPath *> *deletes = [self.deletes mutableCopy];
-    NSMutableSet<NSIndexPath *> *inserts = [self.inserts mutableCopy];
-    NSMutableSet<NSIndexPath *> *filteredUpdates = [self.updates mutableCopy];
+    NSMutableSet<NSIndexPath *> *deletes = [NSMutableSet setWithArray:self.deletes];
+    NSMutableSet<NSIndexPath *> *inserts = [NSMutableSet setWithArray:self.inserts];
+    NSMutableSet<NSIndexPath *> *filteredUpdates = [NSMutableSet setWithArray:self.updates];
 
     NSArray<IGListMoveIndexPath *> *moves = self.moves;
     NSMutableArray<IGListMoveIndexPath *> *filteredMoves = [moves mutableCopy];


### PR DESCRIPTION
## Changes in this pull request

3 variables were meant to be sets but were initialized as arrays, as discussed in #232. Corrected initialization to match definitions.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
