### PR TITLE
Fix crash in Examples-iOS app when tapping "Mixed Data"

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
@@ -27,6 +27,18 @@ class GridItem: NSObject {
 
 }
 
+extension GridItem: IGListDiffable {
+    
+    func diffIdentifier() -> NSObjectProtocol {
+        return self
+    }
+    
+    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+        return self === object ? true : self.isEqual(object)
+    }
+    
+}
+
 final class GridSectionController: IGListSectionController, IGListSectionType {
 
     var object: GridItem?


### PR DESCRIPTION
## Changes in this pull request

Fix crash in Examples-iOS app when tapping "Mixed Data"

Summary:
Make GridItem conform to IGListDiffable now that NSObject+IGListDiffable category has been removed.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
