### PR TITLE
fix(385): Fixed a typo previuossectionMap -> previousSectionMap

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -266,12 +266,12 @@
                                      objectTransitionBlock:^(NSArray *toObjects) {
                                          // temporarily capture the item map that we are transitioning from in case
                                          // there are any item deletes at the same
-                                         weakSelf.previoussectionMap = [weakSelf.sectionMap copy];
+                                         weakSelf.previousSectionMap = [weakSelf.sectionMap copy];
 
                                          [weakSelf updateObjects:toObjects dataSource:dataSource];
                                      } completion:^(BOOL finished) {
                                          // release the previous items
-                                         weakSelf.previoussectionMap = nil;
+                                         weakSelf.previousSectionMap = nil;
 
                                          if (completion) {
                                              completion(finished);
@@ -521,8 +521,8 @@
 
 - (IGListSectionMap *)sectionMapAdjustForUpdateBlock:(BOOL)adjustForUpdateBlock {
     // if we are inside an update block, we may have to use the /previous/ item map for some operations
-    if (adjustForUpdateBlock && self.isInUpdateBlock && self.previoussectionMap != nil) {
-        return self.previoussectionMap;
+    if (adjustForUpdateBlock && self.isInUpdateBlock && self.previousSectionMap != nil) {
+        return self.previousSectionMap;
     } else {
         return self.sectionMap;
     }

--- a/Source/Internal/IGListAdapterInternal.h
+++ b/Source/Internal/IGListAdapterInternal.h
@@ -52,7 +52,7 @@ IGListCollectionContext
  objects or section controllers.
  */
 @property (nonatomic, assign) BOOL isInUpdateBlock;
-@property (nonatomic, strong, nullable) IGListSectionMap *previoussectionMap;
+@property (nonatomic, strong, nullable) IGListSectionMap *previousSectionMap;
 
 @property (nonatomic, strong) NSMutableSet<Class> *registeredCellClasses;
 @property (nonatomic, strong) NSMutableSet<NSString *> *registeredNibNames;


### PR DESCRIPTION
## Changes in this pull request

I have fixed the typo in the code `previuossectionMap` -> `previousSectionMap`. I don't think this change requires to be tested as it appears to be an internal class. Because of this it's not a breaking change so I don't think it needs to be reflected in CHANGELOG.md either.

Closes #385 

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)