### PR TITLE
Check for broken links in markdown files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 - set -o pipefail
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
-      find . -name "*.md" | markdown-link-check;
+      find . -name "*.md" -exec cat {} \; | markdown-link-check;
   fi
 
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
    - EXAMPLE_SCHEME="IGListKitExamples"
 
    matrix:
-   - DESTINATION="OS=8.1,name=iPhone 6" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" BUILD_EXAMPLE="YES" RUN_UI_TESTS="NO" POD_LINT="YES"
+   - DESTINATION="OS=8.1,name=iPhone 6" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" BUILD_EXAMPLE="YES" RUN_UI_TESTS="NO" POD_LINT="YES" CHECK_MARKDOWN="YES"
    - DESTINATION="OS=8.2,name=iPhone 6" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" BUILD_EXAMPLE="NO"  RUN_UI_TESTS="NO" POD_LINT="NO"
    - DESTINATION="OS=8.3,name=iPhone 6" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" BUILD_EXAMPLE="NO"  RUN_UI_TESTS="NO" POD_LINT="NO"
    - DESTINATION="OS=8.4,name=iPhone 6" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" BUILD_EXAMPLE="NO"  RUN_UI_TESTS="NO" POD_LINT="NO"
@@ -39,14 +39,18 @@ env:
 
 before_install:
   - gem install slather --no-rdoc --no-ri --no-document --quiet
+  - npm install -g markdown-link-check
 
 script:
 - set -o pipefail
 
+- if [ $CHECK_MARKDOWN == "YES" ]; then
+      find . -name "*.md" | markdown-link-check;
+  fi
+
 - if [ $POD_LINT == "YES" ]; then
       pod lib lint;
   fi
-
 
 - if [ $BUILD_EXAMPLE == "YES" ] && [ $SDK == $IOS_SDK ]; then
       xcodebuild build -workspace "$IOS_EXAMPLE_WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | xcpretty -c;
@@ -60,7 +64,6 @@ script:
 - if [ $BUILD_EXAMPLE == "YES" ] && [ $SDK == $TVOS_SDK ]; then
       xcodebuild build -workspace "$TVOS_EXAMPLE_WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | xcpretty -c;
   fi
-
 
 - if [ $RUN_TESTS == "YES" ]; then
       xcodebuild analyze test -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES ONLY_ACTIVE_ARCH=YES | xcpretty -c;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
       npm install -g markdown-link-check;
-      find . -name "*.md" -exec cat {} \; | markdown-link-check | echo ${PIPESTATUS[1]};
+      find . -name "*.md" -exec cat {} \; | markdown-link-check | exit ${PIPESTATUS[1]};
   fi
 
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
       npm install -g markdown-link-check;
-      find . -name "*.md" -exec cat {} \; | markdown-link-check;
+      find . -name "*.md" -exec cat {} \; | markdown-link-check | echo ${PIPESTATUS[1]};
   fi
 
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ env:
 
 before_install:
   - gem install slather --no-rdoc --no-ri --no-document --quiet
-  - npm install -g markdown-link-check
 
 script:
 - set -o pipefail
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
       echo -en 'travis_fold:start:script.1\\r';
+      npm install -g markdown-link-check;
       find . -name "*.md" -exec cat {} \; | markdown-link-check;
       echo -en 'travis_fold:end:script.1\\r';
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,8 @@ script:
 - set -o pipefail
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
-      echo -en 'travis_fold:start:script.1\\r';
       npm install -g markdown-link-check;
       find . -name "*.md" -exec cat {} \; | markdown-link-check;
-      echo -en 'travis_fold:end:script.1\\r';
   fi
 
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
       npm install -g markdown-link-check;
-      find . -name "*.md" -exec cat {} \; | markdown-link-check | exit ${PIPESTATUS[1]};
+      find . -name "*.md" -exec cat {} \; | markdown-link-check;
   fi
 
 - if [ $POD_LINT == "YES" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,9 @@ script:
 - set -o pipefail
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
+      echo -en 'travis_fold:start:script.1\\r';
       find . -name "*.md" -exec cat {} \; | markdown-link-check;
+      echo -en 'travis_fold:end:script.1\\r';
   fi
 
 - if [ $POD_LINT == "YES" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ You can find a [migration guide here](https://instagram.github.io/IGListKit/migr
 
 - Added new Guides: [Getting Started](https://instagram.github.io/IGListKit/getting-started.html), [Migration](https://instagram.github.io/IGListKit/migration.html)
 
-- Added examples for Today & iMessage extensions. [Sherlouk](https://github.com/Sherlouk) [(#112)](https://github.com/Instagram/IGListKit/pull/112)
+- Added examples for Today & iMessage extensions. [Sherlouk](https://github.com/Sherlouk) [(#112)](https://github.com/Instagram/IGListKit/pull/1122)
 
 - Added `tvOS` example pack. [Sherlouk](https://github.com/Sherlouk) [(#141)](https://github.com/Instagram/IGListKit/pull/141)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ You can find a [migration guide here](https://instagram.github.io/IGListKit/migr
 
 - Added new Guides: [Getting Started](https://instagram.github.io/IGListKit/getting-started.html), [Migration](https://instagram.github.io/IGListKit/migration.html)
 
-- Added examples for Today & iMessage extensions. [Sherlouk](https://github.com/Sherlouk) [(#112)](https://github.com/Instagram/IGListKit/pull/1122)
+- Added examples for Today & iMessage extensions. [Sherlouk](https://github.com/Sherlouk) [(#112)](https://github.com/Instagram/IGListKit/pull/112)
 
 - Added `tvOS` example pack. [Sherlouk](https://github.com/Sherlouk) [(#141)](https://github.com/Instagram/IGListKit/pull/141)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ You can find a [migration guide here](https://instagram.github.io/IGListKit/migr
 
 - Added support for cells created from nibs. [Sven Bacia](https://github.com/svenbacia) [(#56)](https://github.com/Instagram/IGListKit/pull/56)
 
-- Added an additional initializer for `IGListSingleSectionController` to be able to support single sections created from nibs. An example can be found [here](Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift). [(#56)](https://github.com/Instagram/IGListKit/pull/56)
+- Added an additional initializer for `IGListSingleSectionController` to be able to support single sections created from nibs. An example can be found [here](https://github.com/Instagram/IGListKit/tree/master/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift). [(#56)](https://github.com/Instagram/IGListKit/pull/56)
 
 ```objc
 - (instancetype)initWithNibName:(NSString *)nibName


### PR DESCRIPTION
## Changes in this pull request

- Install `markdown-link-check` as a dependency
- Check each markdown file for links, and check them using aforementioned library

Closes #312 

A few points of note, I'm not sure if we can use the built-in caching capabilities to cache the library (at the moment it's installed for each build, even though it's only used for 1 -- seems a big waste!). Also a downside of the library is it doesn't really like relative links, we only had one -- so I changed it to be absolute.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
