### PR TITLE
Add item-level moves to IGListCollectionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Changed `hasChanges` methods in `IGListIndexPathResult` and `IGListIndexSetResult` to read-only properties. [Bofei Zhu](https://github.com/zhubofei) [(#453)](https://github.com/Instagram/IGListKit/pull/453)
 
+### Enhancements
+
+- You can now manually move items (cells) within a section controller, ex: `[self.collectionContext moveInSectionController:self fromIndex:0 toIndex:1]`. [Ryan Nystrom](https://github.com/rnystrom) [(#418)](https://github.com/Instagram/IGListKit/pull/418)
+
 2.2.0
 -----
 

--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				88144EE31D870EDC007C7F66 /* IGListAdapterTests.m */,
 				88144EE41D870EDC007C7F66 /* IGListAdapterUpdaterTests.m */,
 				88144EE51D870EDC007C7F66 /* IGListBatchUpdateDataTests.m */,
-				2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */,
+				1F0A68C41DF8D5B9009E8ADE /* IGListCollectionViewTests.m */,
 				294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */,
 				88144EE61D870EDC007C7F66 /* IGListDiffSwiftTests.swift */,
 				88144EE81D870EDC007C7F66 /* IGListDiffTests.m */,
@@ -712,7 +712,7 @@
 				821BC4BE1DB8C95300172ED0 /* IGListSingleStoryboardItemControllerTests.m */,
 				88144EEE1D870EDC007C7F66 /* IGListStackSectionControllerTests.m */,
 				88144EEF1D870EDC007C7F66 /* IGListWorkingRangeHandlerTests.m */,
-				1F0A68C41DF8D5B9009E8ADE /* IGListCollectionViewTests.m */,
+				2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */,
 				887D0B571D870E1E009E01F7 /* Info.plist */,
 				88144EF01D870EDC007C7F66 /* Objects */,
 			);

--- a/Source/Common/IGListBatchUpdateData.h
+++ b/Source/Common/IGListBatchUpdateData.h
@@ -11,6 +11,7 @@
 
 #import <IGListKit/IGListMacros.h>
 #import <IGListKit/IGListMoveIndex.h>
+#import <IGListKit/IGListMoveIndexPath.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -48,6 +49,11 @@ IGLK_SUBCLASSING_RESTRICTED
 @property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *deleteIndexPaths;
 
 /**
+ Item delete index paths.
+ */
+@property (nonatomic, strong, readonly) NSSet<IGListMoveIndexPath *> *moveIndexPaths;
+
+/**
  Item reload index paths.
  */
 @property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *reloadIndexPaths;
@@ -60,6 +66,7 @@ IGLK_SUBCLASSING_RESTRICTED
  @param moveSections     Section moves.
  @param insertIndexPaths Item index paths to insert.
  @param deleteIndexPaths Item index paths to delete.
+ @param moveIndexPaths   Item index paths to move.
  @param reloadIndexPaths Item index paths to reload.
 
  @return A new batch update object.
@@ -69,6 +76,7 @@ IGLK_SUBCLASSING_RESTRICTED
                           moveSections:(NSSet<IGListMoveIndex *> *)moveSections
                       insertIndexPaths:(NSSet<NSIndexPath *> *)insertIndexPaths
                       deleteIndexPaths:(NSSet<NSIndexPath *> *)deleteIndexPaths
+                        moveIndexPaths:(NSSet<IGListMoveIndexPath *> *)moveIndexPaths
                       reloadIndexPaths:(NSSet<NSIndexPath *> *)reloadIndexPaths NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/Source/Common/IGListBatchUpdateData.h
+++ b/Source/Common/IGListBatchUpdateData.h
@@ -34,7 +34,7 @@ IGLK_SUBCLASSING_RESTRICTED
 @property (nonatomic, strong, readonly) NSIndexSet *deleteSections;
 
 /**
- section moves.
+ Section moves.
  */
 @property (nonatomic, strong, readonly) NSSet<IGListMoveIndex *> *moveSections;
 
@@ -49,7 +49,7 @@ IGLK_SUBCLASSING_RESTRICTED
 @property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *deleteIndexPaths;
 
 /**
- Item delete index paths.
+ Item moves.
  */
 @property (nonatomic, strong, readonly) NSSet<IGListMoveIndexPath *> *moveIndexPaths;
 

--- a/Source/Common/IGListBatchUpdateData.mm
+++ b/Source/Common/IGListBatchUpdateData.mm
@@ -65,12 +65,14 @@ static void convertMoveToDeleteAndInsert(NSMutableSet<IGListMoveIndex *> *moves,
                           moveSections:(NSSet<IGListMoveIndex *> *)moveSections
                       insertIndexPaths:(NSSet<NSIndexPath *> *)insertIndexPaths
                       deleteIndexPaths:(NSSet<NSIndexPath *> *)deleteIndexPaths
+                        moveIndexPaths:(NSSet<IGListMoveIndexPath *> *)moveIndexPaths
                       reloadIndexPaths:(NSSet<NSIndexPath *> *)reloadIndexPaths {
     IGParameterAssert(insertSections != nil);
     IGParameterAssert(deleteSections != nil);
     IGParameterAssert(moveSections != nil);
     IGParameterAssert(insertIndexPaths != nil);
     IGParameterAssert(deleteIndexPaths != nil);
+    IGParameterAssert(moveIndexPaths != nil);
     IGParameterAssert(reloadIndexPaths != nil);
     if (self = [super init]) {
         NSMutableSet<IGListMoveIndex *> *mMoveSections = [moveSections mutableCopy];

--- a/Source/Common/IGListBatchUpdateData.mm
+++ b/Source/Common/IGListBatchUpdateData.mm
@@ -119,6 +119,7 @@ static void convertMoveToDeleteAndInsert(NSMutableSet<IGListMoveIndex *> *moves,
         _moveSections = [mMoveSections copy];
         _deleteIndexPaths = [mDeleteIndexPaths copy];
         _insertIndexPaths = [mInsertIndexPaths copy];
+        _moveIndexPaths = [moveIndexPaths copy];
         _reloadIndexPaths = [mReloadIndexPaths copy];
     }
     return self;

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -1006,7 +1006,7 @@
              sectionController, fromIndex, toIndex);
 
     NSIndexPath *fromIndexPath = [self indexPathForSectionController:sectionController index:fromIndex usePreviousSection:YES];
-    NSIndexPath *toIndexPath = [self indexPathForSectionController:sectionController index:fromIndex usePreviousSection:NO];
+    NSIndexPath *toIndexPath = [self indexPathForSectionController:sectionController index:toIndex usePreviousSection:NO];
 
     if (fromIndexPath == nil || toIndexPath == nil) {
         return;

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -194,7 +194,7 @@
             offsetMax = endMax;
         }
     }
-    
+
     const CGFloat offsetMid = (offsetMin + offsetMax) / 2.0;
     const CGFloat collectionViewWidth = collectionView.bounds.size.width;
     const CGFloat collectionViewHeight = collectionView.bounds.size.height;
@@ -264,23 +264,23 @@
 
     __weak __typeof__(self) weakSelf = self;
     [self.updater performUpdateWithCollectionView:collectionView
-                                               fromObjects:fromObjects
-                                                 toObjects:newItems
-                                                  animated:animated
-                                     objectTransitionBlock:^(NSArray *toObjects) {
-                                         // temporarily capture the item map that we are transitioning from in case
-                                         // there are any item deletes at the same
-                                         weakSelf.previousSectionMap = [weakSelf.sectionMap copy];
+                                      fromObjects:fromObjects
+                                        toObjects:newItems
+                                         animated:animated
+                            objectTransitionBlock:^(NSArray *toObjects) {
+                                // temporarily capture the item map that we are transitioning from in case
+                                // there are any item deletes at the same
+                                weakSelf.previousSectionMap = [weakSelf.sectionMap copy];
 
-                                         [weakSelf updateObjects:toObjects dataSource:dataSource];
-                                     } completion:^(BOOL finished) {
-                                         // release the previous items
-                                         weakSelf.previousSectionMap = nil;
+                                [weakSelf updateObjects:toObjects dataSource:dataSource];
+                            } completion:^(BOOL finished) {
+                                // release the previous items
+                                weakSelf.previousSectionMap = nil;
 
-                                         if (completion) {
-                                             completion(finished);
-                                         }
-                                     }];
+                                if (completion) {
+                                    completion(finished);
+                                }
+                            }];
 }
 
 - (void)reloadDataWithCompletion:(nullable IGListUpdaterCompletion)completion {
@@ -556,10 +556,11 @@
     return isZero;
 }
 
