### PR TITLE
IGListIndexSetResult and IGListIndexPathResult docs updates use old index

### DIFF
--- a/Source/Common/IGListIndexPathResult.h
+++ b/Source/Common/IGListIndexPathResult.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSArray<NSIndexPath *> *deletes;
 
 /**
- The index paths in the new collection that need updated.
+ The index paths in the old collection that need updated.
  */
 @property (nonatomic, copy, readonly) NSArray<NSIndexPath *> *updates;
 

--- a/Source/Common/IGListIndexSetResult.h
+++ b/Source/Common/IGListIndexSetResult.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSIndexSet *deletes;
 
 /**
- The indexes in the new collection that need updated.
+ The indexes in the old collection that need updated.
  */
 @property (nonatomic, strong, readonly) NSIndexSet *updates;
 


### PR DESCRIPTION
## Changes in this pull request

Updated documentation to fix #408 

## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
