### PR TITLE
disables prefetchEnabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 This release closes the [2.1.0 milestone](https://github.com/Instagram/IGListKit/milestone/2).
 
+### Enhancements
+- Disables `prefetchEnabled` by default on `IGListCollectionView`. [Sven Bacia (#323)](https://github.com/Instagram/IGListKit/pull/323)
+
 2.0.0
 -----
 

--- a/Source/IGListCollectionView.m
+++ b/Source/IGListCollectionView.m
@@ -19,7 +19,20 @@
             self.backgroundColor = [UIColor whiteColor];
         }
         
+        if ([self respondsToSelector:@selector(setPrefetchingEnabled:)]) {
+            self.prefetchingEnabled = NO;
+        }
+        
         self.alwaysBounceVertical = YES;
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    if (self = [super initWithCoder:aDecoder]) {
+        if ([self respondsToSelector:@selector(setPrefetchingEnabled:)]) {
+            self.prefetchingEnabled = NO;
+        }
     }
     return self;
 }

--- a/Tests/IGListCollectionViewTests.m
+++ b/Tests/IGListCollectionViewTests.m
@@ -50,6 +50,24 @@ static const CGRect kIGListCollectionViewTestFrame = (CGRect){{0.0, 0.0}, {100.0
     IGListCollectionView *collectionView = [[IGListCollectionView alloc] initWithFrame: kIGListCollectionViewTestFrame collectionViewLayout:[UICollectionViewFlowLayout new]];
 
     XCTAssertTrue(collectionView.alwaysBounceVertical);
+    
+    if ([collectionView respondsToSelector:@selector(isPrefetchingEnabled)]) {
+        XCTAssertFalse(collectionView.isPrefetchingEnabled);
+    }
+}
+
+-(void)test_thatStoryboardIGListCollectionViewHasCorrectDefaults {
+    UIWindow *window = [[UIWindow alloc] initWithFrame:kIGListCollectionViewTestFrame];
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"IGTestStoryboard" bundle:[NSBundle bundleForClass:self.class]];
+    IGTestStoryboardViewController  *viewController = [storyboard instantiateViewControllerWithIdentifier:@"testVC"];
+    [window addSubview:viewController.view];
+    [viewController performSelectorOnMainThread:@selector(loadView) withObject:nil waitUntilDone:YES];
+    
+    XCTAssertFalse(viewController.collectionView.alwaysBounceVertical);
+    
+    if ([UICollectionView instancesRespondToSelector:@selector(isPrefetchingEnabled)]) {
+        XCTAssertFalse(viewController.collectionView.isPrefetchingEnabled);
+    }
 }
 
 -(void)test_whenUsingUIAppearance_thatStoryboardIGListCollectionViewUsesAppearanceBackgroundColor {


### PR DESCRIPTION
## Changes in this pull request
Disables `prefetchEnabled` by default on `IGListCollectionView` (#318).

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)