### PR TITLE
Fix stacked section controller OOB when cell ends display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This release closes the [2.1.0 milestone](https://github.com/Instagram/IGListKit
 
 - Prevent adapter data source from deallocating after queueing an update. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
 
-- Fix OOB bug when child section controllers in a stack remove cells. [Ryan Nystrom](https://github.com/rnystrom) [(#358)](https://github.com/Instagram/IGListKit/pull/358)
+- Fix out-of-bounds bug when child section controllers in a stack remove cells. [Ryan Nystrom](https://github.com/rnystrom) [(#358)](https://github.com/Instagram/IGListKit/pull/358)
 
 2.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This release closes the [2.1.0 milestone](https://github.com/Instagram/IGListKit
 
 - Prevent adapter data source from deallocating after queueing an update. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
 
+- Fix OOB bug when child section controllers in a stack remove cells. [Ryan Nystrom](https://github.com/rnystrom) [(#358)](https://github.com/Instagram/IGListKit/pull/358)
+
 2.0.0
 -----
 

--- a/Tests/IGListStackSectionControllerTests.m
+++ b/Tests/IGListStackSectionControllerTests.m
@@ -702,4 +702,27 @@ static const CGRect kStackTestFrame = (CGRect){{0.0, 0.0}, {100.0, 100.0}};
     XCTAssertFalse([[self.collectionView cellForItemAtIndexPath:path] isSelected]);
 }
 
+- (void)test_whenRemovingCellsFromChild_thatStackSendsDisplayEventsCorrectly {
+    IGTestObject *object = [[IGTestObject alloc] initWithKey:@0 value:@[@1, @2]];
+    [self setupWithObjects:@[object]];
+
+    IGListStackedSectionController *stack = [self.adapter sectionControllerForObject:object];
+    IGListTestSection *section = stack.sectionControllers.lastObject;
+
+    XCTAssertEqual([self.collectionView numberOfSections], 1);
+    XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 3);
+
+    XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        section.items = 1;
+        [section.collectionContext deleteInSectionController:section atIndexes:[NSIndexSet indexSetWithIndex:1]];
+    } completion:^(BOOL finished) {
+        XCTAssertEqual([self.collectionView numberOfSections], 1);
+        XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 2);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end


### PR DESCRIPTION
## Changes in this pull request

Fixes bug reported internally. When items are removed dynamically the stack internal store will attempt to access data that has already been removed. Instead use assoc objects.

We did change `IGListAdapter` to [use a map](https://github.com/Instagram/IGListKit/blob/master/Source/IGListAdapter.m#L681) instead of assoc objects. That could be a good cleanup.

cc @cdoncarroll

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
