### PR TITLE
Consider supplementary views when sending display events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Empty Views now move with Refresh Controls, and no longer use the `_collectionView.backgroundView` property. [dshahidehpour](https://github.com/dshahidehpour) [(#462)](https://github.com/Instagram/IGListKit/pull/462)]
 
+### Fixes
+
+- Consider supplementary views with display and end-display events. [Ryan Nystrom](https://github.com/rnystrom) [(#470)](https://github.com/Instagram/IGListKit/pull/470)
+
 
 ### Enhancements
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -17,7 +17,7 @@
 #import "IGListSectionControllerInternal.h"
 
 @implementation IGListAdapter {
-    NSMapTable<UICollectionReusableView *, IGListSectionController<IGListSectionType> *> *_cellSectionControllerMap;
+    NSMapTable<UICollectionReusableView *, IGListSectionController<IGListSectionType> *> *_viewSectionControllerMap;
     BOOL _isDequeuingCell;
     BOOL _isSendingWorkingRangeDisplayUpdates;
 }
@@ -49,7 +49,7 @@
         _displayHandler = [[IGListDisplayHandler alloc] init];
         _workingRangeHandler = [[IGListWorkingRangeHandler alloc] initWithWorkingRangeSize:workingRangeSize];
 
-        _cellSectionControllerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableObjectPointerPersonality | NSMapTableStrongMemory
+        _viewSectionControllerMap = [NSMapTable mapTableWithKeyOptions:NSMapTableObjectPointerPersonality | NSMapTableStrongMemory
                                                           valueOptions:NSMapTableStrongMemory];
 
         _updater = updater;
@@ -630,17 +630,17 @@
     IGAssertMainThread();
     IGParameterAssert(view != nil);
     IGParameterAssert(sectionController != nil);
-    [_cellSectionControllerMap setObject:sectionController forKey:view];
+    [_viewSectionControllerMap setObject:sectionController forKey:view];
 }
 
 - (nullable IGListSectionController<IGListSectionType> *)sectionControllerForView:(UICollectionReusableView *)view {
     IGAssertMainThread();
-    return [_cellSectionControllerMap objectForKey:view];
+    return [_viewSectionControllerMap objectForKey:view];
 }
 
 - (void)removeMapForView:(UICollectionReusableView *)view {
     IGAssertMainThread();
-    [_cellSectionControllerMap removeObjectForKey:view];
+    [_viewSectionControllerMap removeObjectForKey:view];
 }
 
 #pragma mark - UICollectionViewDataSource

--- a/Source/Internal/IGListDisplayHandler.h
+++ b/Source/Internal/IGListDisplayHandler.h
@@ -22,7 +22,7 @@ IGLK_SUBCLASSING_RESTRICTED
 @interface IGListDisplayHandler : NSObject
 
 /**
- Tells the handler that a cell will be displayed in the IGListKit infra.
+ Tells the handler that a cell will be displayed in the IGListAdapter.
 
  @param cell              A cell that will display.
  @param listAdapter       The adapter managing the infra.
@@ -37,7 +37,7 @@ IGLK_SUBCLASSING_RESTRICTED
               indexPath:(NSIndexPath *)indexPath;
 
 /**
- Tells the handler that a cell did end display in the IGListKit infra.
+ Tells the handler that a cell did end display in the IGListAdapter.
 
  @param cell              A cell that did end display.
  @param listAdapter       The adapter managing the infra.
@@ -48,6 +48,36 @@ IGLK_SUBCLASSING_RESTRICTED
               forListAdapter:(IGListAdapter *)listAdapter
            sectionController:(IGListSectionController<IGListSectionType> *)sectionController
                    indexPath:(NSIndexPath *)indexPath;
+
+
+/**
+ Tells the handler that a supplementary view will be displayed in the IGListAdapter.
+
+ @param view              A supplementary view that will display.
+ @param listAdapter       The adapter managing the infra.
+ @param sectionController The section controller the view is in.
+ @param object            The object associated with the section controller.
+ @param indexPath         The index path of the supplementary view.
+ */
+- (void)willDisplaySupplementaryView:(UICollectionReusableView *)view
+                      forListAdapter:(IGListAdapter *)listAdapter
+                   sectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                              object:(id)object
+                           indexPath:(NSIndexPath *)indexPath;
+
+
+/**
+ Tells the handler that a supplementary view did end display in the IGListAdapter.
+
+ @param view              A supplementary view that did end display
+ @param listAdapter       The adapter managing the infra.
+ @param sectionController The section controller the view is in.
+ @param indexPath         The index path of the supplementary view.
+ */
+- (void)didEndDisplayingSupplementaryView:(UICollectionReusableView *)view
+                           forListAdapter:(IGListAdapter *)listAdapter
+                        sectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                indexPath:(NSIndexPath *)indexPath;
 
 @end
 

--- a/Source/Internal/IGListDisplayHandler.h
+++ b/Source/Internal/IGListDisplayHandler.h
@@ -24,10 +24,10 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a cell will be displayed in the IGListAdapter.
 
- @param cell              A cell that will display.
- @param listAdapter       The adapter managing the infra.
- @param sectionController The section controller the cell is in.
- @param object            The object associated with the section controller.
+ @param cell              A cell that will be displayed.
+ @param listAdapter       The adapter the cell will display in.
+ @param sectionController The section controller that manages the cell.
+ @param object            The object that powers the section controller.
  @param indexPath         The index path of the cell in the UICollectionView.
  */
 - (void)willDisplayCell:(UICollectionViewCell *)cell
@@ -39,9 +39,9 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a cell did end display in the IGListAdapter.
 
- @param cell              A cell that did end display.
- @param listAdapter       The adapter managing the infra.
- @param sectionController The section controller the cell is in.
+ @param cell              A cell that will be displayed.
+ @param listAdapter       The adapter the cell will display in.
+ @param sectionController The section controller that manages the cell.
  @param indexPath         The index path of the cell in the UICollectionView.
  */
 - (void)didEndDisplayingCell:(UICollectionViewCell *)cell
@@ -53,11 +53,11 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a supplementary view will be displayed in the IGListAdapter.
 
- @param view              A supplementary view that will display.
- @param listAdapter       The adapter managing the infra.
- @param sectionController The section controller the view is in.
- @param object            The object associated with the section controller.
- @param indexPath         The index path of the supplementary view.
+ @param view              A supplementary view that will be displayed.
+ @param listAdapter       The adapter the supplementary view will display in.
+ @param sectionController The section controller that manages the supplementary view.
+ @param object            The object that powers the section controller.
+ @param indexPath         The index path of the supplementary view in the UICollectionView.
  */
 - (void)willDisplaySupplementaryView:(UICollectionReusableView *)view
                       forListAdapter:(IGListAdapter *)listAdapter
@@ -69,10 +69,10 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a supplementary view did end display in the IGListAdapter.
 
- @param view              A supplementary view that did end display
- @param listAdapter       The adapter managing the infra.
- @param sectionController The section controller the view is in.
- @param indexPath         The index path of the supplementary view.
+ @param view              A supplementary view that will be displayed.
+ @param listAdapter       The adapter the supplementary view will display in.
+ @param sectionController The section controller that manages the supplementary view.
+ @param indexPath         The index path of the supplementary view in the UICollectionView.
  */
 - (void)didEndDisplayingSupplementaryView:(UICollectionReusableView *)view
                            forListAdapter:(IGListAdapter *)listAdapter

--- a/Source/Internal/IGListDisplayHandler.m
+++ b/Source/Internal/IGListDisplayHandler.m
@@ -31,56 +31,95 @@
     return self;
 }
 
