### PR TITLE
Fix possible retain cycle during update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This release closes the [2.2.0 milestone](https://github.com/Instagram/IGListKit
 
 - Fix bug where emptyView's hidden status is not updated after the number of items is changed with `insertInSectionController:atIndexes:` or related methods. [Peter Edmonston](https://github.com/edmonston) [(#395)](https://github.com/Instagram/IGListKit/pull/395)
 
+- Fixes a possible retain cycle when the data source is deallocated after queueing an update. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
+
 2.1.0
 -----
 

--- a/IGListKit.xcodeproj/xcshareddata/xcschemes/IGListKit.xcscheme
+++ b/IGListKit.xcodeproj/xcshareddata/xcschemes/IGListKit.xcscheme
@@ -50,6 +50,11 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction

--- a/Source/IGListUpdatingDelegate.h
+++ b/Source/IGListUpdatingDelegate.h
@@ -24,8 +24,10 @@ typedef void (^IGListUpdatingCompletion)(BOOL finished);
  A block to be called when the adapter applies changes to the collection view.
 
  @param toObjects The new objects in the collection.
+
+ @return A flag indicating if the transition was applied.
  */
-typedef void (^IGListObjectTransitionBlock)(NSArray *toObjects);
+typedef BOOL (^IGListObjectTransitionBlock)(NSArray *toObjects);
 
 /// A block that contains all of the updates.
 typedef void (^IGListItemUpdateBlock)();

--- a/Tests/IGListAdapterUpdaterTests.m
+++ b/Tests/IGListAdapterUpdaterTests.m
@@ -45,6 +45,7 @@
     __weak __typeof__(self) weakSelf = self;
     self.updateBlock = ^(NSArray *obj) {
         weakSelf.dataSource.sections = obj;
+        return YES;
     };
 }
 
@@ -268,6 +269,8 @@
         preUpdateBlock();
 
         self.dataSource.sections = toObjects;
+
+        return YES;
     } completion:^(BOOL finished) {
         completionCounter++;
         XCTAssertEqual(completionCounter, 1);
@@ -299,6 +302,7 @@
                                          animated:YES objectTransitionBlock:^(NSArray * toObjects) {
                                              self.dataSource.sections = toObjects;
                                              sectionUpdateBlockExecuted = YES;
+                                             return YES;
                                          }
                                        completion:nil];
 

--- a/Tests/Objects/IGTestDelegateDataSource.h
+++ b/Tests/Objects/IGTestDelegateDataSource.h
@@ -20,4 +20,6 @@
 
 @property (nonatomic, copy) void (^cellConfigureBlock)(IGTestDelegateController *);
 
+@property (nonatomic, strong) IGListAdapter *adapter;
+
 @end


### PR DESCRIPTION
## Changes in this pull request

Fixes a retain cycle introduced in 4cc91a25c8b262953e4f2d8e5dc78ee15c6265b2 when a data source is deallocated after queuing an update. The cycle happens when:

- An object holding a strong ref to an `IGListAdapter` is also the data source
- The object is deallocated after calling `performUpdatesAnimated:completion:`

A strong ref to the `dataSource` (e.g. the object w/ a strong ref to the adapter) is captured in the [objectTransitionBlock](https://github.com/Instagram/IGListKit/blob/master/Source/IGListAdapter.m#L271). The adapter holds a strong ref to the updater, which stores the block with a [strong ref](https://github.com/Instagram/IGListKit/blob/master/Source/Internal/IGListAdapterUpdaterInternal.h#L38).

The cycle [is broken](https://github.com/Instagram/IGListKit/blob/master/Source/IGListAdapterUpdater.m#L312) as soon as the update is performed, but if the data source is deallocated, we might never get here.

I'm not totally crazy about this fix as it complicates the API as its only the least invasive. However we have to bail the update if the data source is deallocated since we can't get the correct state or section controllers. Otherwise the `UICollectionView` will throw (what 4cc91a25c8b262953e4f2d8e5dc78ee15c6265b2 intended to fix).

This diff breaks the cycle by removing the [strongly held data source in the block](https://github.com/Instagram/IGListKit/blob/master/Source/IGListAdapter.m#L271).

Found w/ our retain cycle detector, flagged in tasks t15355965, t15271777, t15271776

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
