### PR TITLE
Cleanup layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit
 - Added new `-[IGListAdapter visibleObjects]` API. [Ryan Nystrom](https://github.com/rnystrom) [(386ae07)](https://github.com/Instagram/IGListKit/commit/386ae0786445c06e1eabf074a4181614332f155f)
 
 - Added new `-[IGListAdapter objectForSectionController:]` API. [Ayush Saraswat](https://github.com/saraswatayu) [(#204)](https://github.com/Instagram/IGListKit/pull/204)
-- Added new `IGListGridCollectionViewLayout` for single-item grid layouts. [Bofei Zhu](https://github.com/zhubofei) [(#225)](https://github.com/Instagram/IGListKit/pull/225)
+
+- Added new `IGListGridCollectionViewLayout`, a section-based grid layout. [Bofei Zhu](https://github.com/zhubofei) [(#225)](https://github.com/Instagram/IGListKit/pull/225)
 
 ### Fixes
 

--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -8,9 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		01E12EE2D2F55E9DE8928E1E /* Pods_IGListKit_tvOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 529C388FDB3DF79737F3496A /* Pods_IGListKit_tvOSTests.framework */; };
+		0BBFB66D1DE3B5A50091290F /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 828540431DDFF59C00118B94 /* IGListGridCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0BBFB66E1DE3B5AB0091290F /* IGListGridCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 828540441DDFF59C00118B94 /* IGListGridCollectionViewLayout.m */; };
 		26271C8A1DAE94E40073E116 /* IGTestSingleNibItemDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C891DAE94E40073E116 /* IGTestSingleNibItemDataSource.m */; };
 		26271C8C1DAE96740073E116 /* IGListSingleNibItemControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C8B1DAE96740073E116 /* IGListSingleNibItemControllerTests.m */; };
-		290486201DCD02750007F41D /* IGTestNibSupplementaryView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2904861E1DCD02750007F41D /* IGTestNibSupplementaryView.h */; };
 		2914BEE91DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
 		2914BEEA1DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
 		294AC6321DDE4C19002FCE5D /* IGListDiffResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */; };
@@ -45,8 +46,6 @@
 		29C579311DE0DA8A003A149B /* IGTestNibSupplementaryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */; };
 		29C579321DE0DA8A003A149B /* IGTestStoryboardSupplementarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8240C7F41DC2D99300B3AAE7 /* IGTestStoryboardSupplementarySource.m */; };
 		29C579331DE0DA8A003A149B /* IGTestStoryboardSupplementaryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8240C7EF1DC272CA00B3AAE7 /* IGTestStoryboardSupplementaryView.m */; };
-		29C579341DE0DB30003A149B /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144F481D870F3E007C7F66 /* IGListAdapterProxy.m */; };
-		29C579351DE0DB30003A149B /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144F481D870F3E007C7F66 /* IGListAdapterProxy.m */; };
 		29EA6C491DB43A8000957A88 /* IGTestNibCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 294369B01DB1B7AE0025F6E7 /* IGTestNibCell.xib */; };
 		5C81083F8E7AEF4B3EBE8871 /* Pods_IGListKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD40284889DE182FFC7F471E /* Pods_IGListKitTests.framework */; };
 		821BC4C01DB8C9D500172ED0 /* IGListSingleStoryboardItemControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4BE1DB8C95300172ED0 /* IGListSingleStoryboardItemControllerTests.m */; };
@@ -59,7 +58,7 @@
 		8240C7F51DC2D99300B3AAE7 /* IGTestStoryboardSupplementarySource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8240C7F41DC2D99300B3AAE7 /* IGTestStoryboardSupplementarySource.m */; };
 		8240C7F81DC2F3FB00B3AAE7 /* IGListTestStoryboardSection.m in Sources */ = {isa = PBXBuildFile; fileRef = 8240C7F71DC2F3FB00B3AAE7 /* IGListTestStoryboardSection.m */; };
 		8240C7FB1DC2F6CF00B3AAE7 /* IGListTestAdapterStoryboardDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8240C7FA1DC2F6CF00B3AAE7 /* IGListTestAdapterStoryboardDataSource.m */; };