+- (id)pluckObjectForView:(UICollectionReusableView *)view {
+    NSMapTable *cellObjectMap = self.visibleCellObjectMap;
+    id object = [cellObjectMap objectForKey:view];
+    [cellObjectMap removeObjectForKey:view];
+    return object;
+}
+
+- (void)willDisplayReusableView:(UICollectionReusableView *)view
+                 forListAdapter:(IGListAdapter *)listAdapter
+              sectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                         object:(id)object
+                      indexPath:(NSIndexPath *)indexPath {
+    IGParameterAssert(view != nil);
+    IGParameterAssert(listAdapter != nil);
+    IGParameterAssert(object != nil);
+    IGParameterAssert(indexPath != nil);
+
+    [self.visibleCellObjectMap setObject:object forKey:view];
+    NSCountedSet *visibleListSections = self.visibleListSections;
+    if ([visibleListSections countForObject:sectionController] == 0) {
+        [sectionController.displayDelegate listAdapter:listAdapter willDisplaySectionController:sectionController];
+        [listAdapter.delegate listAdapter:listAdapter willDisplayObject:object atIndex:indexPath.section];
+    }
+    [visibleListSections addObject:sectionController];
+}
+
+- (void)didEndDisplayingReusableView:(UICollectionReusableView *)view
+                      forListAdapter:(IGListAdapter *)listAdapter
+                   sectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                              object:(id)object
+                           indexPath:(NSIndexPath *)indexPath {
+    IGParameterAssert(view != nil);
+    IGParameterAssert(listAdapter != nil);
+    IGParameterAssert(indexPath != nil);
+
+    if (object == nil || sectionController == nil) {
+        return;
+    }
+
+    const NSInteger section = indexPath.section;
+
+    NSCountedSet *visibleSections = self.visibleListSections;
+    [visibleSections removeObject:sectionController];
+
+    if ([visibleSections countForObject:sectionController] == 0) {
+        [sectionController.displayDelegate listAdapter:listAdapter didEndDisplayingSectionController:sectionController];
+        [listAdapter.delegate listAdapter:listAdapter didEndDisplayingObject:object atIndex:section];
+    }
+}
+
+- (void)willDisplaySupplementaryView:(UICollectionReusableView *)view
+                      forListAdapter:(IGListAdapter *)listAdapter
+                   sectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                              object:(id)object
+                           indexPath:(NSIndexPath *)indexPath {
+    [self willDisplayReusableView:view forListAdapter:listAdapter sectionController:sectionController object:object indexPath:indexPath];
+}
+
+- (void)didEndDisplayingSupplementaryView:(UICollectionReusableView *)view
+                           forListAdapter:(IGListAdapter *)listAdapter
+                        sectionController:(IGListSectionController<IGListSectionType> *)sectionController
+                                indexPath:(NSIndexPath *)indexPath {
+    // if cell display events break, don't send display events when the object has disappeared
+    id object = [self pluckObjectForView:view];
+    [self didEndDisplayingReusableView:view forListAdapter:listAdapter sectionController:sectionController object:object indexPath:indexPath];
+}
+
 - (void)willDisplayCell:(UICollectionViewCell *)cell
          forListAdapter:(IGListAdapter *)listAdapter
       sectionController:(IGListSectionController<IGListSectionType> *)sectionController
                  object:(id)object
               indexPath:(NSIndexPath *)indexPath {
-    IGParameterAssert(cell != nil);
-    IGParameterAssert(listAdapter != nil);
-    IGParameterAssert(object != nil);
-    IGParameterAssert(indexPath != nil);
-
     id <IGListDisplayDelegate> displayDelegate = [sectionController displayDelegate];
-
     [displayDelegate listAdapter:listAdapter willDisplaySectionController:sectionController cell:cell atIndex:indexPath.item];
-
-    [self.visibleCellObjectMap setObject:object forKey:cell];
-
-    if ([self.visibleListSections countForObject:sectionController] == 0) {
-        [displayDelegate listAdapter:listAdapter willDisplaySectionController:sectionController];
-        [listAdapter.delegate listAdapter:listAdapter willDisplayObject:object atIndex:indexPath.section];
-    }
-    [self.visibleListSections addObject:sectionController];
+    [self willDisplayReusableView:cell forListAdapter:listAdapter sectionController:sectionController object:object indexPath:indexPath];
 }
 
 - (void)didEndDisplayingCell:(UICollectionViewCell *)cell
               forListAdapter:(IGListAdapter *)listAdapter
            sectionController:(IGListSectionController<IGListSectionType> *)sectionController
                    indexPath:(NSIndexPath *)indexPath {
-    IGParameterAssert(cell != nil);
-    IGParameterAssert(listAdapter != nil);
-    IGParameterAssert(indexPath != nil);
-
-    const NSInteger section = indexPath.section;
-
-    NSMapTable *cellObjectMap = self.visibleCellObjectMap;
-    id object = [cellObjectMap objectForKey:cell];
-    [cellObjectMap removeObjectForKey:cell];
-
-    if (object == nil || sectionController == nil) {
+    // if cell display events break, don't send cell events to the displayDelegate when the object has disappeared
+    id object = [self pluckObjectForView:cell];
+    if (object == nil) {
         return;
     }
 
-    id <IGListDisplayDelegate> displayDelegate = [sectionController displayDelegate];
-    [displayDelegate listAdapter:listAdapter didEndDisplayingSectionController:sectionController cell:cell atIndex:indexPath.item];
-
-    NSCountedSet *visibleSections = self.visibleListSections;
-    [visibleSections removeObject:sectionController];
-    if ([visibleSections countForObject:sectionController] == 0) {
-        [displayDelegate listAdapter:listAdapter didEndDisplayingSectionController:sectionController];
-        [listAdapter.delegate listAdapter:listAdapter didEndDisplayingObject:object atIndex:section];
-    }
+    [sectionController.displayDelegate listAdapter:listAdapter didEndDisplayingSectionController:sectionController cell:cell atIndex:indexPath.item];
+    [self didEndDisplayingReusableView:cell forListAdapter:listAdapter sectionController:sectionController object:object indexPath:indexPath];
 }
 
 @end

--- a/Source/Internal/IGListDisplayHandler.m
+++ b/Source/Internal/IGListDisplayHandler.m
@@ -17,7 +17,7 @@
 @interface IGListDisplayHandler ()
 
 @property (nonatomic, strong) NSCountedSet *visibleListSections;
-@property (nonatomic, strong) NSMapTable *visibleCellObjectMap;
+@property (nonatomic, strong) NSMapTable *visibleViewObjectMap;
 
 @end
 
@@ -26,15 +26,15 @@
 - (instancetype)init {
     if (self = [super init]) {
         _visibleListSections = [[NSCountedSet alloc] init];
-        _visibleCellObjectMap = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableStrongMemory capacity:0];
+        _visibleViewObjectMap = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableStrongMemory capacity:0];
     }
     return self;
 }
 
 - (id)pluckObjectForView:(UICollectionReusableView *)view {
-    NSMapTable *cellObjectMap = self.visibleCellObjectMap;
-    id object = [cellObjectMap objectForKey:view];
-    [cellObjectMap removeObjectForKey:view];
+    NSMapTable *viewObjectMap = self.visibleViewObjectMap;
+    id object = [viewObjectMap objectForKey:view];
+    [viewObjectMap removeObjectForKey:view];
     return object;
 }
 