-- (IGListSectionMap *)sectionMapAdjustForUpdateBlock:(BOOL)adjustForUpdateBlock {
+- (IGListSectionMap *)sectionMapAdjustForUpdateBlock:(BOOL)usePreviousSection {
     // if we are inside an update block, we may have to use the /previous/ item map for some operations
-    if (adjustForUpdateBlock && self.isInUpdateBlock && self.previousSectionMap != nil) {
-        return self.previousSectionMap;
+    IGListSectionMap *previousSectionMap = self.previousSectionMap;
+    if (usePreviousSection && self.isInUpdateBlock && previousSectionMap != nil) {
+        return previousSectionMap;
     } else {
         return self.sectionMap;
     }
@@ -567,11 +568,12 @@
 
 - (NSArray<NSIndexPath *> *)indexPathsFromSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                                     indexes:(NSIndexSet *)indexes
-                                       adjustForUpdateBlock:(BOOL)adjustForUpdateBlock {
+                                         usePreviousSection:(BOOL)usePreviousSection {
     NSMutableArray<NSIndexPath *> *indexPaths = [[NSMutableArray alloc] init];
 
     IGListSectionMap *map = [self sectionMapAdjustForUpdateBlock:adjustForUpdateBlock];
 
+    IGListSectionMap *map = [self sectionMapAdjustForUpdateBlock:usePreviousSection];
     const NSInteger section = [map sectionForSectionController:sectionController];
     if (section != NSNotFound) {
         [indexes enumerateIndexesUsingBlock:^(NSUInteger idx, BOOL *stop) {
@@ -581,8 +583,11 @@
     return indexPaths;
 }
 
-- (NSIndexPath *)indexPathForSectionController:(IGListSectionController *)controller index:(NSInteger)index {
-    const NSInteger section = [self.sectionMap sectionForSectionController:controller];
+- (NSIndexPath *)indexPathForSectionController:(IGListSectionController *)controller
+                                         index:(NSInteger)index
+                            usePreviousSection:(BOOL)usePreviousSection {
+    IGListSectionMap *map = [self sectionMapAdjustForUpdateBlock:usePreviousSection];
+    const NSInteger section = [map sectionForSectionController:controller];
     if (section == NSNotFound) {
         return nil;
     } else {
@@ -783,7 +788,7 @@
         return nil;
     }
 
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     // prevent querying the collection view if it isn't fully reloaded yet for the current data set
     if (indexPath != nil
         && indexPath.section < [self.collectionView numberOfSections]) {
@@ -815,7 +820,7 @@
                    animated:(BOOL)animated {
     IGAssertMainThread();
     IGParameterAssert(sectionController != nil);
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     [self.collectionView deselectItemAtIndexPath:indexPath animated:animated];
 }
 
@@ -829,7 +834,7 @@
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Dequeueing cell of class %@ from section controller %@ without a collection view at index %zi", NSStringFromClass(cellClass), sectionController, index);
     NSString *identifier = IGListReusableViewIdentifier(cellClass, nil, nil);
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     if (![self.registeredCellClasses containsObject:cellClass]) {
         [self.registeredCellClasses addObject:cellClass];
         [collectionView registerClass:cellClass forCellWithReuseIdentifier:identifier];
@@ -845,7 +850,7 @@
     IGParameterAssert(identifier.length > 0);
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Reloading adapter without a collection view.");
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     return [collectionView dequeueReusableCellWithReuseIdentifier:identifier forIndexPath:indexPath];
 }
 
@@ -859,7 +864,7 @@
     IGParameterAssert(index >= 0);
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Dequeueing cell with nib name %@ and bundle %@ from section controller %@ without a collection view at index %zi.", nibName, bundle, sectionController, index);
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     if (![self.registeredNibNames containsObject:nibName]) {
         [self.registeredNibNames addObject:nibName];
         UINib *nib = [UINib nibWithNibName:nibName bundle:bundle];
@@ -880,7 +885,7 @@
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Dequeueing cell of class %@ from section controller %@ without a collection view at index %zi with supplementary view %@", NSStringFromClass(viewClass), sectionController, index, elementKind);
     NSString *identifier = IGListReusableViewIdentifier(viewClass, nil, elementKind);
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     if (![self.registeredSupplementaryViewIdentifiers containsObject:identifier]) {
         [self.registeredSupplementaryViewIdentifiers addObject:identifier];
         [collectionView registerClass:viewClass forSupplementaryViewOfKind:elementKind withReuseIdentifier:identifier];
@@ -899,7 +904,7 @@
     IGParameterAssert(index >= 0);
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Dequeueing Supplementary View from storyboard of kind %@ with identifier %@ for section controller %@ without a collection view at index %zi", elementKind, identifier, sectionController, index);
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     return [collectionView dequeueReusableSupplementaryViewOfKind:elementKind withReuseIdentifier:identifier forIndexPath:indexPath];
 }
 
@@ -913,7 +918,7 @@
     IGParameterAssert([elementKind length] > 0);
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Reloading adapter without a collection view.");
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     if (![self.registeredSupplementaryViewNibNames containsObject:nibName]) {
         [self.registeredSupplementaryViewNibNames addObject:nibName];
         UINib *nib = [UINib nibWithNibName:nibName bundle:bundle];
@@ -939,21 +944,21 @@
          Internally it appears to convert these operations to a delete+insert. However the transformation is too simple
          in that it doesn't account for the item's section being moved (naturally or explicitly) and can queue animation
          collisions.
-         
+
          If you have an object at section 2 with 4 items and attempt to reload item at index 1, you would create an
          NSIndexPath at section: 2, item: 1. Within -performBatchUpdates:, UICollectionView converts this to a delete
          and insert at the same NSIndexPath.
-         
+
          If a section were inserted at position 2, the original section 2 has naturally shifted to section 3. However,
          the insert NSIndexPath is section: 2, item: 1. Now the UICollectionView has a section animation at section 2,
          as well as an item insert animation at section: 2, item: 1, and it will throw an exception.
-         
+
          IGListAdapter tracks the before/after mapping of section controllers to make precise NSIndexPath conversions.
          */
         [self deleteInSectionController:sectionController atIndexes:indexes];
         [self insertInSectionController:sectionController atIndexes:indexes];
     } else {
-        NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes adjustForUpdateBlock:YES];
+        NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes usePreviousSection:YES];
         [self.updater reloadItemsInCollectionView:collectionView indexPaths:indexPaths];
         [self updateBackgroundViewShouldHide:![self itemCountIsZero]];
     }
@@ -970,7 +975,7 @@
         return;
     }
 
-    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes adjustForUpdateBlock:NO];
+    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes usePreviousSection:NO];
     [self.updater insertItemsIntoCollectionView:collectionView indexPaths:indexPaths];
     [self updateBackgroundViewShouldHide:![self itemCountIsZero]];
 }
@@ -986,9 +991,28 @@
         return;
     }
 
-    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes adjustForUpdateBlock:YES];
+    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes usePreviousSection:YES];
     [self.updater deleteItemsFromCollectionView:collectionView indexPaths:indexPaths];
     [self updateBackgroundViewShouldHide:![self itemCountIsZero]];
+}
+
+- (void)moveInSectionController:(IGListSectionController<IGListSectionType> *)sectionController fromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex {
+    IGAssertMainThread();
+    IGParameterAssert(sectionController != nil);
+    IGParameterAssert(fromIndex >= 0);
+    IGParameterAssert(toIndex >= 0);
+    UICollectionView *collectionView = self.collectionView;
+    IGAssert(collectionView != nil, @"Moving items from %@ without a collection view from index to %zi index %zi.",
+             sectionController, fromIndex, toIndex);
+
+    NSIndexPath *fromIndexPath = [self indexPathForSectionController:sectionController index:fromIndex usePreviousSection:YES];
+    NSIndexPath *toIndexPath = [self indexPathForSectionController:sectionController index:fromIndex usePreviousSection:NO];
+
+    if (fromIndexPath == nil || toIndexPath == nil) {
+        return;
+    }
+
+    [self.updater moveItemInCollectionView:collectionView fromIndexPath:fromIndexPath toIndexPath:toIndexPath];
 }
 
 - (void)reloadSectionController:(IGListSectionController <IGListSectionType> *)sectionController {
@@ -1034,7 +1058,7 @@
     IGAssertMainThread();
     IGParameterAssert(sectionController != nil);
 
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousSection:NO];
     [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:scrollPosition animated:animated];
 }
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -571,8 +571,6 @@
                                          usePreviousSection:(BOOL)usePreviousSection {
     NSMutableArray<NSIndexPath *> *indexPaths = [[NSMutableArray alloc] init];
 
-    IGListSectionMap *map = [self sectionMapAdjustForUpdateBlock:adjustForUpdateBlock];
-
     IGListSectionMap *map = [self sectionMapAdjustForUpdateBlock:usePreviousSection];
     const NSInteger section = [map sectionForSectionController:sectionController];
     if (section != NSNotFound) {

--- a/Source/IGListAdapterUpdaterDelegate.h
+++ b/Source/IGListAdapterUpdaterDelegate.h
@@ -37,7 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note This event is called in the completion block of the batch update.
  */
-- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater didPerformBatchUpdates:(IGListBatchUpdateData *)updates withCollectionView:(UICollectionView *)collectionView;
+- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
+    didPerformBatchUpdates:(IGListBatchUpdateData *)updates
+        withCollectionView:(UICollectionView *)collectionView;
 
 /**
  Notifies the delegate that the updater will call `-[UICollectionView insertItemsAtIndexPaths:]`.
@@ -48,7 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
-- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater willInsertIndexPaths:(NSArray<NSIndexPath *> *)indexPaths collectionView:(UICollectionView *)collectionView;
+- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
+      willInsertIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+            collectionView:(UICollectionView *)collectionView;
 
 /**
  Notifies the delegate that the updater will call `-[UICollectionView deleteItemsAtIndexPaths:]`.
@@ -59,7 +63,24 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
-- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater willDeleteIndexPaths:(NSArray<NSIndexPath *> *)indexPaths collectionView:(UICollectionView *)collectionView;
+- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
+      willDeleteIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+            collectionView:(UICollectionView *)collectionView;
+
+/**
+ Notifies the delegate that the updater will call `-[UICollectionView moveItemAtIndexPath:toIndexPath:]`
+
+ @param listAdapterUpdater The adapter updater owning the transition.
+ @param fromIndexPath      The index path of the item that will be moved.
+ @param toIndexPath        The index path to move the item to.
+ @param collectionView     The collection view that will perform the move.
+
+ @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
+ */
+- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
+     willMoveFromIndexPath:(NSIndexPath *)fromIndexPath
+               toIndexPath:(NSIndexPath *)toIndexPath
+            collectionView:(UICollectionView *)collectionView;
 
 /**
  Notifies the delegate that the updater will call `-[UICollectionView reloadItemsAtIndexPaths:]`.
@@ -70,7 +91,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
-- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater willReloadIndexPaths:(NSArray<NSIndexPath *> *)indexPaths collectionView:(UICollectionView *)collectionView;
+- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
+      willReloadIndexPaths:(NSArray<NSIndexPath *> *)indexPaths
+            collectionView:(UICollectionView *)collectionView;
 
 /**
  Notifies the delegate that the updater will call `-[UICollectionView reloadSections:]`.
@@ -81,7 +104,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
-- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater willReloadSections:(NSIndexSet *)sections collectionView:(UICollectionView *)collectionView;
+- (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
+        willReloadSections:(NSIndexSet *)sections
+            collectionView:(UICollectionView *)collectionView;
 
 /**
  Notifies the delegate that the updater will call `-[UICollectionView reloadData]`.

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -201,6 +201,17 @@ NS_ASSUME_NONNULL_BEGIN
                         atIndexes:(NSIndexSet *)indexes;
 
 /**
+ Moves a cell from one index to another within the section controller.
+
+ @param sectionController The section controller who's cell needs moved.
+ @param fromIndex         The index the cell is currently in.
+ @param toIndex           The index the cell should move to.
+ */
+- (void)moveInSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                      fromIndex:(NSInteger)fromIndex
+                        toIndex:(NSInteger)toIndex;
+
+/**
  Reloads the entire section controller.
 
  @param sectionController The section controller who's cells need reloading.

--- a/Source/IGListReloadDataUpdater.m
+++ b/Source/IGListReloadDataUpdater.m
@@ -49,6 +49,10 @@
     [self synchronousReloadDataWithCollectionView:collectionView];
 }
 
+- (void)moveItemInCollectionView:(UICollectionView *)collectionView fromIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath {
+    [self synchronousReloadDataWithCollectionView:collectionView];
+}
+
 - (void)reloadItemsInCollectionView:(UICollectionView *)collectionView indexPaths:(NSArray<NSIndexPath *> *)indexPaths {
     [self synchronousReloadDataWithCollectionView:collectionView];
 }

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -277,6 +277,13 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
     [self.collectionContext deleteInSectionController:self atIndexes:itemIndexes];
 }
 
+- (void)moveInSectionController:(IGListSectionController<IGListSectionType> *)sectionController fromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex {
+    [self reloadData];
+    const NSInteger fromRelativeIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:fromIndex];
+    const NSInteger toRelativeIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:fromIndex];
+    [self.collectionContext moveInSectionController:self fromIndex:fromRelativeIndex toIndex:toRelativeIndex];
+}
+
 - (void)reloadSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
     [self reloadData];
     [self.collectionContext reloadSectionController:self];

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -280,7 +280,7 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
 - (void)moveInSectionController:(IGListSectionController<IGListSectionType> *)sectionController fromIndex:(NSInteger)fromIndex toIndex:(NSInteger)toIndex {
     [self reloadData];
     const NSInteger fromRelativeIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:fromIndex];
-    const NSInteger toRelativeIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:fromIndex];
+    const NSInteger toRelativeIndex = [self relativeIndexForSectionController:sectionController fromLocalIndex:toIndex];
     [self.collectionContext moveInSectionController:self fromIndex:fromRelativeIndex toIndex:toRelativeIndex];
 }
 

--- a/Source/IGListUpdatingDelegate.h
+++ b/Source/IGListUpdatingDelegate.h
@@ -94,6 +94,17 @@ typedef void (^IGListReloadUpdateBlock)();
 - (void)deleteItemsFromCollectionView:(UICollectionView *)collectionView indexPaths:(NSArray <NSIndexPath *> *)indexPaths;
 
 /**
+ Tells the delegate to move an item from and to given index paths.
+
+ @param collectionView The collection view on which to perform the transition.
+ @param fromIndexPath  The original index path of the item to move.
+ @param toIndexPath    The index path to move the item to.
+ */
+- (void)moveItemInCollectionView:(UICollectionView *)collectionView
+                   fromIndexPath:(NSIndexPath *)fromIndexPath
+                     toIndexPath:(NSIndexPath *)toIndexPath;
+
+/**
  Tells the delegate to perform item reloads at the given index paths.
 
  @param collectionView The collection view on which to perform the transition.

--- a/Source/IGListUpdatingDelegate.h
+++ b/Source/IGListUpdatingDelegate.h
@@ -97,8 +97,8 @@ typedef void (^IGListReloadUpdateBlock)();
  Tells the delegate to move an item from and to given index paths.
 
  @param collectionView The collection view on which to perform the transition.
- @param fromIndexPath  The original index path of the item to move.
- @param toIndexPath    The index path to move the item to.
+ @param fromIndexPath  The source index path of the item to move.
+ @param toIndexPath    The destination index path of the item to move.
  */
 - (void)moveItemInCollectionView:(UICollectionView *)collectionView
                    fromIndexPath:(NSIndexPath *)fromIndexPath

--- a/Source/Internal/IGListAdapterInternal.h
+++ b/Source/Internal/IGListAdapterInternal.h
@@ -61,8 +61,10 @@ IGListCollectionContext
 
 - (NSArray *)indexPathsFromSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                      indexes:(NSIndexSet *)indexes
-                        adjustForUpdateBlock:(BOOL)adjustForUpdateBlock;
-- (nullable NSIndexPath *)indexPathForSectionController:(IGListSectionController *)controller index:(NSInteger)index;
+                        usePreviousSection:(BOOL)usePreviousSection;
+- (nullable NSIndexPath *)indexPathForSectionController:(IGListSectionController *)controller
+                                         index:(NSInteger)index
+                            usePreviousSection:(BOOL)usePreviousSection;
 
 @end
 

--- a/Source/Internal/IGListAdapterInternal.h
+++ b/Source/Internal/IGListAdapterInternal.h
@@ -61,10 +61,11 @@ IGListCollectionContext
 
 - (NSArray *)indexPathsFromSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                                      indexes:(NSIndexSet *)indexes
-                        usePreviousSection:(BOOL)usePreviousSection;
+                  usePreviousIfInUpdateBlock:(BOOL)usePreviousIfInUpdateBlock;
+
 - (nullable NSIndexPath *)indexPathForSectionController:(IGListSectionController *)controller
-                                         index:(NSInteger)index
-                            usePreviousSection:(BOOL)usePreviousSection;
+                                                  index:(NSInteger)index
+                             usePreviousIfInUpdateBlock:(BOOL)usePreviousIfInUpdateBlock;
 
 @end
 

--- a/Source/Internal/IGListAdapterUpdaterInternal.h
+++ b/Source/Internal/IGListAdapterUpdaterInternal.h
@@ -10,6 +10,8 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
+#import <IGListKit/IGListMoveIndexPath.h>
+
 #import "IGListAdapterUpdater.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -33,6 +35,7 @@ FOUNDATION_EXTERN void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
 @property (nonatomic, strong, readonly) NSMutableSet<NSIndexPath *> *deleteIndexPaths;
 @property (nonatomic, strong, readonly) NSMutableSet<NSIndexPath *> *insertIndexPaths;
 @property (nonatomic, strong, readonly) NSMutableSet<NSIndexPath *> *reloadIndexPaths;
+@property (nonatomic, strong, readonly) NSMutableSet<IGListMoveIndexPath *> *moveIndexPaths;
 @property (nonatomic, strong, readonly) NSMutableIndexSet *reloadSections;
 
 @property (nonatomic, copy, nullable) IGListObjectTransitionBlock objectTransitionBlock;

--- a/Source/Internal/UICollectionView+IGListBatchUpdateData.m
+++ b/Source/Internal/UICollectionView+IGListBatchUpdateData.m
@@ -18,6 +18,10 @@
     [self insertItemsAtIndexPaths:[updateData.insertIndexPaths allObjects]];
     [self reloadItemsAtIndexPaths:[updateData.reloadIndexPaths allObjects]];
 
+    for (IGListMoveIndexPath *move in updateData.moveIndexPaths) {
+        [self moveItemAtIndexPath:move.from toIndexPath:move.to];
+    }
+
     for (IGListMoveIndex *move in updateData.moveSections) {
         [self moveSection:move.from toSection:move.to];
     }

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1189,4 +1189,123 @@
     XCTAssertNil(weakSectionController);
 }
 
+- (void)test_whenMovingItems_withObjectMoving_thatCollectionViewWorks {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             genTestObject(@2, @2),
+                             genTestObject(@3, @2),
+                             ]];
+
+    __block BOOL executed = NO;
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+        executed = YES;
+    } completion:nil];
+
+    self.dataSource.objects = @[
+                                genTestObject(@3, @2),
+                                genTestObject(@1, @2),
+                                genTestObject(@2, @2),
+                                ];
+
+    XCTestExpectation *expectation = genExpectation;
+    [self.adapter performUpdatesAnimated:YES completion:^(BOOL finished) {
+        XCTAssertTrue(executed);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
+- (void)test_whenMovingItems_withObjectReloaded_thatCollectionViewWorks {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             ]];
+
+    __block BOOL executed = NO;
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+        executed = YES;
+    } completion:nil];
+
+    self.dataSource.objects = @[
+                                genTestObject(@1, @3),
+                                ];
+
+    XCTestExpectation *expectation = genExpectation;
+    [self.adapter performUpdatesAnimated:YES completion:^(BOOL finished) {
+        XCTAssertTrue(executed);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
+- (void)test_whenMovingItems_withObjectDeleted_thatCollectionViewWorks {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             ]];
+
+    __block BOOL executed = NO;
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+        executed = YES;
+    } completion:nil];
+
+    self.dataSource.objects = @[];
+
+    XCTestExpectation *expectation = genExpectation;
+    [self.adapter performUpdatesAnimated:YES completion:^(BOOL finished) {
+        XCTAssertTrue(executed);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
+- (void)test_whenMovingItems_withObjectInsertedBefore_thatCollectionViewWorks {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             ]];
+
+    __block BOOL executed = NO;
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+        executed = YES;
+    } completion:nil];
+
+    [self setupWithObjects:@[
+                             genTestObject(@2, @2),
+                             genTestObject(@1, @2),
+                             ]];
+
+    XCTestExpectation *expectation = genExpectation;
+    [self.adapter performUpdatesAnimated:YES completion:^(BOOL finished) {
+        XCTAssertTrue(executed);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
+- (void)test_whenMovingItems_thatCollectionViewWorks {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             ]];
+
+    XCTestExpectation *expectation = genExpectation;
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+    } completion:^(BOOL finished) {
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1297,11 +1297,21 @@
                              genTestObject(@1, @2),
                              ]];
 