-		828540451DDFF59C00118B94 /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 828540431DDFF59C00118B94 /* IGListGridCollectionViewLayout.h */; };
+		828540451DDFF59C00118B94 /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 828540431DDFF59C00118B94 /* IGListGridCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		828540461DDFF59C00118B94 /* IGListGridCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 828540441DDFF59C00118B94 /* IGListGridCollectionViewLayout.m */; };
 		828540481DDFF5D400118B94 /* IGListGridCollectionViewLayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 828540471DDFF5D400118B94 /* IGListGridCollectionViewLayoutTests.m */; };
 		828540491DDFF5D400118B94 /* IGListGridCollectionViewLayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 828540471DDFF5D400118B94 /* IGListGridCollectionViewLayoutTests.m */; };
@@ -668,6 +667,7 @@
 				885FE1ED1DC51B18009CE2B4 /* IGListAdapterDataSource.h in Headers */,
 				885FE1F11DC51B18009CE2B4 /* IGListAssert.h in Headers */,
 				885FE1F51DC51B18009CE2B4 /* IGListDiff.h in Headers */,
+				0BBFB66D1DE3B5A50091290F /* IGListGridCollectionViewLayout.h in Headers */,
 				885FE1F01DC51B18009CE2B4 /* IGListAdapterUpdaterDelegate.h in Headers */,
 				885FE1F71DC51B18009CE2B4 /* IGListDisplayDelegate.h in Headers */,
 				885FE2051DC51B18009CE2B4 /* IGListSupplementaryViewSource.h in Headers */,
@@ -694,7 +694,6 @@
 				88144F6C1D870F3E007C7F66 /* IGListDisplayDelegate.h in Headers */,
 				88144F811D870F3E007C7F66 /* IGListUpdatingDelegate.h in Headers */,
 				88144F6D1D870F3E007C7F66 /* IGListExperiments.h in Headers */,
-				290486201DCD02750007F41D /* IGTestNibSupplementaryView.h in Headers */,
 				88144F5E1D870F3E007C7F66 /* IGListAdapterDataSource.h in Headers */,
 				88144F621D870F3E007C7F66 /* IGListAdapterUpdaterDelegate.h in Headers */,
 				88144F8E1D870F3E007C7F66 /* IGListMoveIndexInternal.h in Headers */,
@@ -998,6 +997,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BBFB66E1DE3B5AB0091290F /* IGListGridCollectionViewLayout.m in Sources */,
 				885FE2261DC51B3F009CE2B4 /* IGListDisplayHandler.m in Sources */,
 				885FE2251DC51B3F009CE2B4 /* IGListAdapterProxy.m in Sources */,
 				29B5AFD01DE39B0F004C27A2 /* NSString+IGListDiffable.m in Sources */,
@@ -1037,7 +1037,6 @@
 				29C579311DE0DA8A003A149B /* IGTestNibSupplementaryView.m in Sources */,
 				885FE23C1DC51B86009CE2B4 /* IGTestCell.m in Sources */,
 				29C579331DE0DA8A003A149B /* IGTestStoryboardSupplementaryView.m in Sources */,
-				29C579351DE0DB30003A149B /* IGListAdapterProxy.m in Sources */,
 				885FE2401DC51B86009CE2B4 /* IGTestSingleItemDataSource.m in Sources */,
 				885FE2451DC51B86009CE2B4 /* IGTestStoryboardCell.m in Sources */,
 				828540491DDFF5D400118B94 /* IGListGridCollectionViewLayoutTests.m in Sources */,
@@ -1111,7 +1110,6 @@
 				8240C7FB1DC2F6CF00B3AAE7 /* IGListTestAdapterStoryboardDataSource.m in Sources */,
 				88144F131D870EDC007C7F66 /* IGListTestAdapterDataSource.m in Sources */,
 				88144F071D870EDC007C7F66 /* IGListAdapterE2ETests.m in Sources */,
-				29C579341DE0DB30003A149B /* IGListAdapterProxy.m in Sources */,
 				88144F111D870EDC007C7F66 /* IGListStackSectionControllerTests.m in Sources */,
 				88144F1A1D870EDC007C7F66 /* IGTestObject.m in Sources */,
 				88144F0B1D870EDC007C7F66 /* IGListDiffSwiftTests.swift in Sources */,