@@ -48,7 +48,7 @@
     IGParameterAssert(object != nil);
     IGParameterAssert(indexPath != nil);
 
-    [self.visibleCellObjectMap setObject:object forKey:view];
+    [self.visibleViewObjectMap setObject:object forKey:view];
     NSCountedSet *visibleListSections = self.visibleListSections;
     if ([visibleListSections countForObject:sectionController] == 0) {
         [sectionController.displayDelegate listAdapter:listAdapter willDisplaySectionController:sectionController];

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -1051,4 +1051,34 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     [mockDisplayDelegate verify];
 }
 
+- (void)test_whenWillDisplaySupplementaryView_thatCollectionViewDelegateReceivesEvents {
+    // silence display handler asserts
+    self.dataSource.objects = @[@1, @2];
+    [self.adapter reloadDataWithCompletion:nil];
+    
+    id mockDelegate = [OCMockObject mockForProtocol:@protocol(UICollectionViewDelegate)];
+    self.adapter.collectionViewDelegate = mockDelegate;
+    UICollectionReusableView *view = [UICollectionReusableView new];
+    NSString *kind = @"kind";
+    NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:0];
+    [[mockDelegate expect] collectionView:self.collectionView willDisplaySupplementaryView:view forElementKind:kind atIndexPath:path];
+    [self.adapter collectionView:self.collectionView willDisplaySupplementaryView:view forElementKind:kind atIndexPath:path];
+    [mockDelegate verify];
+}
+
+- (void)test_whenEndDisplayingSupplementaryView_thatCollectionViewDelegateReceivesEvents {
+    // silence display handler asserts
+    self.dataSource.objects = @[@1, @2];
+    [self.adapter reloadDataWithCompletion:nil];
+
+    id mockDelegate = [OCMockObject mockForProtocol:@protocol(UICollectionViewDelegate)];
+    self.adapter.collectionViewDelegate = mockDelegate;
+    UICollectionReusableView *view = [UICollectionReusableView new];
+    NSString *kind = @"kind";
+    NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:0];
+    [[mockDelegate expect] collectionView:self.collectionView didEndDisplayingSupplementaryView:view forElementOfKind:kind atIndexPath:path];
+    [self.adapter collectionView:self.collectionView didEndDisplayingSupplementaryView:view forElementOfKind:kind atIndexPath:path];
+    [mockDelegate verify];
+}
+
 @end

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -997,4 +997,58 @@ XCTAssertEqual(CGPointEqualToPoint(point, p), YES); \
     XCTAssertEqual(self.collectionView.contentOffset.y, 280);
 }
 