+    IGTestCell *cell1 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+    IGTestCell *cell2 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:0]];
+    cell1.label.text = @"foo";
+    cell2.label.text = @"bar";
+
     XCTestExpectation *expectation = genExpectation;
     IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
     [section.collectionContext performBatchAnimated:YES updates:^{
         [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
     } completion:^(BOOL finished) {
+        IGTestCell *movedCell1 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+        IGTestCell *movedCell2 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:0]];
+        XCTAssertEqualObjects(movedCell1.label.text, @"bar");
+        XCTAssertEqualObjects(movedCell2.label.text, @"foo");
+
         [expectation fulfill];
     }];
 

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1318,4 +1318,23 @@
     [self waitForExpectationsWithTimeout:15 handler:nil];
 }
 
+- (void)test_whenMovingItems_withNoBatchUpdate_thatCollectionViewWorks {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             ]];
+
+    IGTestCell *cell1 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+    IGTestCell *cell2 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:0]];
+    cell1.label.text = @"foo";
+    cell2.label.text = @"bar";
+
+    IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:self.dataSource.objects.lastObject];
+    [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+
+    IGTestCell *movedCell1 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
+    IGTestCell *movedCell2 = (IGTestCell*)[self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:0]];
+    XCTAssertEqualObjects(movedCell1.label.text, @"bar");
+    XCTAssertEqualObjects(movedCell2.label.text, @"foo");
+}
+
 @end

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -134,7 +134,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     IGListSectionController <IGListSectionType> * second = [self.adapter sectionControllerForObject:@1];
     NSArray *paths0 = [self.adapter indexPathsFromSectionController:second
                                                             indexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(2, 4)]
