### PR TITLE
Added `-[IGListAdapter visibleCellsForObject:]` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 This release closes the [2.2.0 milestone](https://github.com/Instagram/IGListKit/milestone/4).
 
+### Enhancements
+
+- Added `-[IGListAdapter visibleCellsForObject:]` API. [Sherlouk](https://github.com/Sherlouk) [(#442)](https://github.com/Instagram/IGListKit/pull/442)
+
 ### Fixes
 
 - Fix bug where emptyView's hidden status is not updated after the number of items is changed with `insertInSectionController:atIndexes:` or related methods. [Peter Edmonston](https://github.com/edmonston) [(#395)](https://github.com/Instagram/IGListKit/pull/395)

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -197,6 +197,8 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  An unordered array of the currently visible cells for a given object.
  
+ @param item An object in the list
+ 
  @return An array of collection view cells.
  */
 - (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)item;

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -197,11 +197,11 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  An unordered array of the currently visible cells for a given object.
  
- @param item An object in the list
+ @param object An object in the list
  
  @return An array of collection view cells.
  */
-- (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)item;
+- (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)object;
 
 /**
  Scrolls to the sepcified object in the list adapter.

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -195,6 +195,13 @@ IGLK_SUBCLASSING_RESTRICTED
 - (NSArray *)visibleObjects;
 
 /**
+ An unordered array of the currently visible cells for a given object.
+ 
+ @return An array of collection view cells.
+ */
+- (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)item;
+
+/**
  Scrolls to the sepcified object in the list adapter.
 
  @param object             The object to which to scroll.

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -414,6 +414,23 @@
     return [visibleObjects allObjects];
 }
 
+- (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)item {
+    IGAssertMainThread();
+    IGParameterAssert(item != nil);
+    
+    NSArray<UICollectionViewCell *> *visibleCells = [self.collectionView visibleCells];
+    NSInteger section = [self.sectionMap sectionForObject:item];
+    IGAssert(section != NSNotFound, @"Section not found for object %@", item);
+    
+    NSPredicate *controllerPredicate = [NSPredicate predicateWithBlock:^BOOL(UICollectionViewCell* cell, NSDictionary* bindings) {
+        NSIndexPath *indexPath = [self.collectionView indexPathForCell:cell];
+        return indexPath.section == section;
+    }];
+    
+    NSArray<UICollectionViewCell *> *filteredCells = [visibleCells filteredArrayUsingPredicate:controllerPredicate];
+    return filteredCells;
+}
+
 
 #pragma mark - Layout
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -414,21 +414,23 @@
     return [visibleObjects allObjects];
 }
 
-- (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)item {
+- (NSArray<UICollectionViewCell *> *)visibleCellsForObject:(id)object {
     IGAssertMainThread();
-    IGParameterAssert(item != nil);
+    IGParameterAssert(object != nil);
+    
+    const NSInteger section = [self.sectionMap sectionForObject:object];
+    if (section == NSNotFound) {
+        return [NSArray new];
+    }
     
     NSArray<UICollectionViewCell *> *visibleCells = [self.collectionView visibleCells];
-    NSInteger section = [self.sectionMap sectionForObject:item];
-    IGAssert(section != NSNotFound, @"Section not found for object %@", item);
-    
+    UICollectionView *collectionView = self.collectionView;
     NSPredicate *controllerPredicate = [NSPredicate predicateWithBlock:^BOOL(UICollectionViewCell* cell, NSDictionary* bindings) {
-        NSIndexPath *indexPath = [self.collectionView indexPathForCell:cell];
+        NSIndexPath *indexPath = [collectionView indexPathForCell:cell];
         return indexPath.section == section;
     }];
     
-    NSArray<UICollectionViewCell *> *filteredCells = [visibleCells filteredArrayUsingPredicate:controllerPredicate];
-    return filteredCells;
+    return [visibleCells filteredArrayUsingPredicate:controllerPredicate];
 }
 
 

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -596,16 +596,17 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     XCTAssertEqualObjects(visibleObjects, expectedObjects);
 }
 
-- (void)test_superLongBloodyName_toFollowConvention {
+- (void)test_whenAdapterUpdated_thatVisibleCellsForObjectAreFound {
     // each section controller returns n items sized 100x10
     self.dataSource.objects = @[@2, @10, @5];
     [self.adapter reloadDataWithCompletion:nil];
     self.collectionView.contentOffset = CGPointMake(0, 80);
     [self.collectionView layoutIfNeeded];
 
+    UICollectionView *collectionView = self.collectionView;
     NSArray *visibleCellsForObject = [[self.adapter visibleCellsForObject:@10] sortedArrayUsingComparator:^NSComparisonResult(UICollectionViewCell* lhs, UICollectionViewCell* rhs) {
-        NSIndexPath *lhsIndexPath = [self.collectionView indexPathForCell:lhs];
-        NSIndexPath *rhsIndexPath = [self.collectionView indexPathForCell:rhs];
+        NSIndexPath *lhsIndexPath = [collectionView indexPathForCell:lhs];
+        NSIndexPath *rhsIndexPath = [collectionView indexPathForCell:rhs];
         
         if (lhsIndexPath.section == rhsIndexPath.section) {
             return lhsIndexPath.item > rhsIndexPath.item;
@@ -622,6 +623,17 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     
     NSArray *visibleCellsForObjectTwo = [self.adapter visibleCellsForObject:@5];
     XCTAssertEqual(visibleCellsForObjectTwo.count, 5);
+}
+
+- (void)test_whenAdapterUpdated_thatVisibleCellsForNilObjectIsEmpty {
+    // each section controller returns n items sized 100x10
+    self.dataSource.objects = @[@2, @10, @5];
+    [self.adapter reloadDataWithCompletion:nil];
+    self.collectionView.contentOffset = CGPointMake(0, 80);
+    [self.collectionView layoutIfNeeded];
+    
+    NSArray *visibleCellsForObject = [self.adapter visibleCellsForObject:@3];
+    XCTAssertEqual(visibleCellsForObject.count, 0);
 }
 
 - (void)test_whenScrollVerticallyToItem {

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -596,6 +596,34 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     XCTAssertEqualObjects(visibleObjects, expectedObjects);
 }
 
+- (void)test_superLongBloodyName_toFollowConvention {
+    // each section controller returns n items sized 100x10
+    self.dataSource.objects = @[@2, @10, @5];
+    [self.adapter reloadDataWithCompletion:nil];
+    self.collectionView.contentOffset = CGPointMake(0, 80);
+    [self.collectionView layoutIfNeeded];
+
+    NSArray *visibleCellsForObject = [[self.adapter visibleCellsForObject:@10] sortedArrayUsingComparator:^NSComparisonResult(UICollectionViewCell* lhs, UICollectionViewCell* rhs) {
+        NSIndexPath *lhsIndexPath = [self.collectionView indexPathForCell:lhs];
+        NSIndexPath *rhsIndexPath = [self.collectionView indexPathForCell:rhs];
+        
+        if (lhsIndexPath.section == rhsIndexPath.section) {
+            return lhsIndexPath.item > rhsIndexPath.item;
+        }
+        
+        return lhsIndexPath.section > rhsIndexPath.section;
+    }];
+    
+    XCTAssertEqual(visibleCellsForObject.count, 4);
+    XCTAssertEqual([self.collectionView indexPathForCell:visibleCellsForObject[0]].item, 6);
+    XCTAssertEqual([self.collectionView indexPathForCell:visibleCellsForObject[1]].item, 7);
+    XCTAssertEqual([self.collectionView indexPathForCell:visibleCellsForObject[2]].item, 8);
+    XCTAssertEqual([self.collectionView indexPathForCell:visibleCellsForObject[3]].item, 9);
+    
+    NSArray *visibleCellsForObjectTwo = [self.adapter visibleCellsForObject:@5];
+    XCTAssertEqual(visibleCellsForObjectTwo.count, 5);
+}
+
 - (void)test_whenScrollVerticallyToItem {
     // # of items for each object == [item integerValue], so @2 has 2 items (cells)
     self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];


### PR DESCRIPTION
## Changes in this pull request

- Added `-[IGListAdapter visibleCellsForObject:]` API

## Approach

1. Get all visible cells
2. Get the section for the object
3. Filter cells where indexPath.section of cell is equal to the object
4. Return

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added test(s), an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)

-------------

Purely additive, can go in 2.2.0 release? Hold off on changelog until agreed.
Wanting to learn some more ObjC so gave this a shot, would appreciate some nit picking/feedback

Closes #437 