### PR TITLE
Add APIs for invalidating single and many items in section controller

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -1016,17 +1016,17 @@
 }
 
 - (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
-    IGAssertMainThread()
+    IGAssertMainThread();
     IGParameterAssert(sectionController != nil);
     
-    NSInteger *itemCount = [sectionController numberOfItems];
+    NSInteger itemCount = [sectionController numberOfItems];
     NSIndexSet *indexPathRange = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, itemCount)];
     NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexPathRange adjustForUpdateBlock:NO];
     [self invalidateLayoutForIndexPaths:indexPaths];
 }
 
 - (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths {
-    IGAssertMainThread()
+    IGAssertMainThread();
     IGParameterAssert(indexPaths != nil);
     
     UICollectionViewLayoutInvalidationContext *context = [UICollectionViewLayoutInvalidationContext new];

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -1015,19 +1015,12 @@
     [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:scrollPosition animated:animated];
 }
 
-- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
+- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                   atIndexes:(NSIndexSet *)indexes {
     IGAssertMainThread();
     IGParameterAssert(sectionController != nil);
     
-    NSInteger itemCount = [sectionController numberOfItems];
-    NSIndexSet *indexPathRange = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, itemCount)];
-    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexPathRange adjustForUpdateBlock:NO];
-    [self invalidateLayoutForIndexPaths:indexPaths];
-}
-
-- (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths {
-    IGAssertMainThread();
-    IGParameterAssert(indexPaths != nil);
+    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexes adjustForUpdateBlock:NO];
     
     UICollectionViewLayoutInvalidationContext *context = [UICollectionViewLayoutInvalidationContext new];
     [context invalidateItemsAtIndexPaths:indexPaths];

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -1015,6 +1015,25 @@
     [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:scrollPosition animated:animated];
 }
 
+- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
+    IGAssertMainThread()
+    IGParameterAssert(sectionController != nil);
+    
+    NSInteger *itemCount = [sectionController numberOfItems];
+    NSIndexSet *indexPathRange = [NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, itemCount)];
+    NSArray *indexPaths = [self indexPathsFromSectionController:sectionController indexes:indexPathRange adjustForUpdateBlock:NO];
+    [self invalidateLayoutForIndexPaths:indexPaths];
+}
+
+- (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths {
+    IGAssertMainThread()
+    IGParameterAssert(indexPaths != nil);
+    
+    UICollectionViewLayoutInvalidationContext *context = [UICollectionViewLayoutInvalidationContext new];
+    [context invalidateItemsAtIndexPaths:indexPaths];
+    [self.collectionView.collectionViewLayout invalidateLayoutWithContext:context];
+}
+
 #pragma mark - UICollectionViewDelegateFlowLayout
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -253,6 +253,20 @@ NS_ASSUME_NONNULL_BEGIN
                    scrollPosition:(UICollectionViewScrollPosition)scrollPosition
                          animated:(BOOL)animated;
 
+/**
+ Invalidates the collection view layout for all items in the given section.
+ 
+ @param sectionController The section controller.
+ */
+- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController;
+
+/**
+ Invalidates the collection view layout for the items at the given index paths.
+ 
+ @param indexPaths The index path array to invalidate.
+ */
+- (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -257,15 +257,10 @@ NS_ASSUME_NONNULL_BEGIN
  Invalidates the collection view layout for all items in the given section.
  
  @param sectionController The section controller.
+ @param indexes           The indexes of the items that should be invalidated.
  */
-- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController;
-
-/**
- Invalidates the collection view layout for the items at the given index paths.
- 
- @param indexPaths The index path array to invalidate.
- */
-- (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths;
+- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                   atIndexes:(NSIndexSet *)indexes;
 
 @end
 

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -304,12 +304,9 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
                                              animated:animated];
 }
 
-- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
-    [self.collectionContext invalidateLayoutForSectionController:self];
-}
-
-- (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths {
-    [self.collectionContext invalidateLayoutForIndexPaths:indexPaths];
+- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                   atIndexes:(NSIndexSet *)indexes {
+    [self.collectionContext invalidateLayoutForSectionController:self atIndexes:indexes];
 }
 
 #pragma mark - IGListDisplayDelegate

--- a/Source/IGListStackedSectionController.m
+++ b/Source/IGListStackedSectionController.m
@@ -304,6 +304,14 @@ static void * kStackedSectionControllerIndexKey = &kStackedSectionControllerInde
                                              animated:animated];
 }
 
+- (void)invalidateLayoutForSectionController:(IGListSectionController<IGListSectionType> *)sectionController {
+    [self.collectionContext invalidateLayoutForSectionController:self];
+}
+
+- (void)invalidateLayoutForIndexPaths:(NSArray<NSIndexPath *> *) indexPaths {
+    [self.collectionContext invalidateLayoutForIndexPaths:indexPaths];
+}
+
 #pragma mark - IGListDisplayDelegate
 
 - (void)listAdapter:(IGListAdapter *)listAdapter willDisplaySectionController:(IGListSectionController<IGListSectionType> *)sectionController cell:(UICollectionViewCell *)cell atIndex:(NSInteger)index {

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -925,8 +925,6 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [section.collectionContext scrollToSectionController:section atIndex:0 scrollPosition:UICollectionViewScrollPositionTop animated:NO];
     XCTAssertEqual(self.collectionView.contentOffset.x, 0);
     XCTAssertEqual(self.collectionView.contentOffset.y, 280);
-    
-    [section.collectionContext invalid]
 }
 
 @end

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -925,6 +925,8 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [section.collectionContext scrollToSectionController:section atIndex:0 scrollPosition:UICollectionViewScrollPositionTop animated:NO];
     XCTAssertEqual(self.collectionView.contentOffset.x, 0);
     XCTAssertEqual(self.collectionView.contentOffset.y, 280);
+    
+    [section.collectionContext invalid]
 }
 
 @end


### PR DESCRIPTION
## Changes in this pull request

- Added `-[IGListCollectionContext invalidateLayoutForIndexPaths]`
- Added `-[IGListCollectionContext invalidateLayoutForSectionController]`

Unsure the best way to test these new methods, so a suggestion would be welcomed!

Closes #360 

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