-                                               adjustForUpdateBlock:NO];
+                                               usePreviousSection:NO];
     NSArray *expected = @[
                           [NSIndexPath indexPathForItem:2 inSection:1],
                           [NSIndexPath indexPathForItem:3 inSection:1],
@@ -153,7 +153,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [self.adapter performBatchAnimated:YES updates:^{
         NSArray *paths = [self.adapter indexPathsFromSectionController:second
                                                                indexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(2, 2)]
-                                                  adjustForUpdateBlock:YES];
+                                                  usePreviousSection:YES];
         NSArray *expected = @[
                               [NSIndexPath indexPathForItem:2 inSection:1],
                               [NSIndexPath indexPathForItem:3 inSection:1],

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -750,7 +750,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [self.adapter reloadDataWithCompletion:nil];
 
     id randomSectionController = [IGListSectionController new];
-    XCTAssertNil([self.adapter indexPathForSectionController:randomSectionController index:0]);
+    XCTAssertNil([self.adapter indexPathForSectionController:randomSectionController index:0 usePreviousSection:NO]);
 }
 
 - (void)test_whenQueryingSectionForObject_thatSectionReturned {

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -134,7 +134,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     IGListSectionController <IGListSectionType> * second = [self.adapter sectionControllerForObject:@1];
     NSArray *paths0 = [self.adapter indexPathsFromSectionController:second
                                                             indexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(2, 4)]
-                                                 usePreviousSection:NO];
+                                                 usePreviousIfInUpdateBlock:NO];
     NSArray *expected = @[
                           [NSIndexPath indexPathForItem:2 inSection:1],
                           [NSIndexPath indexPathForItem:3 inSection:1],
@@ -153,7 +153,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [self.adapter performBatchAnimated:YES updates:^{
         NSArray *paths = [self.adapter indexPathsFromSectionController:second
                                                                indexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(2, 2)]
-                                                    usePreviousSection:YES];
+                                                    usePreviousIfInUpdateBlock:YES];
         NSArray *expected = @[
                               [NSIndexPath indexPathForItem:2 inSection:1],
                               [NSIndexPath indexPathForItem:3 inSection:1],
@@ -750,7 +750,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [self.adapter reloadDataWithCompletion:nil];
 
     id randomSectionController = [IGListSectionController new];
-    XCTAssertNil([self.adapter indexPathForSectionController:randomSectionController index:0 usePreviousSection:NO]);
+    XCTAssertNil([self.adapter indexPathForSectionController:randomSectionController index:0 usePreviousIfInUpdateBlock:NO]);
 }
 
 - (void)test_whenQueryingSectionForObject_thatSectionReturned {

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -3,7 +3,7 @@
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant 
+ * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
@@ -134,7 +134,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     IGListSectionController <IGListSectionType> * second = [self.adapter sectionControllerForObject:@1];
     NSArray *paths0 = [self.adapter indexPathsFromSectionController:second
                                                             indexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(2, 4)]
-                                               usePreviousSection:NO];
+                                                 usePreviousSection:NO];
     NSArray *expected = @[
                           [NSIndexPath indexPathForItem:2 inSection:1],
                           [NSIndexPath indexPathForItem:3 inSection:1],
@@ -153,7 +153,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [self.adapter performBatchAnimated:YES updates:^{
         NSArray *paths = [self.adapter indexPathsFromSectionController:second
                                                                indexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(2, 2)]
-                                                  usePreviousSection:YES];
+                                                    usePreviousSection:YES];
         NSArray *expected = @[
                               [NSIndexPath indexPathForItem:2 inSection:1],
                               [NSIndexPath indexPathForItem:3 inSection:1],
@@ -213,8 +213,8 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     self.dataSource.objects = @[@0, @1, @2];
     UIViewController *controller = [UIViewController new];
     IGListAdapter *adapter = [[IGListAdapter alloc] initWithUpdater:[IGListReloadDataUpdater new]
-                                                              viewController:controller
-                                                            workingRangeSize:0];
+                                                     viewController:controller
+                                                   workingRangeSize:0];
     adapter.collectionView = self.collectionView;
     adapter.dataSource = self.dataSource;
     IGListSectionController <IGListSectionType> *sectionController = [adapter sectionControllerForObject:@1];
@@ -224,8 +224,8 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
 - (void)test_whenSettingCollectionView_thenSettingDataSource_thatCellExists {
     self.dataSource.objects = @[@1];
     IGListAdapter *adapter = [[IGListAdapter alloc] initWithUpdater:[IGListReloadDataUpdater new]
-                                                              viewController:nil
-                                                            workingRangeSize:0];
+                                                     viewController:nil
+                                                   workingRangeSize:0];
     adapter.collectionView = self.collectionView;
     adapter.dataSource = self.dataSource;
     [self.collectionView layoutIfNeeded];
@@ -235,8 +235,8 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
 - (void)test_whenSettingDataSource_thenSettingCollectionView_thatCellExists {
     self.dataSource.objects = @[@1];
     IGListAdapter *adapter = [[IGListAdapter alloc] initWithUpdater:[IGListReloadDataUpdater new]
-                                                              viewController:nil
-                                                            workingRangeSize:0];
+                                                     viewController:nil
+                                                   workingRangeSize:0];
     adapter.dataSource = self.dataSource;
     adapter.collectionView = self.collectionView;
     [self.collectionView layoutIfNeeded];
@@ -682,17 +682,17 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
 - (void)test_whenScrollToItem_thatSupplementarySourceSupportsSingleHeader {
     self.dataSource.objects = @[@1, @2];
     [self.adapter reloadDataWithCompletion:nil];
-    
+
     IGTestSupplementarySource *supplementarySource = [IGTestSupplementarySource new];
     supplementarySource.collectionContext = self.adapter;
     supplementarySource.supportedElementKinds = @[UICollectionElementKindSectionHeader];
-    
+
     IGListSectionController<IGListSectionType> *controller = [self.adapter sectionControllerForObject:@1];
     controller.supplementaryViewSource = supplementarySource;
     supplementarySource.sectionController = controller;
-    
+
     [self.adapter performUpdatesAnimated:NO completion:nil];
-    
+
     XCTAssertNotNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
     [self.adapter scrollToObject:@1 supplementaryKinds:@[UICollectionElementKindSectionHeader] scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone animated:NO];
     IGAssertEqualPoint([self.collectionView contentOffset], 0, 0);
@@ -703,17 +703,17 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
 - (void)test_whenScrollToItem_thatSupplementarySourceSupportsHeaderAndFooter {
     self.dataSource.objects = @[@1, @2];
     [self.adapter reloadDataWithCompletion:nil];
-    
+
     IGTestSupplementarySource *supplementarySource = [IGTestSupplementarySource new];
     supplementarySource.collectionContext = self.adapter;
     supplementarySource.supportedElementKinds = @[UICollectionElementKindSectionHeader, UICollectionElementKindSectionFooter];
-    
+
     IGListSectionController<IGListSectionType> *controller = [self.adapter sectionControllerForObject:@1];
     controller.supplementaryViewSource = supplementarySource;
     supplementarySource.sectionController = controller;
-    
+
     [self.adapter performUpdatesAnimated:NO completion:nil];
-    
+
     XCTAssertNotNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
     XCTAssertNotNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
     [self.adapter scrollToObject:@1 supplementaryKinds:@[UICollectionElementKindSectionHeader, UICollectionElementKindSectionFooter] scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone animated:NO];
@@ -960,7 +960,7 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
 - (void)test_whenScrollingToIndex_withSectionController_thatPositionCorrect {
     self.dataSource.objects = @[@1, @2, @3, @4, @5, @6, @7, @8, @9, @10, @11, @12, @13, @14, @15, @16, @17, @18, @19];
     [self.adapter reloadDataWithCompletion:nil];
-
+    
     IGListSectionController<IGListSectionType> *section = [self.adapter sectionControllerForObject:@8];
     [section.collectionContext scrollToSectionController:section atIndex:0 scrollPosition:UICollectionViewScrollPositionTop animated:NO];
     XCTAssertEqual(self.collectionView.contentOffset.x, 0);

--- a/Tests/IGListBatchUpdateDataTests.m
+++ b/Tests/IGListBatchUpdateDataTests.m
@@ -171,6 +171,4 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@1]));
 }
 
