### PR TITLE
Prevent item reload, delete, insert collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 This release closes the [2.1.0 milestone](https://github.com/Instagram/IGListKit/milestone/2).
 
 ### Enhancements
+
 - Disables `prefetchEnabled` by default on `IGListCollectionView`. [Sven Bacia (#323)](https://github.com/Instagram/IGListKit/pull/323)
+
+### Fixes
+
+- Avoid `UICollectionView` crashes when queueing a reload and insert/delete on the same item as well as reloading an item in a section that is animating. [Ryan Nystrom](https://github.com/rnystrom) [(#325)](https://github.com/Instagram/IGListKit/pull/325)
 
 2.0.0
 -----

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1076,4 +1076,35 @@
     [self waitForExpectationsWithTimeout:15 handler:nil];
 }
 
+- (void)test_whenReloadingItems_withSectionInsertedInFront_thatUpdateCanBeApplied {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @1),
+                             genTestObject(@2, @5),
+                             genTestObject(@3, @1),
+                             ]];
+
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects[1]];
+
+    XCTestExpectation *expectation1 = genExpectation;
+    [section.collectionContext performBatchAnimated:NO updates:^{
+        [section.collectionContext reloadInSectionController:section atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 4)]];
+    } completion:^(BOOL finished) {
+        [expectation1 fulfill];
+    }];
+
+    self.dataSource.objects = @[
+                                genTestObject(@1, @1),
+                                genTestObject(@4, @1), // insert to shift object @2
+                                genTestObject(@2, @5),
+                                genTestObject(@3, @1),
+                                ];
+
+    XCTestExpectation *expectation2 = genExpectation;
+    [self.adapter performUpdatesAnimated:YES completion:^(BOOL finished) {
+        [expectation2 fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1055,4 +1055,25 @@
     [self waitForExpectationsWithTimeout:15 handler:nil];
 }
 
+- (void)test_whenReloadingItems_withDeleteAndInsertCollision_thatUpdateCanBeApplied {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @1),
+                             genTestObject(@2, @5),
+                             genTestObject(@3, @1),
+                             ]];
+
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects[1]];
+
+    XCTestExpectation *expectation = genExpectation;
+    [section.collectionContext performBatchAnimated:NO updates:^{
+        [section.collectionContext deleteInSectionController:section atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 2)]];
+        [section.collectionContext insertInSectionController:section atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 2)]];
+        [section.collectionContext reloadInSectionController:section atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 4)]];
+    } completion:^(BOOL finished) {
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1107,4 +1107,33 @@
     [self waitForExpectationsWithTimeout:15 handler:nil];
 }
 
+- (void)test_whenReloadingItems_withSectionDeletedInFront_thatUpdateCanBeApplied {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @1),
+                             genTestObject(@2, @5),
+                             genTestObject(@3, @1),
+                             ]];
+
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects[1]];
+
+    XCTestExpectation *expectation1 = genExpectation;
+    [section.collectionContext performBatchAnimated:NO updates:^{
+        [section.collectionContext reloadInSectionController:section atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(1, 4)]];
+    } completion:^(BOOL finished) {
+        [expectation1 fulfill];
+    }];
+
+    self.dataSource.objects = @[
+                                genTestObject(@2, @5),
+                                genTestObject(@3, @1),
+                                ];
+
+    XCTestExpectation *expectation2 = genExpectation;
+    [self.adapter performUpdatesAnimated:YES completion:^(BOOL finished) {
+        [expectation2 fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end


### PR DESCRIPTION
## Changes in this pull request

Adds a new test and fixes an item animation collision that `UICollectionView` throws on. Basically we cannot collide reloads with insert+delete. 

The example in the test is trivial, but real-world situations do appear b/c of the coalescence of `IGListAdapterUpdater`. It can queue reloads and deletes/inserts at the same index paths while waiting.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)