--- a/Source/IGListGridCollectionViewLayout.h
+++ b/Source/IGListGridCollectionViewLayout.h
@@ -8,6 +8,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <IGListKit/IGListMacros.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,17 +22,17 @@ IGLK_SUBCLASSING_RESTRICTED
 @interface IGListGridCollectionViewLayout : UICollectionViewLayout
 
 /**
- The minimum spacing to use between lines of items in the grid.
+ The minimum spacing to use between lines of items in the grid. The default value is `1.0`.
  */
 @property (nonatomic, assign) IBInspectable CGFloat minimumLineSpacing;
 
 /**
- The minimum spacing to use between items in the same row.
+ The minimum spacing to use between items in the same row. The default value is `1.0`.
  */
 @property (nonatomic, assign) IBInspectable CGFloat minimumInteritemSpacing;
 
 /**
- The default size to use for cells.
+ The default size to use for cells. The default value is `(100.0, 100.0)`.
  */
 @property (nonatomic, assign) IBInspectable CGSize itemSize;
 

--- a/Source/IGListGridCollectionViewLayout.h
+++ b/Source/IGListGridCollectionViewLayout.h
@@ -9,18 +9,15 @@
 
 #import <UIKit/UIKit.h>
 
-/**
- IGListGridCollectionViewLayout provide a grid layout for UICollectionView with section controllers that return 1 item.
- The size of the item for each section can be varying.
- 
- @note This layout dose not have support for section insets and scroll direction yet. 
- */
-@interface IGListGridCollectionViewLayout : UICollectionViewLayout
+NS_ASSUME_NONNULL_BEGIN
 
 /**
- The scroll direction of the grid.
+ `IGListGridCollectionViewLayout` provides a vertically-scrolling, section-based grid layout for `UICollectionView`.
+ Items in the layout are displayed consecutively in a grid with exactly 1 item per section.
+ If items are square, the appearance would be similar to the iOS Photos app.
+ However, the size of the items for each section can vary.
  */
-@property (nonatomic, assign) UICollectionViewScrollDirection scrollDirection;
+@interface IGListGridCollectionViewLayout : UICollectionViewLayout
 
 /**
  The minimum spacing to use between lines of items in the grid.
@@ -38,3 +35,5 @@
 @property (nonatomic, assign) IBInspectable CGSize itemSize;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListGridCollectionViewLayout.h
+++ b/Source/IGListGridCollectionViewLayout.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  If items are square, the appearance would be similar to the iOS Photos app.
  However, the size of the items for each section can vary.
  */
+IGLK_SUBCLASSING_RESTRICTED
 @interface IGListGridCollectionViewLayout : UICollectionViewLayout
 
 /**

--- a/Source/IGListGridCollectionViewLayout.m
+++ b/Source/IGListGridCollectionViewLayout.m
@@ -64,11 +64,11 @@
 }
 
 - (void)commonInit {
-    _minimumLineSpacing = 0.0;
-    _minimumInteritemSpacing = 0.0;
+    _minimumLineSpacing = 1.0f;
+    _minimumInteritemSpacing = 1.0f;
     _lineCache = [NSMutableArray new];
     _lineForItem = [NSMutableArray new];
-    _itemSize = CGSizeZero;
+    _itemSize = CGSizeMake(100.0f, 100.0f);
 }
 
 #pragma mark - Layout Infomation

--- a/Source/IGListKit.h
+++ b/Source/IGListKit.h
@@ -32,6 +32,7 @@ FOUNDATION_EXPORT const unsigned char IGListKitVersionString[];
 #import <IGListKit/IGListDiffable.h>
 #import <IGListKit/IGListDisplayDelegate.h>
 #import <IGListKit/IGListExperiments.h>
+#import <IGListKit/IGListGridCollectionViewLayout.h>
 #import <IGListKit/IGListIndexPathResult.h>
 #import <IGListKit/IGListIndexSetResult.h>
 #import <IGListKit/IGListSectionController.h>

--- a/Source/NSNumber+IGListDiffable.h
+++ b/Source/NSNumber+IGListDiffable.h
@@ -11,6 +11,9 @@
 
 #import <IGListKit/IGListDiffable.h>
 
+/**
+ This category provides default `IGListDiffable` conformance for `NSNumber`.
+ */
 @interface NSNumber (IGListDiffable) <IGListDiffable>
 
 @end