-// any section that is moved w/ an item-level op in it should: discard all item ops, convert to delete+insert
-
 @end

--- a/Tests/IGListBatchUpdateDataTests.m
+++ b/Tests/IGListBatchUpdateDataTests.m
@@ -3,13 +3,14 @@
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant 
+ * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
 #import <XCTest/XCTest.h>
 
 #import "IGListBatchUpdateData.h"
+#import "IGListMoveIndexPathInternal.h"
 
 // IGListMoveIndexInternal.h
 @interface IGListMoveIndex (Private)
@@ -44,6 +45,7 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
                                                                              moveSections:[NSSet new]
                                                                          insertIndexPaths:[NSSet new]
                                                                          deleteIndexPaths:[NSSet new]
+                                                                           moveIndexPaths:[NSSet new]
                                                                          reloadIndexPaths:[NSSet new]];
     XCTAssertNotNil(result);
 }
@@ -54,12 +56,15 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
                                                                              moveSections:[NSSet setWithArray:@[newMove(3, 4)]]
                                                                          insertIndexPaths:[NSSet setWithArray:@[newPath(0, 0)]]
                                                                          deleteIndexPaths:[NSSet setWithArray:@[newPath(1, 0)]]
+                                                                           moveIndexPaths:[NSSet setWithArray:@[[[IGListMoveIndexPath alloc] initWithFrom:newPath(6, 0) to:newPath(6, 1)]]]
                                                                          reloadIndexPaths:[NSSet setWithArray:@[newPath(2, 0)]]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@0, @1]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@5]));
     XCTAssertEqualObjects(result.moveSections, [NSSet setWithArray:@[newMove(3, 4)]]);
     XCTAssertEqualObjects(result.insertIndexPaths, [NSSet setWithArray:@[newPath(0, 0)]]);
     XCTAssertEqualObjects(result.deleteIndexPaths, [NSSet setWithArray:@[newPath(1, 0)]]);
