### PR TITLE
Add incremental move reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 This release closes the [2.1.0 milestone](https://github.com/Instagram/IGListKit/milestone/2).
 
 ### Enhancements
-
 - Added support for macOS. Note: this is *only* for the Diffing components. There is **no support** for `IGListAdapter`, `IGListSectionController`, and other components at this time. [Guilherme Rambo](https://github.com/insidegui) [(#235)](https://github.com/Instagram/IGListKit/pull/235)
+
+- Added algorithm for generating incremental moves, which can be used to reorder a collection, and are required for moving rows with NSTableView. Available via `IGListDiffBehaviorIncrementalMoves` for `IGListDiffWithBehavior` and `IGListDiffPathsWithBehavior`. [Anton Sotkov](https://github.com/antons) [(#342)](https://github.com/Instagram/IGListKit/pull/342)
 
 - Added a [macOS example](https://github.com/Instagram/IGListKit/tree/master/Examples/Examples-macOS) project. [Guilherme Rambo](https://github.com/insidegui) [(#337)](https://github.com/Instagram/IGListKit/pull/337)
 

--- a/Source/Common/IGListDiff.h
+++ b/Source/Common/IGListDiff.h
@@ -34,7 +34,43 @@ typedef NS_ENUM(NSInteger, IGListDiffOption) {
  */
 typedef NS_OPTIONS(NSInteger, IGListDiffBehavior) {
     IGListDiffBehaviorDefault = 0,
+    /**
+     When used, moves are reported incrementally. Can be used to reorder a collection. O(n^2) complexity.
+     
+     By default, moves are reported with old and new positions. O(n) complexity.
+     */
+    IGListDiffBehaviorIncrementalMoves = 1 << 0
 };
+
+/**
+ Creates a diff using indexes between two collections.
+
+ @param oldArray The old objects to diff against.
+ @param newArray The new objects.
+ @param option   An option on how to compare objects.
+
+ @return A result object containing affected indexes.
+ */
+FOUNDATION_EXTERN IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable>> *_Nullable oldArray,
+                                                   NSArray<id<IGListDiffable>> *_Nullable newArray,
+                                                   IGListDiffOption option);
+
+/**
+ Creates a diff using index paths between two collections.
+
+ @param fromSection The old section.
+ @param toSection   The new section.
+ @param oldArray    The old objects to diff against.
+ @param newArray    The new objects.
+ @param option      An option on how to compare objects.
+
+ @return A result object containing affected indexes.
+ */
+FOUNDATION_EXTERN IGListIndexPathResult *IGListDiffPaths(NSInteger fromSection,
+                                                         NSInteger toSection,
+                                                         NSArray<id<IGListDiffable>> *_Nullable oldArray,
+                                                         NSArray<id<IGListDiffable>> *_Nullable newArray,
+                                                         IGListDiffOption option);
 
 /**
  Creates a diff using indexes between two collections.
@@ -69,35 +105,5 @@ FOUNDATION_EXTERN IGListIndexPathResult *IGListDiffPathsWithBehavior(NSInteger f
                                                                      NSArray<id<IGListDiffable>> *_Nullable newArray,
                                                                      IGListDiffOption option,
                                                                      IGListDiffBehavior behavior);
-
-/**
- Creates a diff using indexes between two collections.
-
- @param oldArray The old objects to diff against.
- @param newArray The new objects.
- @param option   An option on how to compare objects.
-
- @return A result object containing affected indexes.
- */
-FOUNDATION_EXTERN IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable>> *_Nullable oldArray,
-                                                   NSArray<id<IGListDiffable>> *_Nullable newArray,
-                                                   IGListDiffOption option);
-
-/**
- Creates a diff using index paths between two collections.
-
- @param fromSection The old section.
- @param toSection   The new section.
- @param oldArray    The old objects to diff against.
- @param newArray    The new objects.
- @param option      An option on how to compare objects.
-
- @return A result object containing affected indexes.
- */
-FOUNDATION_EXTERN IGListIndexPathResult *IGListDiffPaths(NSInteger fromSection,
-                                                         NSInteger toSection,
-                                                         NSArray<id<IGListDiffable>> *_Nullable oldArray,
-                                                         NSArray<id<IGListDiffable>> *_Nullable newArray,
-                                                         IGListDiffOption option);
 
 NS_ASSUME_NONNULL_END

--- a/Source/Common/IGListDiff.h
+++ b/Source/Common/IGListDiff.h
@@ -30,6 +30,47 @@ typedef NS_ENUM(NSInteger, IGListDiffOption) {
 };
 
 /**
+ Comparison behavior options.
+ */
+typedef NS_OPTIONS(NSInteger, IGListDiffBehavior) {
+    IGListDiffBehaviorDefault = 0,
+};
+
+/**
+ Creates a diff using indexes between two collections.
+
+ @param oldArray The old objects to diff against.
+ @param newArray The new objects.
+ @param option   An option on how to compare objects.
+ @param behavior Comparison behaviors.
+
+ @return A result object containing affected indexes.
+ */
+FOUNDATION_EXTERN IGListIndexSetResult *IGListDiffWithBehavior(NSArray<id<IGListDiffable>> *_Nullable oldArray,
+                                                               NSArray<id<IGListDiffable>> *_Nullable newArray,
+                                                               IGListDiffOption option,
+                                                               IGListDiffBehavior behavior);
+
+/**
+ Creates a diff using index paths between two collections.
+
+ @param fromSection The old section.
+ @param toSection   The new section.
+ @param oldArray    The old objects to diff against.
+ @param newArray    The new objects.
+ @param option      An option on how to compare objects.
+ @param behavior    Comparison behaviors.
+
+ @return A result object containing affected indexes.
+ */
+FOUNDATION_EXTERN IGListIndexPathResult *IGListDiffPathsWithBehavior(NSInteger fromSection,
+                                                                     NSInteger toSection,
+                                                                     NSArray<id<IGListDiffable>> *_Nullable oldArray,
+                                                                     NSArray<id<IGListDiffable>> *_Nullable newArray,
+                                                                     IGListDiffOption option,
+                                                                     IGListDiffBehavior behavior);
+
+/**
  Creates a diff using indexes between two collections.
 
  @param oldArray The old objects to diff against.

--- a/Source/Common/IGListDiff.mm
+++ b/Source/Common/IGListDiff.mm
@@ -78,6 +78,7 @@ static id IGListDiffing(BOOL returnIndexPaths,
                         NSArray<id<IGListDiffable>> *oldArray,
                         NSArray<id<IGListDiffable>> *newArray,
                         IGListDiffOption option,
+                        IGListDiffBehavior behavior,
                         IGListExperiment experiments) {
     const NSInteger newCount = newArray.count;
     const NSInteger oldCount = oldArray.count;
@@ -277,7 +278,7 @@ static id IGListDiffing(BOOL returnIndexPaths,
 IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable> > *oldArray,
                                  NSArray<id<IGListDiffable>> *newArray,
                                  IGListDiffOption option) {
-    return IGListDiffing(NO, 0, 0, oldArray, newArray, option, 0);
+    return IGListDiffing(NO, 0, 0, oldArray, newArray, option, IGListDiffBehaviorDefault, 0);
 }
 
 IGListIndexPathResult *IGListDiffPaths(NSInteger fromSection,
@@ -285,14 +286,31 @@ IGListIndexPathResult *IGListDiffPaths(NSInteger fromSection,
                                        NSArray<id<IGListDiffable>> *oldArray,
                                        NSArray<id<IGListDiffable>> *newArray,
                                        IGListDiffOption option) {
-    return IGListDiffing(YES, fromSection, toSection, oldArray, newArray, option, 0);
+    return IGListDiffing(YES, fromSection, toSection, oldArray, newArray, option, IGListDiffBehaviorDefault, 0);
+}
+
+
+IGListIndexSetResult *IGListDiffWithBehavior(NSArray<id<IGListDiffable> > *oldArray,
+                                             NSArray<id<IGListDiffable>> *newArray,
+                                             IGListDiffOption option,
+                                             IGListDiffBehavior behavior) {
+    return IGListDiffing(NO, 0, 0, oldArray, newArray, option, behavior, 0);
+}
+
+IGListIndexPathResult *IGListDiffPathsWithBehavior(NSInteger fromSection,
+                                                   NSInteger toSection,
+                                                   NSArray<id<IGListDiffable>> *oldArray,
+                                                   NSArray<id<IGListDiffable>> *newArray,
+                                                   IGListDiffOption option,
+                                                   IGListDiffBehavior behavior) {
+    return IGListDiffing(YES, fromSection, toSection, oldArray, newArray, option, behavior, 0);
 }
 
 IGListIndexSetResult *IGListDiffExperiment(NSArray<id<IGListDiffable>> *_Nullable oldArray,
                                            NSArray<id<IGListDiffable>> *_Nullable newArray,
                                            IGListDiffOption option,
                                            IGListExperiment experiments) {
-    return IGListDiffing(NO, 0, 0, oldArray, newArray, option, experiments);
+    return IGListDiffing(NO, 0, 0, oldArray, newArray, option, IGListDiffBehaviorDefault, experiments);
 }
 
 IGListIndexPathResult *IGListDiffPathsExperiment(NSInteger fromSection,
@@ -301,5 +319,5 @@ IGListIndexPathResult *IGListDiffPathsExperiment(NSInteger fromSection,
                                                  NSArray<id<IGListDiffable>> *_Nullable newArray,
                                                  IGListDiffOption option,
                                                  IGListExperiment experiments) {
-    return IGListDiffing(YES, fromSection, toSection, oldArray, newArray, option, experiments);
+    return IGListDiffing(YES, fromSection, toSection, oldArray, newArray, option, IGListDiffBehaviorDefault, experiments);
 }

--- a/Source/Common/IGListDiff.mm
+++ b/Source/Common/IGListDiff.mm
@@ -80,6 +80,8 @@ static id IGListDiffing(BOOL returnIndexPaths,
                         IGListDiffOption option,
                         IGListDiffBehavior behavior,
                         IGListExperiment experiments) {
+    const BOOL incrementalMoves = (behavior & IGListDiffBehaviorIncrementalMoves) != 0;
+
     const NSInteger newCount = newArray.count;
     const NSInteger oldCount = oldArray.count;
 
@@ -136,17 +138,17 @@ static id IGListDiffing(BOOL returnIndexPaths,
             const id<IGListDiffable> o = oldArray[originalIndex];
             switch (option) {
                 case IGListDiffPointerPersonality:
-                    // flag the entry as updated if the pointers are not the same
-                    if (n != o) {
-                        entry->updated = YES;
-                    }
+                // flag the entry as updated if the pointers are not the same
+                if (n != o) {
+                    entry->updated = YES;
+                }
                     break;
                 case IGListDiffEquality:
-                    // use -[IGListDiffable isEqualToDiffableObject:] between both version of data to see if anything has changed
-                    // skip the equality check if both indexes point to the same object
-                    if (n != o && ![n isEqualToDiffableObject:o]) {
-                        entry->updated = YES;
-                    }
+                // use -[IGListDiffable isEqualToDiffableObject:] between both version of data to see if anything has changed
+                // skip the equality check if both indexes point to the same object
+                if (n != o && ![n isEqualToDiffableObject:o]) {
+                    entry->updated = YES;
+                }
                     break;
             }
         }
@@ -199,8 +201,20 @@ static id IGListDiffing(BOOL returnIndexPaths,
         [map setObject:value forKey:[array[index] diffIdentifier]];
     };
 
+    void (^addMoveFromIndexToIndex)(NSInteger, NSInteger) = ^(NSInteger fromIndex, NSInteger toIndex) {
+        id move;
+        if (returnIndexPaths) {
+            NSIndexPath *from = [NSIndexPath indexPathForItem:fromIndex inSection:fromSection];
+            NSIndexPath *to = [NSIndexPath indexPathForItem:toIndex inSection:toSection];
+            move = [[IGListMoveIndexPath alloc] initWithFrom:from to:to];
+        } else {
+            move = [[IGListMoveIndex alloc] initWithFrom:fromIndex to:toIndex];
+        }
+        [mMoves addObject:move];
+    };
+
     // track offsets from deleted items to calculate where items have moved
-    vector<NSInteger> deleteOffsets(oldCount), insertOffsets(newCount);
+    vector<NSInteger> deleteOffsets(oldCount), insertOffsets(newCount), oldInsertOffsets(oldCount), moveOffsets(newCount);
     NSInteger runningOffset = 0;
 
     // iterate old array records checking for deletes
@@ -225,7 +239,7 @@ static id IGListDiffing(BOOL returnIndexPaths,
         const IGListRecord record = newResultsArray[i];
         const NSInteger oldIndex = record.index;
         // add to inserts if the opposing index is NSNotFound
-        if (record.index == NSNotFound) {
+        if (oldIndex == NSNotFound) {
             addIndexToCollection(mInserts, toSection, i);
             runningOffset++;
         } else {
@@ -233,25 +247,61 @@ static id IGListDiffing(BOOL returnIndexPaths,
             if (record.entry->updated) {
                 addIndexToCollection(mUpdates, fromSection, oldIndex);
             }
-
             // calculate the offset and determine if there was a move
             // if the indexes match, ignore the index
             const NSInteger insertOffset = insertOffsets[i];
             const NSInteger deleteOffset = deleteOffsets[oldIndex];
-            if ((oldIndex - deleteOffset + insertOffset) != i) {
-                id move;
-                if (returnIndexPaths) {
-                    NSIndexPath *from = [NSIndexPath indexPathForItem:oldIndex inSection:fromSection];
-                    NSIndexPath *to = [NSIndexPath indexPathForItem:i inSection:toSection];
-                    move = [[IGListMoveIndexPath alloc] initWithFrom:from to:to];
-                } else {
-                    move = [[IGListMoveIndex alloc] initWithFrom:oldIndex to:i];
+            if (incrementalMoves) {
+                oldInsertOffsets[i + deleteOffset - insertOffset] = runningOffset;
+            } else {
+                if ((oldIndex - deleteOffset + insertOffset) != i) {
+                    addMoveFromIndexToIndex(oldIndex, i);
                 }
-                [mMoves addObject:move];
             }
         }
 
         addIndexToMap(toSection, i, newArray, newMap);
+    }
+
+    if (incrementalMoves) {
+        for (NSInteger i = 0; i < newCount; i++) {
+            const IGListRecord record = newResultsArray[i];
+            const NSInteger oldIndex = record.index;
+            // calculate the offset and determine if there was a move
+            // if the indexes match, ignore the index
+            const NSInteger insertOffset = oldIndex == NSNotFound ? 0 : oldInsertOffsets[oldIndex];
+            const NSInteger deleteOffset = oldIndex == NSNotFound ? 0 : deleteOffsets[oldIndex];
+            // initial index is array state after applying deletes and insertions
+            const NSInteger initialIndex = oldIndex == NSNotFound ? i : oldIndex - deleteOffset + insertOffset;
+            const NSInteger currentIndex = initialIndex + moveOffsets[initialIndex];
+            const NSInteger deltaToFinalIndex = i - currentIndex;
+            // process moves only if delta < 0
+            // this is simpler, but results in less optimal moves
+            //  0  1  2  3 old
+            // +3 -1 -1 -1 moveOffsets
+            //  1  2  3  0 new
+            // is currently reported as 3 moves
+            // ideally it would be reported as one move
+            if (deltaToFinalIndex < 0) {
+                addMoveFromIndexToIndex(currentIndex, i);
+                // array state at the current step, key is current index, value initial index
+                vector<NSInteger> currentIndexes(newCount);
+                for (NSInteger k = 0; k < newCount; k++) {
+                    currentIndexes[k + moveOffsets[k]] = k;
+                }
+                // update move offsets for moves
+                //  0  1  2 old
+                // +1 +1 -2 moveOffsets
+                //  2  0  1 new
+                // +2 ±0 -2 moveOffsets
+                //  2  1  0 final
+                for (NSInteger j = currentIndex + deltaToFinalIndex; j < currentIndex; j++) {
+                    const NSInteger initialIndexToShift = currentIndexes[j];
+                    moveOffsets[initialIndexToShift] += 1;
+                    moveOffsets[initialIndex] -= 1;
+                }
+            }
+        }
     }
 
     NSCAssert((oldCount + [mInserts count] - [mDeletes count]) == newCount,


### PR DESCRIPTION
## Changes in this pull request

Added incremental move reporting, as mentioned in #337. Diffs with incremental moves are necessary for NSTableView, and can be used to apply changes to collections.

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)