--- a/Source/NSString+IGListDiffable.h
+++ b/Source/NSString+IGListDiffable.h
@@ -11,6 +11,9 @@
 
 #import <IGListKit/IGListDiffable.h>
 
+/**
+ This category provides default `IGListDiffable` conformance for `NSString`.
+ */
 @interface NSString (IGListDiffable) <IGListDiffable>
 
 @end

--- a/docs/Categories.html
+++ b/docs/Categories.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>
@@ -203,9 +206,9 @@
                 <li class="item">
                   <div>
                     <code>
-                    <a name="/c:objc(cy)NSObject@IGListDiffable"></a>
-                    <a name="//apple_ref/objc/Extension/NSObject(IGListDiffable)" class="dashAnchor"></a>
-                    <a class="token" href="#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                    <a name="/c:objc(cy)NSNumber@IGListDiffable"></a>
+                    <a name="//apple_ref/objc/Extension/NSNumber(IGListDiffable)" class="dashAnchor"></a>
+                    <a class="token" href="#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
                     </code>
                   </div>
                   <div class="height-container">
@@ -213,21 +216,45 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>This category adds diffing comparisons similar to adding the object into an <code>NSSet</code>, 
-where the object&rsquo;s <code>-isEqual:</code> method drives the uniqueness of the object.</p>
-
-<p>For instance, an <code>NSString</code>&rsquo;s <code>-isEqual:</code> will compare the value of the strings. 
-So if you were to diff <code>@&quot;cat&quot;</code> and <code>@&quot;cat&quot;</code> each object would have the same diff identifier.</p>
-
-<p>However objects that don&rsquo;t implement a custom <code>-isEqual:</code> (e.g. the <code>NSObject</code> base class), the diff will default to simple
-pointer comparisons to establish uniqueness.</p>
+                        <p>This category provides default <code><a href="Protocols/IGListDiffable.html">IGListDiffable</a></code> conformance for <code>NSNumber</code>.</p>
 
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
                         <div class="language">
                           <p class="aside-title">Objective-C</p>
-                          <pre class="highlight"><code><span class="k">@interface</span> <span class="nc">NSObject</span> <span class="p">(</span><span class="nl">IGListDiffable</span><span class="p">)</span></code></pre>
+                          <pre class="highlight"><code><span class="k">@interface</span> <span class="nc">NSNumber</span> <span class="p">(</span><span class="nl">IGListDiffable</span><span class="p">)</span></code></pre>
+
+                        </div>
+                      </div>
+                    </section>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div class="task-group">
+              <ul>
+                <li class="item">
+                  <div>
+                    <code>
+                    <a name="/c:objc(cy)NSString@IGListDiffable"></a>
+                    <a name="//apple_ref/objc/Extension/NSString(IGListDiffable)" class="dashAnchor"></a>
+                    <a class="token" href="#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
+                    </code>
+                  </div>
+                  <div class="height-container">
+                    <div class="pointer-container"></div>
+                    <section class="section">
+                      <div class="pointer"></div>
+                      <div class="abstract">
+                        <p>This category provides default <code><a href="Protocols/IGListDiffable.html">IGListDiffable</a></code> conformance for <code>NSString</code>.</p>
+
+                      </div>
+                      <div class="declaration">
+                        <h4>Declaration</h4>
+                        <div class="language">
+                          <p class="aside-title">Objective-C</p>
+                          <pre class="highlight"><code><span class="k">@interface</span> <span class="nc">NSString</span> <span class="p">(</span><span class="nl">IGListDiffable</span><span class="p">)</span></code></pre>
 
                         </div>
                       </div>