+    XCTAssertEqual(result.moveIndexPaths.count, 1);
+    XCTAssertEqualObjects(result.moveIndexPaths.anyObject, [[IGListMoveIndexPath alloc] initWithFrom:newPath(6, 0) to:newPath(6, 1)]);
     XCTAssertEqualObjects(result.reloadIndexPaths, [NSSet setWithArray:@[newPath(2, 0)]]);
 }
 
@@ -74,6 +79,7 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
                                                                              moveSections:[NSSet setWithArray:@[newMove(2, 4)]]
                                                                          insertIndexPaths:[NSSet new]
                                                                          deleteIndexPaths:[NSSet new]
+                                                                           moveIndexPaths:[NSSet new]
                                                                          reloadIndexPaths:[NSSet setWithArray:reloads]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@4]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@2]));
@@ -87,6 +93,7 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
                                                                              moveSections:[NSSet new]
                                                                          insertIndexPaths:[NSSet new]
                                                                          deleteIndexPaths:[NSSet new]
+                                                                           moveIndexPaths:[NSSet new]
                                                                          reloadIndexPaths:[NSSet setWithArray:@[newPath(2, 0)]]];
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@2]));
     XCTAssertEqual(result.reloadIndexPaths.count, 0);
@@ -98,6 +105,7 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
                                                                              moveSections:[NSSet setWithArray:@[newMove(2, 4)]]
                                                                          insertIndexPaths:[NSSet new]
                                                                          deleteIndexPaths:[NSSet setWithArray:@[newPath(2, 0), newPath(3, 4)]]
