### PR TITLE
Add stacked section controller demo

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		29C629831DCFDB57004A5BB1 /* UserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C629821DCFDB57004A5BB1 /* UserHeaderView.swift */; };
 		29D2E4AD1DD69B6000CD255D /* DisplaySectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D2E4AC1DD69B6000CD255D /* DisplaySectionController.swift */; };
 		29D2E4AF1DD69C0E00CD255D /* DisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D2E4AE1DD69C0E00CD255D /* DisplayViewController.swift */; };
+		29D873561E0C539700A6BA95 /* StackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D873551E0C539700A6BA95 /* StackedViewController.swift */; };
 		696C69AF297B6455C862314F /* Pods_IGListKitTodayExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D64E902433068998DDE711FB /* Pods_IGListKitTodayExample.framework */; };
 		75B39B8327726E4F6AA04B13 /* Pods_IGListKitMessageExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60AF908234A48B4187E68DAB /* Pods_IGListKitMessageExample.framework */; };
 		814F1E00410200822610BB49 /* Pods_IGListKitExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A8DC2D07A93D7AA55BC993 /* Pods_IGListKitExamples.framework */; };
@@ -170,6 +171,7 @@
 		29C629821DCFDB57004A5BB1 /* UserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserHeaderView.swift; sourceTree = "<group>"; };
 		29D2E4AC1DD69B6000CD255D /* DisplaySectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplaySectionController.swift; sourceTree = "<group>"; };
 		29D2E4AE1DD69C0E00CD255D /* DisplayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayViewController.swift; sourceTree = "<group>"; };
+		29D873551E0C539700A6BA95 /* StackedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StackedViewController.swift; sourceTree = "<group>"; };
 		4125DCD99578FDEF3C373BA0 /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitExamples.release.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitExamples/Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
 		45D6CC137030027019AE64D8 /* Pods-IGListKitTodayExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitTodayExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitTodayExample/Pods-IGListKitTodayExample.debug.xcconfig"; sourceTree = "<group>"; };
 		52A8DC2D07A93D7AA55BC993 /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IGListKitExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -327,6 +329,7 @@
 				296DD7521DD2147500206780 /* SelfSizingCellsViewController.swift */,
 				82D91B681DBA0EF300E62758 /* SingleSectionStoryboardViewController.swift */,
 				26271C8D1DAE9D3F0073E116 /* SingleSectionViewController.swift */,
+				29D873551E0C539700A6BA95 /* StackedViewController.swift */,
 				821BC4B51DB8B3DC00172ED0 /* StoryboardViewController.swift */,
 				29C6297A1DCFD857004A5BB1 /* SupplementaryViewController.swift */,
 				2981BA381DB874BB00A987F9 /* WorkingRangeViewController.swift */,
@@ -732,6 +735,7 @@
 				2981BA351DB868A500A987F9 /* ImageCell.swift in Sources */,
 				2942FF931D9F39E00015D24B /* SearchSectionController.swift in Sources */,
 				297546FA1DD25384002A6F89 /* FullWidthSelfSizingCell.swift in Sources */,
+				29D873561E0C539700A6BA95 /* StackedViewController.swift in Sources */,
 				82D91B691DBA0EF300E62758 /* SingleSectionStoryboardViewController.swift in Sources */,
 				29D2E4AF1DD69C0E00CD255D /* DisplayViewController.swift in Sources */,
 				2942FF911D9F39E00015D24B /* LabelSectionController.swift in Sources */,

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
@@ -43,7 +43,7 @@ final class ExpandableSectionController: IGListSectionController, IGListSectionT
 
     func didSelectItem(at index: Int) {
         expanded = !expanded
-        collectionContext?.reload(self)
+        collectionContext?.reload(in: self, at: IndexSet(integer: 0))
     }
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -36,6 +36,7 @@ final class DemosViewController: UIViewController, IGListAdapterDataSource {
         DemoItem(name: "Supplementary Views", controllerClass: SupplementaryViewController.self),
         DemoItem(name: "Self-sizing cells", controllerClass: SelfSizingCellsViewController.self),
         DemoItem(name: "Display delegate", controllerClass: DisplayViewController.self),
+        DemoItem(name: "Stacked Section Controllers", controllerClass: StackedViewController.self),
     ]
 
     override func viewDidLoad() {

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
@@ -1,0 +1,58 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+ The examples provided by Facebook are for non-commercial testing and evaluation
+ purposes only. Facebook reserves all rights not expressly granted.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+import IGListKit
+
+final class StackedViewController: UIViewController, IGListAdapterDataSource {
+
+    lazy var adapter: IGListAdapter = {
+        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 1)
+    }()
+    let collectionView = IGListCollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+
+    let data = [128, 256, 64]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        collectionView.backgroundColor = UIColor(white: 0.95, alpha: 1)
+        view.addSubview(collectionView)
+        adapter.collectionView = collectionView
+        adapter.dataSource = self
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        collectionView.frame = view.bounds
+    }
+
+    // MARK: IGListAdapterDataSource
+
+    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+        return data as [IGListDiffable]
+    }
+
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+        let sectionController = IGListStackedSectionController(sectionControllers: [
+            WorkingRangeSectionController(),
+            DisplaySectionController(),
+            HorizontalSectionController(),
+            ])!
+        sectionController.inset = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
+        return sectionController
+    }
+
+    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+
+}

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
@@ -44,6 +44,7 @@ final class StackedViewController: UIViewController, IGListAdapterDataSource {
     }
 
     func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+        // note that each child section controller is designed to handle an Int (or no data)
         let sectionController = IGListStackedSectionController(sectionControllers: [
             WorkingRangeSectionController(),
             DisplaySectionController(),

--- a/Examples/Examples-iOS/IGListKitExamples/Views/LabelCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/LabelCell.swift
@@ -31,21 +31,30 @@ class LabelCell: UICollectionViewCell {
         return ceil(bounds.height) + insets.top + insets.bottom
     }
 
-    lazy var label: UILabel = {
+    let label: UILabel = {
         let label = UILabel()
         label.backgroundColor = .clear
         label.numberOfLines = 1
         label.font = LabelCell.font
-        self.contentView.addSubview(label)
         return label
     }()
 
-    lazy var separator: CALayer = {
+    let separator: CALayer = {
         let layer = CALayer()
         layer.backgroundColor = UIColor(red: 200/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1).cgColor
-        self.contentView.layer.addSublayer(layer)
         return layer
     }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(label)
+        contentView.layer.addSublayer(separator)
+        contentView.backgroundColor = .white
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func layoutSubviews() {
         super.layoutSubviews()


### PR DESCRIPTION
## Changes in this pull request

Adding a pretty basic stacked demo. 3 different sections, each with 3 child section controllers that handle an `Int` data.

Requires #354 to be fully functional (working range).

Closes #134

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