--- a/docs/Categories.html
+++ b/docs/Categories.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes.html
+++ b/docs/Classes.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes.html
+++ b/docs/Classes.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">
@@ -342,6 +345,41 @@ methods are called on the collection view returned by <code>-[IGListAdapter coll
                         <div class="language">
                           <p class="aside-title">Swift</p>
                           <pre class="highlight"><code><span class="kd">class</span> <span class="kt">IGListCollectionView</span></code></pre>
+
+                        </div>
+                      </div>
+                    </section>
+                  </div>
+                </li>
+              </ul>
+            </div>
+            <div class="task-group">
+              <ul>
+                <li class="item">
+                  <div>
+                    <code>
+                    <a name="/c:objc(cs)IGListGridCollectionViewLayout"></a>
+                    <a name="//apple_ref/objc/Class/IGListGridCollectionViewLayout" class="dashAnchor"></a>
+                    <a class="token" href="#/c:objc(cs)IGListGridCollectionViewLayout">IGListGridCollectionViewLayout</a>
+                    </code>
+                  </div>
+                  <div class="height-container">
+                    <div class="pointer-container"></div>
+                    <section class="section">
+                      <div class="pointer"></div>
+                      <div class="abstract">
+                        <p><code>IGListGridCollectionViewLayout</code> provides a vertically-scrolling, section-based grid layout for <code>UICollectionView</code>.
+Items in the layout are displayed consecutively in a grid with exactly 1 item per section.
+If items are square, the appearance would be similar to the iOS Photos app.
+However, the size of the items for each section can vary.</p>
+
+                        <a href="Classes/IGListGridCollectionViewLayout.html" class="slightly-smaller">See more</a>
+                      </div>
+                      <div class="declaration">
+                        <h4>Declaration</h4>
+                        <div class="language">
+                          <p class="aside-title">Objective-C</p>
+                          <pre class="highlight"><code><span class="k">@interface</span> <span class="nc">IGListGridCollectionViewLayout</span> <span class="p">:</span> <span class="nc">UICollectionViewLayout</span></code></pre>
 
                         </div>
                       </div>

--- a/docs/Classes/IGListAdapter.html
+++ b/docs/Classes/IGListAdapter.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListAdapter.html
+++ b/docs/Classes/IGListAdapter.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListAdapterUpdater.html
+++ b/docs/Classes/IGListAdapterUpdater.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListAdapterUpdater.html
+++ b/docs/Classes/IGListAdapterUpdater.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListBatchUpdateData.html
+++ b/docs/Classes/IGListBatchUpdateData.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListBatchUpdateData.html
+++ b/docs/Classes/IGListBatchUpdateData.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListGridCollectionViewLayout.html
+++ b/docs/Classes/IGListGridCollectionViewLayout.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListGridCollectionViewLayout.html
+++ b/docs/Classes/IGListGridCollectionViewLayout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>IGListMoveIndexPath Class Reference</title>
+    <title>IGListGridCollectionViewLayout Class Reference</title>
     <link rel="stylesheet" type="text/css" href="../css/jazzy.css" />
     <link rel="stylesheet" type="text/css" href="../css/highlight.css" />
     <meta charset='utf-8'>
@@ -10,8 +10,8 @@
     
   </head>
   <body>
-    <a name="//apple_ref/objc/Class/IGListMoveIndexPath" class="dashAnchor"></a>
-    <a title="IGListMoveIndexPath Class Reference"></a>
+    <a name="//apple_ref/objc/Class/IGListGridCollectionViewLayout" class="dashAnchor"></a>
+    <a title="IGListGridCollectionViewLayout Class Reference"></a>
     <header>
       <div class="content-wrapper">
         <p><a href="../index.html">IGListKit Docs</a> (100% documented)</p>
@@ -22,7 +22,7 @@
       <p id="breadcrumbs">
         <a href="../index.html">IGListKit Reference</a>
         <img id="carat" src="../img/carat.png" />
-        IGListMoveIndexPath Class Reference
+        IGListGridCollectionViewLayout Class Reference
       </p>
     </div>
     <div class="content-wrapper">
@@ -194,14 +194,17 @@
       <article class="main-content">
         <section>
           <section class="section">
-            <h1>IGListMoveIndexPath</h1>
+            <h1>IGListGridCollectionViewLayout</h1>
               <div class="declaration">
                 <div class="language">
-                  <pre class="highlight"><code><span class="k">@interface</span> <span class="nc">IGListMoveIndexPath</span> <span class="p">:</span> <span class="nc">NSObject</span></code></pre>
+                  <pre class="highlight"><code><span class="k">@interface</span> <span class="nc">IGListGridCollectionViewLayout</span> <span class="p">:</span> <span class="nc">UICollectionViewLayout</span></code></pre>
 
                 </div>
               </div>
-            <p>An object representing a move between indexes.</p>
+            <p><code>IGListGridCollectionViewLayout</code> provides a vertically-scrolling, section-based grid layout for <code>UICollectionView</code>.
+Items in the layout are displayed consecutively in a grid with exactly 1 item per section.
+If items are square, the appearance would be similar to the iOS Photos app.
+However, the size of the items for each section can vary.</p>
 
           </section>
           <section class="section task-group-section">
@@ -210,9 +213,9 @@
                 <li class="item">
                   <div>
                     <code>
-                    <a name="/c:objc(cs)IGListMoveIndexPath(py)from"></a>
-                    <a name="//apple_ref/objc/Property/from" class="dashAnchor"></a>
-                    <a class="token" href="#/c:objc(cs)IGListMoveIndexPath(py)from">from</a>
+                    <a name="/c:objc(cs)IGListGridCollectionViewLayout(py)minimumLineSpacing"></a>
+                    <a name="//apple_ref/objc/Property/minimumLineSpacing" class="dashAnchor"></a>
+                    <a class="token" href="#/c:objc(cs)IGListGridCollectionViewLayout(py)minimumLineSpacing">minimumLineSpacing</a>
                     </code>
                   </div>
                   <div class="height-container">
@@ -220,19 +223,14 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>An index path in the old collection.</p>
+                        <p>The minimum spacing to use between lines of items in the grid. The default value is <code>1.0</code>.</p>
 
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
                         <div class="language">
                           <p class="aside-title">Objective-C</p>
-                          <pre class="highlight"><code><span class="k">@property</span> <span class="p">(</span><span class="n">readonly</span><span class="p">,</span> <span class="n">strong</span><span class="p">,</span> <span class="n">nonatomic</span><span class="p">)</span> <span class="n">NSIndexPath</span> <span class="o">*</span><span class="n">_Nonnull</span> <span class="n">from</span><span class="p">;</span></code></pre>
-
-                        </div>
-                        <div class="language">
-                          <p class="aside-title">Swift</p>
-                          <pre class="highlight"><code><span class="k">var</span> <span class="nv">from</span><span class="p">:</span> <span class="kt">IndexPath</span> <span class="p">{</span> <span class="k">get</span> <span class="p">}</span></code></pre>
+                          <pre class="highlight"><code><span class="k">@property</span> <span class="p">(</span><span class="n">assign</span><span class="p">,</span> <span class="n">readwrite</span><span class="p">,</span> <span class="n">nonatomic</span><span class="p">)</span> <span class="n">CGFloat</span> <span class="n">minimumLineSpacing</span><span class="p">;</span></code></pre>
 
                         </div>
                       </div>
@@ -242,9 +240,9 @@
                 <li class="item">
                   <div>
                     <code>
-                    <a name="/c:objc(cs)IGListMoveIndexPath(py)to"></a>
-                    <a name="//apple_ref/objc/Property/to" class="dashAnchor"></a>
-                    <a class="token" href="#/c:objc(cs)IGListMoveIndexPath(py)to">to</a>
+                    <a name="/c:objc(cs)IGListGridCollectionViewLayout(py)minimumInteritemSpacing"></a>
+                    <a name="//apple_ref/objc/Property/minimumInteritemSpacing" class="dashAnchor"></a>
+                    <a class="token" href="#/c:objc(cs)IGListGridCollectionViewLayout(py)minimumInteritemSpacing">minimumInteritemSpacing</a>
                     </code>
                   </div>
                   <div class="height-container">
@@ -252,19 +250,41 @@
                     <section class="section">
                       <div class="pointer"></div>
                       <div class="abstract">
-                        <p>An index path in the new collection.</p>
+                        <p>The minimum spacing to use between items in the same row. The default value is <code>1.0</code>.</p>
 
                       </div>
                       <div class="declaration">
                         <h4>Declaration</h4>
                         <div class="language">
                           <p class="aside-title">Objective-C</p>
-                          <pre class="highlight"><code><span class="k">@property</span> <span class="p">(</span><span class="n">readonly</span><span class="p">,</span> <span class="n">strong</span><span class="p">,</span> <span class="n">nonatomic</span><span class="p">)</span> <span class="n">NSIndexPath</span> <span class="o">*</span><span class="n">_Nonnull</span> <span class="n">to</span><span class="p">;</span></code></pre>
+                          <pre class="highlight"><code><span class="k">@property</span> <span class="p">(</span><span class="n">assign</span><span class="p">,</span> <span class="n">readwrite</span><span class="p">,</span> <span class="n">nonatomic</span><span class="p">)</span> <span class="n">CGFloat</span> <span class="n">minimumInteritemSpacing</span><span class="p">;</span></code></pre>
 
                         </div>
+                      </div>
+                    </section>
+                  </div>
+                </li>
+                <li class="item">
+                  <div>
+                    <code>
+                    <a name="/c:objc(cs)IGListGridCollectionViewLayout(py)itemSize"></a>
+                    <a name="//apple_ref/objc/Property/itemSize" class="dashAnchor"></a>
+                    <a class="token" href="#/c:objc(cs)IGListGridCollectionViewLayout(py)itemSize">itemSize</a>
+                    </code>
+                  </div>
+                  <div class="height-container">
+                    <div class="pointer-container"></div>
+                    <section class="section">
+                      <div class="pointer"></div>
+                      <div class="abstract">
+                        <p>The default size to use for cells. The default value is <code>(100.0, 100.0)</code>.</p>
+
+                      </div>
+                      <div class="declaration">
+                        <h4>Declaration</h4>
                         <div class="language">
-                          <p class="aside-title">Swift</p>
-                          <pre class="highlight"><code><span class="k">var</span> <span class="nv">to</span><span class="p">:</span> <span class="kt">IndexPath</span> <span class="p">{</span> <span class="k">get</span> <span class="p">}</span></code></pre>
+                          <p class="aside-title">Objective-C</p>
+                          <pre class="highlight"><code><span class="k">@property</span> <span class="p">(</span><span class="n">assign</span><span class="p">,</span> <span class="n">readwrite</span><span class="p">,</span> <span class="n">nonatomic</span><span class="p">)</span> <span class="n">CGSize</span> <span class="n">itemSize</span><span class="p">;</span></code></pre>
 
                         </div>
                       </div>

--- a/docs/Classes/IGListIndexPathResult.html
+++ b/docs/Classes/IGListIndexPathResult.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListIndexPathResult.html
+++ b/docs/Classes/IGListIndexPathResult.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListIndexSetResult.html
+++ b/docs/Classes/IGListIndexSetResult.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListIndexSetResult.html
+++ b/docs/Classes/IGListIndexSetResult.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListMoveIndex.html
+++ b/docs/Classes/IGListMoveIndex.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListMoveIndex.html
+++ b/docs/Classes/IGListMoveIndex.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListMoveIndexPath.html
+++ b/docs/Classes/IGListMoveIndexPath.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListSectionController.html
+++ b/docs/Classes/IGListSectionController.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListSectionController.html
+++ b/docs/Classes/IGListSectionController.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListSingleSectionController.html
+++ b/docs/Classes/IGListSingleSectionController.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListSingleSectionController.html
+++ b/docs/Classes/IGListSingleSectionController.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Classes/IGListStackedSectionController.html
+++ b/docs/Classes/IGListStackedSectionController.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Classes/IGListStackedSectionController.html
+++ b/docs/Classes/IGListStackedSectionController.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Constants.html
+++ b/docs/Constants.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Constants.html
+++ b/docs/Constants.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Enums.html
+++ b/docs/Enums.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Enums.html
+++ b/docs/Enums.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Enums/IGListDiffOption.html
+++ b/docs/Enums/IGListDiffOption.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Enums/IGListDiffOption.html
+++ b/docs/Enums/IGListDiffOption.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Enums/IGListExperiment.html
+++ b/docs/Enums/IGListExperiment.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Enums/IGListExperiment.html
+++ b/docs/Enums/IGListExperiment.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Functions.html
+++ b/docs/Functions.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Functions.html
+++ b/docs/Functions.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols.html
+++ b/docs/Protocols.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols.html
+++ b/docs/Protocols.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListAdapterDataSource.html
+++ b/docs/Protocols/IGListAdapterDataSource.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListAdapterDataSource.html
+++ b/docs/Protocols/IGListAdapterDataSource.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListAdapterDelegate.html
+++ b/docs/Protocols/IGListAdapterDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListAdapterDelegate.html
+++ b/docs/Protocols/IGListAdapterDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListAdapterUpdaterDelegate.html
+++ b/docs/Protocols/IGListAdapterUpdaterDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListAdapterUpdaterDelegate.html
+++ b/docs/Protocols/IGListAdapterUpdaterDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListCollectionContext.html
+++ b/docs/Protocols/IGListCollectionContext.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListCollectionContext.html
+++ b/docs/Protocols/IGListCollectionContext.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListDiffable.html
+++ b/docs/Protocols/IGListDiffable.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListDiffable.html
+++ b/docs/Protocols/IGListDiffable.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListDisplayDelegate.html
+++ b/docs/Protocols/IGListDisplayDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListDisplayDelegate.html
+++ b/docs/Protocols/IGListDisplayDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListScrollDelegate.html
+++ b/docs/Protocols/IGListScrollDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListScrollDelegate.html
+++ b/docs/Protocols/IGListScrollDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListSectionType.html
+++ b/docs/Protocols/IGListSectionType.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListSectionType.html
+++ b/docs/Protocols/IGListSectionType.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListSingleSectionControllerDelegate.html
+++ b/docs/Protocols/IGListSingleSectionControllerDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListSingleSectionControllerDelegate.html
+++ b/docs/Protocols/IGListSingleSectionControllerDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListSupplementaryViewSource.html
+++ b/docs/Protocols/IGListSupplementaryViewSource.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListSupplementaryViewSource.html
+++ b/docs/Protocols/IGListSupplementaryViewSource.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListUpdatingDelegate.html
+++ b/docs/Protocols/IGListUpdatingDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListUpdatingDelegate.html
+++ b/docs/Protocols/IGListUpdatingDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Protocols/IGListWorkingRangeDelegate.html
+++ b/docs/Protocols/IGListWorkingRangeDelegate.html
@@ -32,7 +32,10 @@
             <a href="../Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="../Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="../Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="../Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Protocols/IGListWorkingRangeDelegate.html
+++ b/docs/Protocols/IGListWorkingRangeDelegate.html
@@ -52,6 +52,9 @@
                 <a href="../Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="../Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="../Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/Type Definitions.html
+++ b/docs/Type Definitions.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/Type Definitions.html
+++ b/docs/Type Definitions.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,10 @@
             <a href="Categories.html">Categories</a>
             <ul class="nav-group-tasks">
               <li class="nav-group-task">
-                <a href="Categories.html#/c:objc(cy)NSObject@IGListDiffable">NSObject(IGListDiffable)</a>
+                <a href="Categories.html#/c:objc(cy)NSNumber@IGListDiffable">NSNumber(IGListDiffable)</a>
+              </li>
+              <li class="nav-group-task">
+                <a href="Categories.html#/c:objc(cy)NSString@IGListDiffable">NSString(IGListDiffable)</a>
               </li>
             </ul>
           </li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,6 +51,9 @@
                 <a href="Classes.html#/c:objc(cs)IGListCollectionView">IGListCollectionView</a>
               </li>
               <li class="nav-group-task">
+                <a href="Classes/IGListGridCollectionViewLayout.html">IGListGridCollectionViewLayout</a>
+              </li>
+              <li class="nav-group-task">
                 <a href="Classes/IGListIndexPathResult.html">IGListIndexPathResult</a>
               </li>
               <li class="nav-group-task">

--- a/docs/undocumented.json
+++ b/docs/undocumented.json
@@ -2,5 +2,5 @@
   "warnings": [
 
   ],
-  "source_directory": "/Users/jsq/GitHub/IGListKit"
+  "source_directory": "/Users/jesse/GitHub/IGListKit"
 }


### PR DESCRIPTION
Replaces #243 

---------------------

- Clean up GridLayout + docs
- Remove GridLayout scroll direction, not used/supported?
- Fix some file target membership issues
- Add GridLayout to umbrella header
- "Sort by name" on xcode project directories
- crtl-I auto format in xcode
- re-gen docs