### PR TITLE
Create private method in IGListStackedSectionController to get relative index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 2.0.0
 -----
 
-This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit/milestone/1?closed=1). We've increased test coverage to 95%. Thanks to the [23 contributors](https://github.com/Instagram/IGListKit/graphs/contributors) who helped with this release!
+This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit/milestone/1?closed=1). We've increased test coverage to 95%. Thanks to the [24 contributors](https://github.com/Instagram/IGListKit/graphs/contributors) who helped with this release!
 
 ### Breaking Changes
 
@@ -21,7 +21,7 @@ This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - `IGListDiffable` equality method changed from `isEqual:` to `isEqualToDiffableObject:` [(ab890fc)](https://github.com/Instagram/IGListKit/commit/ab890fc6070f170a2db5a383a6296e62dcf75678)
 
-- The default `NSObject<IGListDiffable>` category was removed and replaced with `NSString<IGListDiffable>` and `NSNumber<IGListDiffable>` categories. All other models will need to conform to `IGListDiffable`. 
+- The default `NSObject<IGListDiffable>` category was removed and replaced with `NSString<IGListDiffable>` and `NSNumber<IGListDiffable>` categories. All other models will need to conform to `IGListDiffable`.
 
 - Added support for specifying an end position when scrolling. [Bofei Zhu](https://github.com/zhubofei) [(#196)](https://github.com/Instagram/IGListKit/pull/196). The `IGListAdapter` scrolling method changed:
 ```objc
@@ -59,7 +59,7 @@ This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Added `-isFirstSection` and `-isLastSection` APIs to `IGListSectionController`
 
-- Added support for cells and supplementaryViews created from storyboard in `IGListCollectionContext`. [Bofei Zhu](https://github.com/zhubofei) [(#92)](https://github.com/Instagram/IGListKit/pull/92)
+- Added support for cells and supplementaryViews created from storyboard. There's a new required method on the `IGListCollectionContext` protocol to do this. [Bofei Zhu](https://github.com/zhubofei) [(#92)](https://github.com/Instagram/IGListKit/pull/92)
 
 ```objc
 // IGListCollectionContext
@@ -70,11 +70,21 @@ This release closes the [2.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Added `tvOS` support. [Jesse Squires](https://github.com/jessesquires) [(#137)](https://github.com/Instagram/IGListKit/pull/137)
 
-- Added new `-[IGListAdapter visibleObjects]` API. [Ryan Nystrom](https://github.com/rnystrom) [(386ae07)](https://github.com/Instagram/IGListKit/commit/386ae0786445c06e1eabf074a4181614332f155f)
+- Added `-[IGListAdapter visibleObjects]` API. [Ryan Nystrom](https://github.com/rnystrom) [(386ae07)](https://github.com/Instagram/IGListKit/commit/386ae0786445c06e1eabf074a4181614332f155f)
 
-- Added new `-[IGListAdapter objectForSectionController:]` API. [Ayush Saraswat](https://github.com/saraswatayu) [(#204)](https://github.com/Instagram/IGListKit/pull/204)
+- Added `-[IGListAdapter objectForSectionController:]` API. [Ayush Saraswat](https://github.com/saraswatayu) [(#204)](https://github.com/Instagram/IGListKit/pull/204)
 
-- Added new `IGListGridCollectionViewLayout`, a section-based grid layout. [Bofei Zhu](https://github.com/zhubofei) [(#225)](https://github.com/Instagram/IGListKit/pull/225)
+- Added `IGListGridCollectionViewLayout`, a section-based grid layout. [Bofei Zhu](https://github.com/zhubofei) [(#225)](https://github.com/Instagram/IGListKit/pull/225)
+
+- Added support for scrolling to an index in a section controller from within that section controller. There's a new required method on the `IGListCollectionContext` protocol to do this. [Jesse Squires](https://github.com/jessesquires)
+
+```objc
+// IGListCollectionContext
+- (void)scrollToSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                          atIndex:(NSInteger)index
+                   scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                         animated:(BOOL)animated;
+```
 
 ### Fixes
 

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -194,9 +194,9 @@ IGLK_SUBCLASSING_RESTRICTED
 
  @param object             The object to which to scroll.
  @param supplementaryKinds The types of supplementary views in the section.
- @param scrollDirection    A flag indicating the direction to scroll.
+ @param scrollDirection    An option indicating the direction to scroll.
  @param scrollPosition     An option that specifies where the item should be positioned when scrolling finishes. 
- @param animated           A flag indicating if the transition should be animated.
+ @param animated           A flag indicating if the scrolling should be animated.
  */
 - (void)scrollToObject:(id)object
     supplementaryKinds:(nullable NSArray<NSString *> *)supplementaryKinds

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -957,6 +957,16 @@
     } completion:completion];
 }
 
+- (void)scrollToSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                          atIndex:(NSInteger)index
+                   scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                         animated:(BOOL)animated {
+    IGAssertMainThread();
+    IGParameterAssert(sectionController != nil);
+
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:scrollPosition animated:animated];
+}
 
 #pragma mark - UICollectionViewDelegateFlowLayout
 

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return The index of the cell or `NSNotFound` if it does not exist in the collection.
  */
 - (NSInteger)indexForCell:(UICollectionViewCell *)cell
-         sectionController:(IGListSectionController<IGListSectionType> *)sectionController;
+        sectionController:(IGListSectionController<IGListSectionType> *)sectionController;
 
 /**
  Returns the cell in the collection at the specified index for the section controller.
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param sectionController The section controller requesting this information.
 
  @return The collection view cell, or `nil` if not found.
- 
+
  @warning This method may return `nil` if the cell is offscreen.
  */
 - (nullable __kindof UICollectionViewCell *)cellForItemAtIndex:(NSInteger)index
@@ -95,14 +95,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Dequeues a cell from the collection view reuse pool.
- 
+
  @param nibName           The name of the nib file.
  @param bundle            The bundle in which to search for the nib file. If `nil`, this method searches the main bundle.
  @param sectionController The section controller requesting this information.
  @param index             The index of the cell.
- 
+
  @return A cell dequeued from the reuse pool or a newly created one.
- 
+
  @note This method uses a string representation of the cell class as the identifier.
  */
 - (__kindof UICollectionViewCell *)dequeueReusableCellWithNibName:(NSString *)nibName
@@ -112,11 +112,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Dequeues a storyboard prototype cell from the collection view reuse pool.
- 
+
  @param identifier        The identifier of the cell prototype in storyboard.
  @param sectionController The section controller requesting this information.
  @param index             The index of the cell.
- 
+
  @return A cell dequeued from the reuse pool or a newly created one.
  */
 - (__kindof UICollectionViewCell *)dequeueReusableCellFromStoryboardWithIdentifier:(NSString *)identifier
@@ -142,12 +142,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Dequeues a supplementary view from the collection view reuse pool.
- 
+
  @param elementKind       The kind of supplementary veiw.
  @param identifier        The identifier of the supplementary view in storyboard.
  @param sectionController The section controller requesting this information.
  @param index             The index of the supplementary vew.
- 
+
  @return A supplementary view dequeued from the reuse pool or a newly created one.
  */
 - (__kindof UICollectionReusableView *)dequeueReusableSupplementaryViewFromStoryboardOfKind:(NSString *)elementKind
@@ -156,15 +156,15 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                     atIndex:(NSInteger)index;
 /**
  Dequeues a supplementary view from the collection view reuse pool.
- 
+
  @param elementKind       The kind of supplementary veiw.
  @param sectionController The section controller requesting this information.
  @param nibName           The name of the nib file.
  @param bundle            The bundle in which to search for the nib file. If `nil`, this method searches the main bundle.
  @param index             The index of the supplementary vew.
- 
+
  @return A supplementary view dequeued from the reuse pool or a newly created one.
- 
+
  @note This method uses a string representation of the view class as the identifier.
  */
 - (__kindof UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
@@ -238,6 +238,20 @@ NS_ASSUME_NONNULL_BEGIN
  synchronously, so you should make sure that your data source changes only when necessary.
  */
 - (void)performBatchAnimated:(BOOL)animated updates:(void (^)())updates completion:(nullable void (^)(BOOL finished))completion;
+
+
+/**
+ Scrolls to the specified section controller in the list.
+
+ @param sectionController The section controller.
+ @param index             The index of the item in the section controller to which to scroll.
+ @param scrollPosition    An option that specifies where the item should be positioned when scrolling finishes.
+ @param animated          A flag indicating if the scrolling should be animated.
+ */
+- (void)scrollToSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                          atIndex:(NSInteger)index
+                   scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                         animated:(BOOL)animated;
 
 @end
 

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -292,9 +292,9 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
                           atIndex:(NSInteger)index
                    scrollPosition:(UICollectionViewScrollPosition)scrollPosition
                          animated:(BOOL)animated {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSUInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     [self.collectionContext scrollToSectionController:self
-                                              atIndex:(offset + index)
+                                              atIndex:offsetIndex
                                        scrollPosition:scrollPosition
                                              animated:animated];
 }

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -288,6 +288,16 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
     }];
 }
 
+- (void)scrollToSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                          atIndex:(NSInteger)index
+                   scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+                         animated:(BOOL)animated {
+    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    [self.collectionContext scrollToSectionController:self
+                                              atIndex:(offset + index)
+                                       scrollPosition:scrollPosition
+                                             animated:animated];
+}
 
 #pragma mark - IGListDisplayDelegate
 

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -109,6 +109,11 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
     return index - offset;
 }
 
+- (NSInteger)relativeIndexForSectionController:(IGListSectionController<IGListSectionType> *)sectionController fromLocalIndex:(NSInteger)index {
+    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    return index + offset;
+}
+
 - (NSIndexSet *)itemIndexesForSectionController:(IGListSectionController<IGListSectionType> *)sectionController indexes:(NSIndexSet *)indexes {
     const NSUInteger offset = [self offsetForSectionController:sectionController];
     NSMutableIndexSet *itemIndexes = [[NSMutableIndexSet alloc] init];
@@ -161,8 +166,7 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
 }
 
 - (UICollectionViewCell *)cellForItemAtIndex:(NSInteger)index sectionController:(IGListSectionController<IGListSectionType> *)sectionController {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
-    return [self.collectionContext cellForItemAtIndex:(index + offset) sectionController:self];
+    return [self.collectionContext cellForItemAtIndex: [self relativeIndexForSectionController:sectionController fromLocalIndex:index] sectionController:self];
 }
 
 - (NSArray<UICollectionViewCell *> *)visibleCellsForSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
@@ -190,52 +194,52 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
 - (UICollectionViewCell *)dequeueReusableCellOfClass:(Class)cellClass
                                 forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                              atIndex:(NSInteger)index {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableCellOfClass:cellClass
                                                                          forSectionController:self
-                                                                                      atIndex:(index + offset)];
+                                                                                      atIndex:offsetIndex];
 }
 
 - (UICollectionViewCell *)dequeueReusableCellWithNibName:(NSString *)nibName
                                                   bundle:(NSBundle *)bundle
                                     forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                  atIndex:(NSInteger)index {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableCellWithNibName:nibName
                                                                                            bundle:bundle
                                                                              forSectionController:self
-                                                                                          atIndex:(index + offset)];
+                                                                                          atIndex:offsetIndex];
 }
 
 - (UICollectionViewCell *)dequeueReusableCellFromStoryboardWithIdentifier:(NSString *)identifier
                                                      forSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                                                   atIndex:(NSInteger)index {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableCellFromStoryboardWithIdentifier:identifier
                                                                                               forSectionController:self
-                                                                                                           atIndex:(index + offset)];
+                                                                                                           atIndex:offsetIndex];
 }
 
 - (UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
                                                 forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                                class:(Class)viewClass
                                                              atIndex:(NSInteger)index {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableSupplementaryViewOfKind:elementKind
                                                                                      forSectionController:self
                                                                                                     class:viewClass
-                                                                                                  atIndex:(index + offset)];
+                                                                                                  atIndex:offsetIndex];
 }
 
 - (UICollectionReusableView *)dequeueReusableSupplementaryViewFromStoryboardOfKind:(NSString *)elementKind
                                                                     withIdentifier:(NSString *)identifier
                                                               forSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                                                                            atIndex:(NSInteger)index {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableSupplementaryViewFromStoryboardOfKind:elementKind
                                                                                                          withIdentifier:identifier
                                                                                                    forSectionController:self
-                                                                                                                atIndex:(index + offset)];
+                                                                                                                atIndex:offsetIndex];
 }
 
 - (UICollectionReusableView *)dequeueReusableSupplementaryViewOfKind:(NSString *)elementKind