+- (void)test_whenDisplayingSectionController_withOnlySupplementaryView_thatDisplayEventStillSent {
+    self.dataSource.objects = @[@0];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+
+    IGTestSupplementarySource *supplementarySource = [IGTestSupplementarySource new];
+    supplementarySource.collectionContext = self.adapter;
+    supplementarySource.supportedElementKinds = @[UICollectionElementKindSectionHeader];
+
+    IGListSectionController<IGListSectionType> *controller = [self.adapter sectionControllerForObject:@0];
+    controller.supplementaryViewSource = supplementarySource;
+    supplementarySource.sectionController = controller;
+
+    id mockDisplayDelegate = [OCMockObject mockForProtocol:@protocol(IGListDisplayDelegate)];
+    [[mockDisplayDelegate expect] listAdapter:self.adapter willDisplaySectionController:controller];
+    [[mockDisplayDelegate reject] listAdapter:self.adapter willDisplaySectionController:controller cell:[OCMArg any] atIndex:0];
+
+    controller.displayDelegate = mockDisplayDelegate;
+
+    [self.adapter performUpdatesAnimated:NO completion:nil];
+    XCTAssertNotNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+
+    [mockDisplayDelegate verify];
+}
+
+- (void)test_whenEndingDisplayOfSectionController_withOnlySupplementaryView_thatDisplayEventStillSent {
+    self.dataSource.objects = @[@0];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+
+    IGTestSupplementarySource *supplementarySource = [IGTestSupplementarySource new];
+    supplementarySource.collectionContext = self.adapter;
+    supplementarySource.supportedElementKinds = @[UICollectionElementKindSectionHeader];
+
+    IGListSectionController<IGListSectionType> *controller = [self.adapter sectionControllerForObject:@0];
+    controller.supplementaryViewSource = supplementarySource;
+    supplementarySource.sectionController = controller;
+
+    [self.adapter performUpdatesAnimated:NO completion:nil];
+    XCTAssertNotNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+
+    id mockDisplayDelegate = [OCMockObject mockForProtocol:@protocol(IGListDisplayDelegate)];
+    [[mockDisplayDelegate expect] listAdapter:self.adapter didEndDisplayingSectionController:controller];
+    [[mockDisplayDelegate reject] listAdapter:self.adapter didEndDisplayingSectionController:controller cell:[OCMArg any] atIndex:0];
+
+    controller.displayDelegate = mockDisplayDelegate;
+
+    controller.supplementaryViewSource = nil;
+    [self.adapter performUpdatesAnimated:NO completion:nil];
+    XCTAssertNil([self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]]);
+
+    [mockDisplayDelegate verify];
+}
+
 @end