+                                                                           moveIndexPaths:[NSSet new]
                                                                          reloadIndexPaths:[NSSet new]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@4]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@2]));
@@ -111,6 +119,7 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
                                                                              moveSections:[NSSet setWithArray:@[newMove(2, 4)]]
                                                                          insertIndexPaths:[NSSet setWithArray:@[newPath(4, 0), newPath(3, 4)]]
                                                                          deleteIndexPaths:[NSSet new]
+                                                                           moveIndexPaths:[NSSet new]
                                                                          reloadIndexPaths:[NSSet new]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@4]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@2]));

--- a/Tests/IGListStackSectionControllerTests.m
+++ b/Tests/IGListStackSectionControllerTests.m
@@ -782,4 +782,31 @@ static const CGRect kStackTestFrame = (CGRect){{0.0, 0.0}, {100.0, 100.0}};
     [self waitForExpectationsWithTimeout:15 handler:nil];
 }
 
+- (void)test_whenMovingItemsInChild_thatCorrectCellsAreMoved {
+    [self setupWithObjects:@[
+                             [[IGTestObject alloc] initWithKey:@0 value:@[@1, @2, @3]],
+                             [[IGTestObject alloc] initWithKey:@1 value:@[@1, @2, @3]],
+                             [[IGTestObject alloc] initWithKey:@2 value:@[@1, @2, @3]],
+                             ]];
+
+    UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:2 inSection:1]];
+    cell.tag = 42;
+
+    IGListStackedSectionController *stack = [self.adapter sectionControllerForObject:self.dataSource.objects[1]];
+    IGListTestSection *section = stack.sectionControllers[1];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+    [section.collectionContext performBatchAnimated:YES updates:^{
+        [section.collectionContext moveInSectionController:section fromIndex:1 toIndex:0];
+    } completion:^(BOOL finished) {
+        XCTAssertEqual([self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]].tag, 0);
+        XCTAssertEqual([self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:1 inSection:1]].tag, 42);
+        XCTAssertEqual([self.collectionView cellForItemAtIndexPath:[NSIndexPath indexPathForItem:2 inSection:1]].tag, 0);
+
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end

