### PR TITLE
Print file name when searching for broken links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,10 @@ script:
 
 - if [ $CHECK_MARKDOWN == "YES" ]; then
       npm install -g markdown-link-check;
-      find . -name "*.md" -exec cat {} \; | markdown-link-check;
+      find . -name "*.md" | while read filename; do
+        echo "Searching $filename"
+        cat "$filename" | markdown-link-check
+      done
   fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,8 @@ script:
 - if [ $CHECK_MARKDOWN == "YES" ]; then
       npm install -g markdown-link-check;
       find . -name "*.md" | while read filename; do
-        echo "Searching $filename"
-        cat "$filename" | markdown-link-check
+        echo "Searching $filename";
+        cat "$filename" | markdown-link-check;
       done
   fi
 


### PR DESCRIPTION
## Changes in this pull request

Wasn't sure how to make it a one line wonder, so probably could be improved -- but slapped it into a while loops and print name before triggering the `markdown-link-check`.

Refers to https://github.com/Instagram/IGListKit/pull/344#issuecomment-268163911

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