@@ -243,12 +247,12 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
                                                              nibName:(NSString *)nibName
                                                               bundle:(NSBundle *)bundle
                                                              atIndex:(NSInteger)index {
-    const NSUInteger offset = [self offsetForSectionController:sectionController];
+    const NSInteger offsetIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:index];
     return (UICollectionViewCell *_Nonnull)[self.collectionContext dequeueReusableSupplementaryViewOfKind:elementKind
                                                                                      forSectionController:self
                                                                                                   nibName:nibName
                                                                                                    bundle:bundle
-                                                                                                  atIndex:(index + offset)];
+                                                                                                  atIndex:offsetIndex];
 }
 
 - (void)reloadInSectionController:(IGListSectionController<IGListSectionType> *)sectionController atIndexes:(NSIndexSet *)indexes {

--- a/Source/Internal/IGListStackedSectionControllerInternal.h
+++ b/Source/Internal/IGListStackedSectionControllerInternal.h
@@ -20,7 +20,7 @@ IGListScrollDelegate
 
 @property (nonatomic, strong, readonly) NSOrderedSet<__kindof IGListSectionController<IGListSectionType> *> *sectionControllers;
 
-/// An array the length of the total number of items in the stack, pointing to an section controller for the item index.
+/// An array the length of the total number of items in the stack, pointing to a section controller for the item index.
 @property (nonatomic, copy) NSArray<IGListSectionController<IGListSectionType> *> *sectionControllersForItems;
 
 /// An array of index offsets for each item in the flattened stack.


### PR DESCRIPTION
## Changes in this pull request

Adds `relativeIndexForSectionController: fromLocalIndex:` method to add index to offset.
Refactors all `index + offset` to use the method.
Closes #272  

Should I add tests? I figured the current tests would cover this change.
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)