--- a/Tests/IGListDisplayHandlerTests.m
+++ b/Tests/IGListDisplayHandlerTests.m
@@ -176,7 +176,6 @@
     [self.mockAdapterDelegate verify];
 }
 
-
 - (void)test_whenCellInserted_withDisplayedCellExistingAtPath_thatDisplayHandlerReceivesCorrectParams {
     // simulate first cell appearing in the collection view
     NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:0];

--- a/Tests/IGListDisplayHandlerTests.m
+++ b/Tests/IGListDisplayHandlerTests.m
@@ -198,4 +198,51 @@
     [self.mockDisplayDelegate verify];
 }
 
+- (void)test_whenWillDisplaySupplementaryView_withCellDisplayedAfter_thatDisplayHandlerReceivesOneEvent {
+    NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:0];
+    UICollectionReusableView *view = [UICollectionReusableView new];
+    UICollectionViewCell *cell = [UICollectionViewCell new];
+
+    self.list.displayDelegate = self.mockDisplayDelegate;
+    self.adapter.delegate = self.mockAdapterDelegate;
+
+    [[self.mockDisplayDelegate expect] listAdapter:self.adapter willDisplaySectionController:self.list];
+    [[self.mockAdapterDelegate expect] listAdapter:self.adapter willDisplayObject:self.object atIndex:path.section];
+
+    [self.displayHandler willDisplaySupplementaryView:view forListAdapter:self.adapter sectionController:self.list object:self.object indexPath:path];
+    
+    [self.mockDisplayDelegate verify];
+    [self.mockAdapterDelegate verify];
+
+    [[self.mockDisplayDelegate expect] listAdapter:self.adapter willDisplaySectionController:self.list cell:cell atIndex:path.item];
+    [[self.mockAdapterDelegate reject] listAdapter:self.adapter willDisplayObject:self.list atIndex:path.item];
+    [[self.mockDisplayDelegate reject] listAdapter:self.adapter willDisplaySectionController:self.list];
+
+    [self.displayHandler willDisplayCell:cell forListAdapter:self.adapter sectionController:self.list object:self.object indexPath:path];
+}
+
+- (void)test_whenEndDisplayingSupplementaryView_withEndDisplayingTwice_thatDisplayHandlerReceivesOneEvent {
+    NSIndexPath *path = [NSIndexPath indexPathForItem:0 inSection:0];
+    UICollectionReusableView *view = [UICollectionReusableView new];
+
+    [self.displayHandler willDisplaySupplementaryView:view forListAdapter:self.adapter sectionController:self.list object:self.object indexPath:path];
+
+    [[self.mockDisplayDelegate expect] listAdapter:self.adapter didEndDisplayingSectionController:self.list];
+    [[self.mockAdapterDelegate expect] listAdapter:self.adapter didEndDisplayingObject:self.object atIndex:path.section];
+
+    [[self.mockDisplayDelegate reject] listAdapter:self.adapter didEndDisplayingSectionController:self.list];
+    [[self.mockDisplayDelegate reject] listAdapter:self.adapter didEndDisplayingSectionController:self.list cell:[OCMArg any] atIndex:path.item];
+    [[self.mockAdapterDelegate reject] listAdapter:self.adapter didEndDisplayingObject:self.object atIndex:path.section];
+
+    self.list.displayDelegate = self.mockDisplayDelegate;
+    self.adapter.delegate = self.mockAdapterDelegate;
+    //first call
+    [self.displayHandler didEndDisplayingSupplementaryView:view forListAdapter:self.adapter sectionController:self.list indexPath:path];
+    //second call
+    [self.displayHandler didEndDisplayingSupplementaryView:view forListAdapter:self.adapter sectionController:self.list indexPath:path];
+
+    [self.mockDisplayDelegate verify];
+    [self.mockAdapterDelegate verify];
+}
+
 @end


### PR DESCRIPTION
This was a little bit of an invasive change with the display handler, but I think that this is the right call. When sending display events for objects, we should account for the supplementary view as part of the section controller. This is especially useful for headers and footers.

Note that this wont effect the working range API at all.

Fixes #300