### PR TITLE
didDeselect for IGListAdapter and IGListSingleSectionControllerDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
                         withObject:(id)object;
 ```
 
+- Added `didDeselectItemAtIndex` delegate call in `IGListSectionType` and `didDeselect` delegate call in `IGListSingleSectionControllerDelegate`. [Daniel Rhodes](https://github.com/danielrhodes) [(#411)](https://github.com/Instagram/IGListKit/pull/411)
+
 2.2.0
 -----
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -80,5 +80,7 @@ final class DemoSectionController: IGListSectionController, IGListSectionType {
             viewController?.navigationController?.pushViewController(controller, animated: true)
         }
     }
+  
+    func didDeselectItem(at index: Int) { }
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
@@ -41,6 +41,8 @@ class DisplaySectionController: IGListSectionController, IGListSectionType, IGLi
     func didUpdate(to object: Any) {}
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
     // MARK: IGListDisplayDelegate
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/EmbeddedSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/EmbeddedSectionController.swift
@@ -46,5 +46,7 @@ final class EmbeddedSectionController: IGListSectionController, IGListSectionTyp
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
@@ -45,5 +45,7 @@ final class ExpandableSectionController: IGListSectionController, IGListSectionT
         expanded = !expanded
         collectionContext?.reload(in: self, at: IndexSet(integer: 0))
     }
+  
+    func didDeselectItem(at index: Int) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
@@ -44,6 +44,8 @@ final class FeedItemSectionController: IGListSectionController, IGListSectionTyp
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
     // MARK: IGListSupplementaryViewSource
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
@@ -71,5 +71,7 @@ final class GridSectionController: IGListSectionController, IGListSectionType {
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
@@ -47,6 +47,8 @@ final class HorizontalSectionController: IGListSectionController, IGListSectionT
 
     func didSelectItem(at index: Int) {}
 
+    func didDeselectItem(at index: Int) {}
+  
     //MARK: IGListAdapterDataSource
 
     func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
@@ -16,6 +16,11 @@ import UIKit
 import IGListKit
 
 final class LabelSectionController: IGListSectionController, IGListSectionType {
+  /**
+   Tells the section that the cell at the specified index path was deselected.
+   @param index The index of the selected cell.
+   */
+
 
     var object: String?
 
@@ -38,5 +43,7 @@ final class LabelSectionController: IGListSectionController, IGListSectionType {
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/RemoveSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/RemoveSectionController.swift
@@ -48,6 +48,8 @@ final class RemoveSectionController: IGListSectionController, IGListSectionType,
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
     //MARK: RemoveCellDelegate
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
@@ -43,6 +43,7 @@ final class SearchSectionController: IGListSectionController, IGListSectionType,
 
     func didUpdate(to object: Any) {}
     func didSelectItem(at index: Int) {}
+    func didDeselectItem(at index: Int) {}
 
     //MARK: UISearchBarDelegate
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SelfSizingSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SelfSizingSectionController.swift
@@ -59,5 +59,7 @@ final class SelfSizingSectionController: IGListSectionController, IGListSectionT
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/StoryboardLabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/StoryboardLabelSectionController.swift
@@ -45,5 +45,7 @@ final class StoryboardLabelSectionController: IGListSectionController, IGListSec
     func didSelectItem(at index: Int) {
         delegate?.removeSectionControllerWantsRemoved(self)
     }
+  
+    func didDeselectItem(at index: Int) { }
     
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/UserSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/UserSectionController.swift
@@ -39,5 +39,7 @@ final class UserSectionController: IGListSectionController, IGListSectionType {
     }
 
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
@@ -64,6 +64,8 @@ final class WorkingRangeSectionController: IGListSectionController, IGListSectio
 
     func didSelectItem(at index: Int) {}
 
+    func didDeselectItem(at index: Int) {}
+  
     //MARK: IGListWorkingRangeDelegate
 
     func listAdapter(_ listAdapter: IGListAdapter, sectionControllerWillEnterWorkingRange sectionController: IGListSectionController) {

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionStoryboardViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionStoryboardViewController.swift
@@ -65,5 +65,7 @@ final class SingleSectionStoryboardViewController: UIViewController, IGListAdapt
         alert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))
         present(alert, animated: true, completion: nil)
     }
-    
+  
+    func didDeselect(_ sectionController: IGListSingleSectionController, with object: Any) { }
+  
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift
@@ -77,5 +77,7 @@ final class SingleSectionViewController: UIViewController, IGListAdapterDataSour
         alert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))
         present(alert, animated: true, completion: nil)
     }
-    
+  
+    func didDeselect(_ sectionController: IGListSingleSectionController, with object: Any) { }
+
 }

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/CarouselSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/CarouselSectionController.swift
@@ -48,5 +48,7 @@ final class CarouselSectionController: IGListSectionController, IGListSectionTyp
     }
     
     func didSelectItem(at index: Int) {}
-    
+  
+    func didDeselectItem(at index: Int) {}
+  
 }

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -70,5 +70,7 @@ final class DemoSectionController: IGListSectionController, IGListSectionType {
             viewController?.navigationController?.pushViewController(controller, animated: true)
         }
     }
-    
+  
+    func didDeselectItem(at index: Int) { }
+  
 }

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
@@ -51,7 +51,9 @@ final class HorizontalSectionController: IGListSectionController, IGListSectionT
     }
     
     func didSelectItem(at index: Int) {}
-    
+  
+    func didDeselectItem(at index: Int) {}
+  
     // MARK: IGListAdapterDataSource
     
     func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
@@ -38,5 +38,7 @@ final class LabelSectionController: IGListSectionController, IGListSectionType {
     }
     
     func didSelectItem(at index: Int) {}
+  
+    func didDeselectItem(at index: Int) {}
     
 }

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -657,6 +657,17 @@
     [sectionController didSelectItemAtIndex:indexPath.item];
 }
 
+- (void)collectionView:(UICollectionView *)collectionView didDeselectItemAtIndexPath:(NSIndexPath *)indexPath {
+  // forward this method to the delegate b/c this implementation will steal the message from the proxy
+  id<UICollectionViewDelegate> collectionViewDelegate = self.collectionViewDelegate;
+  if ([collectionViewDelegate respondsToSelector:@selector(collectionView:didDeselectItemAtIndexPath:)]) {
+    [collectionViewDelegate collectionView:collectionView didDeselectItemAtIndexPath: indexPath];
+  }
+  
+  IGListSectionController <IGListSectionType> * sectionController = [self.sectionMap sectionControllerForSection:indexPath.section];
+  [sectionController didDeselectItemAtIndex:indexPath.item];
+}
+
 - (void)collectionView:(UICollectionView *)collectionView willDisplayCell:(UICollectionViewCell *)cell forItemAtIndexPath:(NSIndexPath *)indexPath {
     // forward this method to the delegate b/c this implementation will steal the message from the proxy
     id<UICollectionViewDelegate> collectionViewDelegate = self.collectionViewDelegate;

--- a/Source/IGListSectionType.h
+++ b/Source/IGListSectionType.h
@@ -86,6 +86,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)didSelectItemAtIndex:(NSInteger)index;
 
+/**
+ Tells the section that the cell at the specified index path was deselected.
+ @param index The index of the selected cell.
+ */
+- (void)didDeselectItemAtIndex:(NSInteger)index;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/IGListSingleSectionController.h
+++ b/Source/IGListSingleSectionController.h
@@ -50,6 +50,15 @@ typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionC
 - (void)didSelectSectionController:(IGListSingleSectionController *)sectionController
                         withObject:(id)object;
 
+/**
+ Tells the delegate that the section controller was deselected.
+ 
+ @param sectionController The section controller that was deselected.
+ @param object            The model for the given section.
+ */
+- (void)didDeselectSectionController:(IGListSingleSectionController *)sectionController
+                        withObject:(id)object;
+
 @end
 
 /**

--- a/Source/IGListSingleSectionController.m
+++ b/Source/IGListSingleSectionController.m
@@ -109,4 +109,8 @@
     [self.selectionDelegate didSelectSectionController:self withObject:self.item];
 }
 
+- (void)didDeselectItemAtIndex:(NSUInteger)index {
+    [self.selectionDelegate didDeselectSectionController:self withObject:self.item];
+}
+
 @end

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -160,6 +160,12 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
     [sectionController didSelectItemAtIndex:localIndex];
 }
 
+- (void)didDeselectItemAtIndex:(NSUInteger)index {
+  IGListSectionController<IGListSectionType> *sectionController = [self sectionControllerForObjectIndex:index];
+  const NSUInteger localIndex = [self localIndexForSectionController:sectionController index:index];
+  [sectionController didDeselectItemAtIndex:localIndex];
+}
+
 #pragma mark - IGListCollectionContext
 
 - (CGSize)containerSize {

--- a/Source/Internal/IGListAdapterProxy.m
+++ b/Source/Internal/IGListAdapterProxy.m
@@ -19,6 +19,7 @@ static BOOL isInterceptedSelector(SEL sel) {
     return (
             // UICollectionViewDelegate
             sel == @selector(collectionView:didSelectItemAtIndexPath:) ||
+            sel == @selector(collectionView:didDeselectItemAtIndexPath:) ||
             sel == @selector(collectionView:willDisplayCell:forItemAtIndexPath:) ||
             sel == @selector(collectionView:didEndDisplayingCell:forItemAtIndexPath:) ||
             // UICollectionViewDelegateFlowLayout

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -842,6 +842,41 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     XCTAssertFalse(s2.wasSelected);
 }
 
+- (void)test_whenDeselectingCell_thatCollectionViewDelegateReceivesMethod {
+  self.dataSource.objects = @[@0, @1, @2];
+  [self.adapter reloadDataWithCompletion:nil];
+  
+  id mockDelegate = [OCMockObject mockForProtocol:@protocol(UICollectionViewDelegate)];
+  self.adapter.collectionViewDelegate = mockDelegate;
+  
+  NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+  [[mockDelegate expect] collectionView:self.collectionView didDeselectItemAtIndexPath:indexPath];
+  
+  // simulates the collectionview telling its delegate that it was tapped
+  [self.adapter collectionView:self.collectionView didDeselectItemAtIndexPath:indexPath];
+  
+  [mockDelegate verify];
+}
+
+- (void)test_whenDeselectingCell_thatSectionControllerReceivesMethod {
+  self.dataSource.objects = @[@0, @1, @2];
+  [self.adapter reloadDataWithCompletion:nil];
+  
+  NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+  
+  // simulates the collectionview telling its delegate that it was tapped
+  [self.adapter collectionView:self.collectionView didSelectItemAtIndexPath:indexPath];
+  [self.adapter collectionView:self.collectionView didDeselectItemAtIndexPath:indexPath];
+  
+  IGListTestSection *s0 = [self.adapter sectionControllerForObject:@0];
+  IGListTestSection *s1 = [self.adapter sectionControllerForObject:@1];
+  IGListTestSection *s2 = [self.adapter sectionControllerForObject:@2];
+  
+  XCTAssertFalse(s0.wasSelected);
+  XCTAssertFalse(s1.wasSelected);
+  XCTAssertFalse(s2.wasSelected);
+}
+
 - (void)test_whenDisplayingCell_thatCollectionViewDelegateReceivesMethod {
     self.dataSource.objects = @[@0, @1, @2];
     [self.adapter reloadDataWithCompletion:nil];

--- a/Tests/IGListSingleSectionControllerTests.m
+++ b/Tests/IGListSingleSectionControllerTests.m
@@ -131,4 +131,16 @@
     [mockDelegate verify];
 }
 
+- (void)test_whenDeselected_thatDelegateReceivesEvent {
+  [self setupWithObjects:@[
+                           genTestObject(@1, @"a")
+                           ]];
+  IGListSingleSectionController *section = [self.adapter sectionControllerForObject:self.dataSource.objects.firstObject];
+  id mockDelegate = [OCMockObject mockForProtocol:@protocol(IGListSingleSectionControllerDelegate)];
+  section.selectionDelegate = mockDelegate;
+  [[mockDelegate expect] didDeselectSectionController:section withObject:self.dataSource.objects.firstObject];
+  [self.adapter collectionView:self.collectionView didDeselectItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+  [mockDelegate verify];
+}
+
 @end

--- a/Tests/IGListStackSectionControllerTests.m
+++ b/Tests/IGListStackSectionControllerTests.m
@@ -468,6 +468,33 @@ static const CGRect kStackTestFrame = (CGRect){{0.0, 0.0}, {100.0, 100.0}};
     XCTAssertTrue([stack2.sectionControllers[1] wasSelected]);
 }
 
+- (void)test_whenDeselectingItems_thatChildSectionControllersSelected {
+  [self setupWithObjects:@[
+                           [[IGTestObject alloc] initWithKey:@0 value:@[@1, @2, @3]],
+                           [[IGTestObject alloc] initWithKey:@1 value:@[@1, @2, @3]],
+                           [[IGTestObject alloc] initWithKey:@2 value:@[@1, @1]]
+                           ]];
+  
+  [self.adapter collectionView:self.collectionView didSelectItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+  [self.adapter collectionView:self.collectionView didSelectItemAtIndexPath:[NSIndexPath indexPathForItem:2 inSection:1]];
+  [self.adapter collectionView:self.collectionView didSelectItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:2]];
+  
+  [self.adapter collectionView:self.collectionView didDeselectItemAtIndexPath:[NSIndexPath indexPathForItem:2 inSection:1]];
+  [self.adapter collectionView:self.collectionView didDeselectItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:2]];
+  
+  IGListStackedSectionController *stack0 = [self.adapter sectionControllerForObject:self.dataSource.objects[0]];
+  IGListStackedSectionController *stack1 = [self.adapter sectionControllerForObject:self.dataSource.objects[1]];
+  IGListStackedSectionController *stack2 = [self.adapter sectionControllerForObject:self.dataSource.objects[2]];
+  
+  XCTAssertTrue([stack0.sectionControllers[0] wasSelected]);
+  XCTAssertFalse([stack0.sectionControllers[1] wasSelected]);
+  XCTAssertFalse([stack0.sectionControllers[2] wasSelected]);
+  XCTAssertFalse([stack1.sectionControllers[0] wasSelected]);
+  XCTAssertFalse([stack1.sectionControllers[1] wasSelected]);
+  XCTAssertFalse([stack2.sectionControllers[0] wasSelected]);
+  XCTAssertFalse([stack2.sectionControllers[1] wasSelected]);
+}
+
 - (void)test_whenUsingNibs_withStoryboards_thatCellsAreConfigured {
     [self setupWithObjects:@[
                              [[IGTestObject alloc] initWithKey:@0 value:@[@1, @"nib", @"storyboard"]],

--- a/Tests/Objects/IGListTestHorizontalSection.m
+++ b/Tests/Objects/IGListTestHorizontalSection.m
@@ -39,4 +39,8 @@
     self.wasSelected = YES;
 }
 
+- (void)didDeselectItemAtIndex:(NSUInteger)index {
+    self.wasSelected = NO;
+}
+
 @end

--- a/Tests/Objects/IGListTestSection.m
+++ b/Tests/Objects/IGListTestSection.m
@@ -39,4 +39,8 @@
     self.wasSelected = YES;
 }
 
+- (void)didDeselectItemAtIndex:(NSUInteger)index {
+    self.wasSelected = NO;
+}
+
 @end

--- a/Tests/Objects/IGListTestStoryboardSection.m
+++ b/Tests/Objects/IGListTestStoryboardSection.m
@@ -34,4 +34,6 @@
 
 - (void)didSelectItemAtIndex:(NSInteger)index {}
 
+- (void)didDeselectItemAtIndex:(NSUInteger)index {}
+
 @end

--- a/Tests/Objects/IGTestDelegateController.m
+++ b/Tests/Objects/IGTestDelegateController.m
@@ -59,6 +59,8 @@
 
 - (void)didSelectItemAtIndex:(NSInteger)index {}
 
+- (void)didDeselectItemAtIndex:(NSUInteger)index {}
+
 #pragma mark - IGListDisplayDelegate
 
 - (void)listAdapter:(IGListAdapter *)listAdapter willDisplaySectionController:(IGListSectionController <IGListSectionType> *)sectionController {


### PR DESCRIPTION
This implements the `didDeselectItemAt:` delegate call from `UICollectionViewDelegate`. It mostly does the exact same thing as the `didSelect` calls which already exist. Tests are also based on the select tests.

## Changes in this pull request
- Implements the `UICollectionViewDelegate` `didDeselectItemAt:` delegate call in `IGListAdapter`
- Adds `didDeselectSectionController:withObject:` delegate call to `IGListSingleSectionControllerDelegate`
- Tests for changes
- Updates example projects

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