--- a/Tests/IGReloadDataUpdaterTests.m
+++ b/Tests/IGReloadDataUpdaterTests.m
@@ -95,4 +95,13 @@
     XCTAssertTrue(executed);
 }
 
+- (void)test_whenMovingFromContext_thatCollectionViewUpdated {
+    self.dataSource.objects = @[@2];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 2);
+    IGListTestSection *section = [self.adapter sectionControllerForObject:@2];
+    [section.collectionContext moveInSectionController:section fromIndex:0 toIndex:1];
+    XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 2);
+}
+
 @end


### PR DESCRIPTION
## Changes in this pull request

Adding an API to do item-level (cell) moves on the collection view. This complicates things a little bit because of all the issues that moving sections have while in batch updates (e.g. simultaneous animation UICV bugs). Thankfully we use pretty strict types so the compiler does most of the work for us.

Closes #145 

## TODO

- [x] Tests build and pass
- [x] Add `IGListBatchUpdateData` tests to check moves during
  - [x] ~~Moving within a reloaded section (no op)~~ can't reload sections
  - [x] Moving within a deleted section (no op)
  - [x] Moving within a moved section (convert section ops to delete+insert)
  - [x] Moving an index path that is also reloaded (convert to delete+insert path)
- [x] Add move unit tests to `IGListAdapterUpdater`
- [x] Add move unit tests to `IGListReloadDataUpdater` (mostly for code coverage...)
- [x] Add move unit tests to `IGListStackedSectionController`
- [x] Add `CHANGELOG.md` entry for 3.0.0
- [x] Test moving without batch updates