### PR TITLE
Vertical UICollectionViewLayout supporting inline sections (take 2)

### DIFF
--- a/Examples/Examples-iOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,86 +7,88 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02538AD450DD078DE24C22B03CA856D7 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3474A2DD0EFBC2D80CA54B8964FF36C1 /* IGListDisplayHandler.m */; };
-		0516BDDE5DB0048ECFFEC0EC8ACE404F /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = E58D9C9EFA3CB0E5A7A9B6E78270D613 /* UICollectionView+IGListBatchUpdateData.m */; };
-		06E48130C61B46DD674D2D6BFC11901D /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = 45A488444D3E4C30D596D2E59667E2E7 /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B8647DEC498B2E89EE01BEB006275D6 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 9E6D1448395A3825AB772744AD44885D /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E45609BB284A81673F917EFA1C79F00 /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = F194BE184048FF1EECA6FE4826E89DBD /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E4EF7D9F292CE93E8253E29728D6DC7 /* IGListSectionType.h in Headers */ = {isa = PBXBuildFile; fileRef = FC3B4AFAC77A68C8D85528505D738FE9 /* IGListSectionType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E77DF509A11BEA2B4FC9096323B57A1 /* IGListGridCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 149A38753F3483410BBC4FC831B3CF57 /* IGListGridCollectionViewLayout.m */; };
-		0F2729D06BF400CF3E8590E67608EA2D /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 437D3F32477ED0F197276F74F7BCF5F9 /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		10F9438B40D41F2BEDC9B5D474B4F184 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 616BEB51ECCAD129BDBCB7A956B56CC6 /* Foundation.framework */; };
-		11BB692868610B1C1A89053F713C4236 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 973C0111567909ABEC4F9E595938270D /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1871E1D447E0C147C84B1BB5AB2A8289 /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = FC34577174C0EACD1AE1DFDC35A2401B /* IGListAdapterUpdater.m */; };
+		01D960147A50B0AD89063323798E95A5 /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D541476B839EBDCCB7707E90F95824C9 /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06F8E88488FE810B9E172CFE33ED41F7 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 007CD14840FF786EC7E8AD6CD9DDE8C2 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0C92682C2F3006D7850E1ED5BD76B866 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = F0F0D86BE08A0360D4E8CD65175AB917 /* IGListAdapterProxy.m */; };
+		15EBEE41EB35F173F1223522B0361668 /* IGListStackedSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 523D60563CFBF708BA49A5F8BC4542A2 /* IGListStackedSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18C83DBC6EE5A90364983B388CD9F9AA /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D4623AB557C67C59E26579977C08917 /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A89AF7CCCD65D9D5B946363776D05AE /* Pods-IGListKitExamples-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A8E514E9DA595A3527E8C938A6CAEB1E /* Pods-IGListKitExamples-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		20C776592B599DACFBEA25CEBE2BD5B5 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C18B1B5A77AE27443F1161960638FBF /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C2747A131B2BF3C9FF512B68597998B /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = EF27BC1D2E5D17F4B1540CDACD6D96E8 /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CB9FF8EE402C8EE978F7827538982C0 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 32A1DD1DF7F87BC0F1D8B71D32A4610A /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3EFBC9584ED9BDA7DA02206B4A1BE3D7 /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86A47A3867E32653663D543FFA238B66 /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		4083D1A227353B9CEA104788D83D4BA4 /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 66BCC337218B28E039E7622C2FDC7557 /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4087748A7E033F7B113F008696F10100 /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = F8D2BE56328DBC118F72FA48C54744E5 /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1B58DD85CAB309DFD10AC8371784C1C6 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 27C7946695CF383F60B180D3E1E25F39 /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF9D4830CFC408E66D65D49271A47CE /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 563BC3BA9D8E7B1A46267CC7F9858BB8 /* IGListReloadDataUpdater.m */; };
+		1C9880BCCC1110014B8977006A2671A4 /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B2D0233D5EFB5C872CE626C51CAC55D /* IGListKit-dummy.m */; };
+		24671B7BB1B273DDF93C0F84436FE83F /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = E71F9961B7B176987D477ADAB574FD72 /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A7A79F69BE70FF3E26E5B5F1E6D9389 /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38302CBFD52834AEAE52C181445E0969 /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D71A0E1CE80BD6382B43803D93E7A0B /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = B17A8809A55BE2B46A542858C913F546 /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31C48B86CE9E325FCB4FB69A87494105 /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FD1790AD6E2CBAD69EF5F77D8878F9E /* IGListMoveIndex.m */; };
+		320A1C4C3413EB1AA898DBBC513A1F35 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 96DA04F35F0621FB8E5203BD488D7986 /* IGListDisplayHandler.m */; };
+		38D672CA93D1AE1EAB3F89212B5B7D40 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = D76B4AC988CFD788DCE9EB2F35FE3347 /* IGListDiff.mm */; };
+		3CCA6A6721A6CC5F13A5CE7886C08C4D /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1380ACDA4B11A7EC148A8781933A5DE0 /* IGListSingleSectionController.m */; };
+		3DA7F209EFA56B0FE51B2D2F74A764F4 /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD6613F5C1050ECA7A566DAD5021497 /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4441ECCCE547C6118B7AD035DF7B28D6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 616BEB51ECCAD129BDBCB7A956B56CC6 /* Foundation.framework */; };
-		484458D2F230B607F24B61470F484B73 /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 99DAC1DACF3D9B8B953D89F250392A97 /* IGListSingleSectionController.m */; };
-		4D7AC944906022E9C1CA8CA31705D5D8 /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = A0464AF7C9464A4BF23ABC042FF52E85 /* IGListSectionMap.m */; };
+		4502A5A9A265E5A901223721FE3FD45B /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FE8592FBEB9DC4A6E4A08610E5D52283 /* IGListIndexSetResult.m */; };
+		49E2D0633E49EFDF5E81CEF258D6FA9F /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 64053C4B797AD59DC4FAD139773770D6 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D6885C5F1380275DDF40178E0170014 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 60FA236E400942885D16B1CC58A232E7 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D91C3E61B324897958DCE8965EC0D86 /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = F53B11F32F27AD82E9F3BECC5753B5E2 /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DC076C43C4AA5A3C88EEC49F5097581 /* Pods-IGListKitMessageExample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B2806858B5ED353CF2D8B37BFAE4171C /* Pods-IGListKitMessageExample-dummy.m */; };
-		5049064A9255B5B681AE820BF054CF18 /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = B5C4899828474D4672DCD4ED732C44DA /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		517439F690B63858DFF5104AF8DAAB58 /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D62857279428D46468E4514C858CCCE /* IGListMoveIndex.m */; };
+		4F7F4F7BB3D07B3A9DE3E0858B02F63C /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C086829337C7DD6374184979AB83B11 /* IGListCollectionViewLayout.mm */; };
 		521D101EE7EF9C5A5B7D92BCCEF1A5BB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 616BEB51ECCAD129BDBCB7A956B56CC6 /* Foundation.framework */; };
-		56BC154A684A2CE83B207A7A79B2AA79 /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 623530BAAE53E0498F40FF5643E68D03 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		580A85CE009B9B1B19E2FEAF5446FE19 /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = FB66656E7E1D0A20CF22FBA7BBD64F85 /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A8A597D0274374C6C283294A5E99EA7 /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = FDEFF9D44CF56743F4F14151C2C42426 /* IGListWorkingRangeHandler.mm */; };
-		5C490928BABB0EF533E0E54CD4A0102D /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 46CB3DC86D72062BDCDD5156E2CC1BAD /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5E2452BF11067A611340CB9C654037D1 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BB792552EF8843679311A49564E1E1 /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63F2505138750A7498D3C948AFCCCD23 /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 479B17E3CE9E2FA31D12375164698567 /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E05E9BFD9B91DB07DCCB2CD8B18CDC3 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 59E8EC874B990948E73E650DB37477CC /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E47CEDB94A176B0CB142CA479DFEDB2 /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AC1734AD455F39EF4B49F5E224AAD53 /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		70F593265D74E691B47D4EBE8536517E /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = DED8A8B0486FDA758CAD0BEAB83EA95F /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7201CDE3182F7CCAA0D9EDAA5346EB00 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = CA1535DE686A69C69B513A561FC02516 /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		734D0DD10CA2837A43EFF5929B63CC38 /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 76FAFA532584EF262276772345D9DC4C /* NSString+IGListDiffable.m */; };
-		73B92B0EC06263755BA5960BC8A65B02 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CD4699F62A4900F2E29B6888FF51B2C /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		76B1E85B1B2AE0BF0F3EFE20E96D65CA /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 170E77C17F016E872ED9CCCBE86197BC /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81F1C424E560910B109D4BB6ECBE2EC6 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B4975E02606CFC350EBA563444B0EDA /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		83D4E09F31A387ADCDE669B3185B8849 /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 760700BE1D1EB3C0933CE198882E155B /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		86C91F3A89F9683BA3A8F5AA54E8AA08 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = D163104286844FCF5DDA6FE4AD25280F /* IGListDiff.mm */; };
-		8894FBD9663EE633E6B19497BB6FDBD0 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = EF033C31ACBB393122D6B69FF9DF0928 /* IGListBatchUpdateData.mm */; };
-		89CB98DBDE68549E708D91862247F905 /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = AE3C53F655C7BA38BA03398173503B81 /* NSNumber+IGListDiffable.m */; };
-		8D3C2055830CBB009FD573A573EE81B2 /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = A1718D4D1AA43835D06443E7BC37A254 /* IGListAdapter.m */; };
-		8E1D2B5ED4785D929E6C6886ED21DA15 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BFE3F67D2A2DE42E042EEEF009B924A /* IGListAdapterProxy.m */; };
-		968D6E4549F53AB3151B434AE102711B /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E05417E0198793F136BDDDEF7BC18948 /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97682876C9B6181D19D746AE3C2278F4 /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 809D4D4F95847C671ECC1826108B121C /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		984C2F0951A593458769BBFD5C845B96 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A758DF5D1AD164EDDC65D5CAC4CD34 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9ABE87D3484334FD79EDD6FABE32EAAC /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B93BF9BE09FDC2BCE22C9C93FD982CB /* IGListMoveIndexPath.m */; };
-		A524BD6FA5B85CB1839A10ADA68ACE77 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = D2C6B1F15ACE47288C4EC2DC85D1CA76 /* IGListIndexPathResult.m */; };
-		AC5FA1790BCB08D8BE6CF6124FF300C0 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E2748CA379DCBB1629ED26423FAE70A7 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		522742C0B97521E0633735AD6532B482 /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = C06B8DE68EE4471F5EE4C9BABC0FE87D /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		52A165DB4F13E4B383D1F9B8E725716D /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 038013D514A1854C7BB8A5E1E0383DBE /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55C2E3F3FA5E34475A161E1E150C7550 /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F39646F30DD551ED9A4979D513CA4958 /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		577C8C904DDB755609EEDA5ABEF3025D /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B7B68693081EFC6ED277E99674BD2AE /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5921F3BF43B02C6C9FD1612FA4D69FDB /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4127C35F50D6467B19CE522B90A50BFA /* IGListAdapter.m */; };
+		5BA3992DFE1D781FC63FE6DA01FA9A94 /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F29F8A5D216D9EEF9D82060F5B06810 /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5F3BD5B484A8FE2554BD1FACEE219516 /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 9894E767D495C11A93244B229495BA16 /* IGListSectionMap.m */; };
+		684E29407CC45D82238936D271F817B5 /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = E008556D74E9DFCDB57437E2FBDAE70E /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69BE65435B8C06B8D7BB2432CD42CEFE /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 482B69229E7DAC666D1463F3576E98ED /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69DBA1085FB0EC6401FF67947EB47451 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5179581402D4978BE620F88728CC9EEF /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6BFB986E530B6684679742EF2AEA2D8D /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 57986540EDFA0C908FD91C4751B9D16E /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DD3C165ACE9D427248805159BBFDEF6 /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 06E5980D2B4CA19F0BB013572F92F9F1 /* NSString+IGListDiffable.m */; };
+		7025B5FD1E713D99EB130037FDD9920A /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 99B3350B7764EF0CD5D8CECDB6CED56C /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		707397172DA3CAFA8E0935B4E9BB5C94 /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D6C9CEB4A46FB3810BE348030BC804F /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74AC5B625D916B9901881A951510E87C /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC0F5BC5190AD44D8A5D3158F2675E39 /* IGListWorkingRangeHandler.mm */; };
+		752376C890CF4BAB2F04C29F343C51A0 /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC02DA7BF6C70969ABB28FF9E443273 /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AF1A995D99680AE42E9827F3938AFA3 /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62F45A4E061FAE66F50E25BB14BD337C /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7D5CE5E55109BF2D2E72F4DC4418E4EE /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 62C9393B5198E696E44FBEEE3E9D8A04 /* IGListAdapterUpdater.m */; };
+		7EA100A6EAEBB641FA6FCFF32C35E36D /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = EB462594F4EE05E99D8E3400A9E21E84 /* IGListGridCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		802D9E93BF6999351D7410DB58D55BDE /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F674CC9F81D4EAE5B8F7391F5AE65B5 /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A08F7FC9BC02D22D544D8F3B58ACC09 /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E3969BE68622EDB983721F131EABA51 /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94F5112620D580A88C0A0E495871AFD5 /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 397BDE6BE132E18BCEC7962674692D46 /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9939E6F72560E556DBBC193523EA1565 /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 21615F3D9DCC5260312EBDBE25FF791C /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9942D193832F197046B2606FC0DF8B4D /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 25BDE272AEE5CF850E5AA432D7166C96 /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99CAC417EE670DC893C2EF2CD1ABB618 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = A6AC86CA2031A234EF8A2E542289FC1C /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99DFF77291442C1EF8A473DA65A028D3 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EC994CDC2D681BA26389F78A7E4B325 /* UIKit.framework */; };
+		A7076D98D4A84CF84A7D1114435E08C2 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 594D84B7ECEC395242AE02F6A1A99F5F /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB27911ABADEC8A211A2A71223901F37 /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 09413730A9D64C2187472F52BAC1FC64 /* NSNumber+IGListDiffable.m */; };
+		B4247B838DEB8037E98E0171BC46CFA3 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = ACCE0225FC713111C5679C81283FA790 /* IGListBatchUpdateData.mm */; };
+		B5B4C2CD7C6D966C2A7791D4C94347D6 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D89618155F341C355FE614B37C6D16 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B718064EE1D4B6E9B8212A936CA8EA75 /* Pods-IGListKitTodayExample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 60C3700A55A1751BE6C71BAEBADD7E7A /* Pods-IGListKitTodayExample-dummy.m */; };
 		B737133A4230ACB664806CF20F03FAD1 /* Pods-IGListKitTodayExample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3709B01F4A8953783FFACB86C3D0CE15 /* Pods-IGListKitTodayExample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BC3054D66CE4FA6E84CE82C696F446FA /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CE75DA4021EEECE4B725496154A1B82 /* IGListCollectionView.m */; };
-		C0265ABA36762C82F6338723A465F61E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EC994CDC2D681BA26389F78A7E4B325 /* UIKit.framework */; };
+		B74CE62D05C4BF0B09D8D6F47C117D2C /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = F9E11EBF9FAD302321BFF4ED169D446C /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B913048F3FEFBCF8E92DF4FEC2327D08 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 107BB6A5158CDDD83AFFCE5CD5AFF561 /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC084214AE6061F593784CFBB66226DF /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E8A886E845A5D11E528AA6E0C712E2C /* IGListCollectionView.m */; };
+		C27A53137529E6E1523E25E1472B0D77 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D30748A6212C6F8312F054C01695750 /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C36489FE69B295502E1CD6D943E332E4 /* IGListGridCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 7923F491D78CBBEC0C299BDCA15B79F4 /* IGListGridCollectionViewLayout.m */; };
 		C4C4C1B02AFD7277F00A40570658152C /* Pods-IGListKitExamples-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5CE5A84B8F2E7646B7E32B1F54007D /* Pods-IGListKitExamples-dummy.m */; };
-		C506D8A24A14D01EEC1BE8CE7CD2C164 /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 0649342E621753776E9D8FC495CA9F27 /* IGListGridCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CA1A85850EE450CD49CBD54E595577A6 /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 115B584D90D1BB4A3F8F9DD991D4B0F4 /* IGListSectionController.m */; };
-		CCA6CB8E8819B9D032B90F3CD0015550 /* IGListStackedSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 436B138446F1B9CD983855D18CF2B53C /* IGListStackedSectionController.m */; };
-		CE6A0032D5362E3EEE3CBF08FAB8CCD5 /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C90612ABE05D39FA23544371C674E81 /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CFFF332D28FB693561D6D2DDAE8B7EF6 /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9927E33F639FCE21AE92766AC127B909 /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D099903FB310D5A12B23B3A43BCCED8D /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 2009EB38BF6EB4C980D61AB4614894A9 /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D21C7CE8688679FB2B5159BE89958B22 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 616BEB51ECCAD129BDBCB7A956B56CC6 /* Foundation.framework */; };
-		D44A1AE4A2AD83B4D81015DA09F35450 /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B209AB6A816AD4426B79C12BFACB791 /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5DB2A7D796C1EA166A4D719D785FECF /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CAFAD20DCEA25457B0CB34D4AB91B0D7 /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D78A53EA678B4828CD033E20D8084292 /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 76103495A13E89B0A806236D8B2EC60C /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D922D112237DBFE7C3FAC62DF2D07F3D /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3B2D0233D5EFB5C872CE626C51CAC55D /* IGListKit-dummy.m */; };
-		DFAACC0AF49FAE11E092F2EA2C35D48E /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 76FC7798B67EB39486764BC9D5B75B42 /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E230A3E09D2E48BCF7EB60F565F18690 /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B5038D622E0FD1FF5C618669743C0A2 /* IGListIndexSetResult.m */; };
+		D2BE741EE63C36C4BDD3F50507FEB5E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 616BEB51ECCAD129BDBCB7A956B56CC6 /* Foundation.framework */; };
+		D351299A0B6FABFD60835D26A071934A /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F75839327A3FC6DCFF60F95127B2F544 /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D53CE6BFDE81C2849E2D655816D40D83 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = C3C618C76DF0511336959278B00D496D /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6BC5A25B977372C1795830B2FE80BB7 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FD7763164C2BA94D0D59DAE9CD2E083 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBCF13DA01CA7B8E23EC60436A9B54CF /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DA9A6DBD20676788CB0568CDE94256A /* IGListSectionController.m */; };
+		DE95203F33CB5EE5DF5F9671BA6CBA26 /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = D01EC818FA6B15FF713362350793ADE9 /* IGListMoveIndexPath.m */; };
 		E353B40949D9675B8B2B03C7569F96F5 /* Pods-IGListKitMessageExample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5566AE25970A51436D6E32AE60BE5E87 /* Pods-IGListKitMessageExample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3F3D0B97462F6EBAD13EA91F0F6212A /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A4CB34DE558A070DC4B39B45377EF4 /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E860594EC0FAF157159C0C0DAE33C6BA /* IGListStackedSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 25935E7FC2F5908FC21DC3E32333A9F1 /* IGListStackedSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EC4BD0B3B63D7B876AB2FB2035F82E61 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C99BEB9FCE7C1DDFA618B44541C7E5C0 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ED4C4D8C79179EF7D0F7A9D6A78B3028 /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EC54C40D53368520151851056C3040 /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ED97249B08390763C07ECA48A6C2089E /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = FE818A58D20171396C3BCE9707079537 /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F376B87428013B5FB2AC705A90E084A2 /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D7B45D73ED6E8DB34A85221717E37C5C /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F41FEEE5690485539BCAC553974FE6A7 /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 482B69229E7DAC666D1463F3576E98ED /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F42CD0C401C2B1D2B183535DA794302B /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 67B5038DA275A8077E443CBA4B4F5900 /* IGListReloadDataUpdater.m */; };
-		F822A5D8EF3791FACBE74C754D579489 /* IGListStackedSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 138F4F27D60FA07F60E7CC6AC0729890 /* IGListStackedSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F8CEF7EE893CEBE0F01D3D6F91DC1FD2 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 91ED6CD3D3F1DE558DDA5EEEE30F725E /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E46248A5BA890CF52B2D99D22E80EB78 /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 192DEA0DB1ACE440C834607A7CF4CF0B /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E469EB08F12FCD2777918299B5CC8EEB /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = D08280C80ED23650988759D725955C42 /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E894EDACBC44D5909E6191181C7100B7 /* IGListStackedSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DA0D300B7C9A06B33151AFE3583408B5 /* IGListStackedSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EAD4262C7C09BD4E217D6E40D1A68655 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FE9537AF75299E876FEDC9559872EB8 /* IGListIndexPathResult.m */; };
+		F02EC7E844F17A792A7A47B2ED54810D /* IGListSectionType.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BC744C3B9DB1FFC1EACB3778CE9B238 /* IGListSectionType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F952415DF594C60359C82BA2B3CE3E00 /* IGListStackedSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D8BDDDB6FEEAAAD815FC74FC628363F /* IGListStackedSectionController.m */; };
+		FAADDDFD575939F342DC0EB33C46102E /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B59D5AE3A62A2FFEB60845A0F952AB9B /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FABBE08E7C27E02F72B072CF42FD9619 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = C13E7AFD4D3A4DE811FEA37ED3C51788 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB1BF9A9C0ABAD993CEF66EDABFDCD71 /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = 77020C5424C48F544B6285E8B07B9ABC /* UICollectionView+IGListBatchUpdateData.m */; };
+		FBAE002D5D392B1C0B1513758CAC2F95 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = CBF111A0B1CFDC94A3F16694031ACFDB /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC2AD36A65985DF0B6039CDFDDD495D2 /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B389B8E5BC779507885D93445D9D53D /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -94,143 +96,145 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9CE1FC57ED556647A09C53464FF9EB5A;
+			remoteGlobalIDString = C8FFE709A50B36A8E6CEEFA81A6E808D;
 			remoteInfo = IGListKit;
 		};
 		7D332B346FFC0D5E5159546D185DAFEF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9CE1FC57ED556647A09C53464FF9EB5A;
+			remoteGlobalIDString = C8FFE709A50B36A8E6CEEFA81A6E808D;
 			remoteInfo = IGListKit;
 		};
 		A0A5426482C447F640D6A192E71D5F5B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9CE1FC57ED556647A09C53464FF9EB5A;
+			remoteGlobalIDString = C8FFE709A50B36A8E6CEEFA81A6E808D;
 			remoteInfo = IGListKit;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0649342E621753776E9D8FC495CA9F27 /* IGListGridCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListGridCollectionViewLayout.h; sourceTree = "<group>"; };
-		0D62857279428D46468E4514C858CCCE /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
+		007CD14840FF786EC7E8AD6CD9DDE8C2 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
+		038013D514A1854C7BB8A5E1E0383DBE /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdater.h; sourceTree = "<group>"; };
+		06E5980D2B4CA19F0BB013572F92F9F1 /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
+		09413730A9D64C2187472F52BAC1FC64 /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
+		0D30748A6212C6F8312F054C01695750 /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
 		0E9E68D2900796EE8622487D6254AC9C /* Pods-IGListKitExamples-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitExamples-frameworks.sh"; sourceTree = "<group>"; };
-		115B584D90D1BB4A3F8F9DD991D4B0F4 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionController.m; sourceTree = "<group>"; };
+		0F29F8A5D216D9EEF9D82060F5B06810 /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
+		107BB6A5158CDDD83AFFCE5CD5AFF561 /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
 		116948205344E279070B2977E925F803 /* IGListKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = IGListKit.framework; path = IGListKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		138F4F27D60FA07F60E7CC6AC0729890 /* IGListStackedSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionController.h; sourceTree = "<group>"; };
-		149A38753F3483410BBC4FC831B3CF57 /* IGListGridCollectionViewLayout.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListGridCollectionViewLayout.m; sourceTree = "<group>"; };
-		170E77C17F016E872ED9CCCBE86197BC /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
+		1380ACDA4B11A7EC148A8781933A5DE0 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSingleSectionController.m; sourceTree = "<group>"; };
+		192DEA0DB1ACE440C834607A7CF4CF0B /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
 		1B2E0BC65B098972E1E94F970F834DA0 /* Pods-IGListKitTodayExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-IGListKitTodayExample.modulemap"; sourceTree = "<group>"; };
-		1C90612ABE05D39FA23544371C674E81 /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
-		1CD4699F62A4900F2E29B6888FF51B2C /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
-		2009EB38BF6EB4C980D61AB4614894A9 /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadDataUpdater.h; sourceTree = "<group>"; };
+		1B7B68693081EFC6ED277E99674BD2AE /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
+		1D6C9CEB4A46FB3810BE348030BC804F /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
+		1D8BDDDB6FEEAAAD815FC74FC628363F /* IGListStackedSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListStackedSectionController.m; sourceTree = "<group>"; };
 		20D642EAE3662BDC17956017E6D622E8 /* Pods-IGListKitMessageExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitMessageExample-acknowledgements.markdown"; sourceTree = "<group>"; };
-		25935E7FC2F5908FC21DC3E32333A9F1 /* IGListStackedSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionControllerInternal.h; sourceTree = "<group>"; };
+		21615F3D9DCC5260312EBDBE25FF791C /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionContext.h; sourceTree = "<group>"; };
+		25BDE272AEE5CF850E5AA432D7166C96 /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayout.h; sourceTree = "<group>"; };
 		2698205F5C5CB69B82E6AC7C1D7E9519 /* Pods-IGListKitExamples-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitExamples-resources.sh"; sourceTree = "<group>"; };
 		270C1C7FCBA7F319FD7A0398BC18710F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		32A1DD1DF7F87BC0F1D8B71D32A4610A /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDelegate.h; sourceTree = "<group>"; };
-		3474A2DD0EFBC2D80CA54B8964FF36C1 /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
+		27C7946695CF383F60B180D3E1E25F39 /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDelegate.h; sourceTree = "<group>"; };
+		2E3969BE68622EDB983721F131EABA51 /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadDataUpdater.h; sourceTree = "<group>"; };
 		3546419AAFB29CE358FDE5691F031F9E /* Pods_IGListKitTodayExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitTodayExample.framework; path = "Pods-IGListKitTodayExample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3709B01F4A8953783FFACB86C3D0CE15 /* Pods-IGListKitTodayExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitTodayExample-umbrella.h"; sourceTree = "<group>"; };
-		3B209AB6A816AD4426B79C12BFACB791 /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
+		38302CBFD52834AEAE52C181445E0969 /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayDelegate.h; sourceTree = "<group>"; };
+		397BDE6BE132E18BCEC7962674692D46 /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
 		3B2D0233D5EFB5C872CE626C51CAC55D /* IGListKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListKit-dummy.m"; sourceTree = "<group>"; };
-		3B93BF9BE09FDC2BCE22C9C93FD982CB /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
-		3BFE3F67D2A2DE42E042EEEF009B924A /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
+		3C086829337C7DD6374184979AB83B11 /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
+		3D4623AB557C67C59E26579977C08917 /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
 		3DFBEA9D0D85DB9366D3C949C20332DD /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitExamples.framework; path = "Pods-IGListKitExamples.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		436B138446F1B9CD983855D18CF2B53C /* IGListStackedSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListStackedSectionController.m; sourceTree = "<group>"; };
-		437D3F32477ED0F197276F74F7BCF5F9 /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
-		45A488444D3E4C30D596D2E59667E2E7 /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
-		46CB3DC86D72062BDCDD5156E2CC1BAD /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionContext.h; sourceTree = "<group>"; };
-		479B17E3CE9E2FA31D12375164698567 /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
+		3F674CC9F81D4EAE5B8F7391F5AE65B5 /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
+		4127C35F50D6467B19CE522B90A50BFA /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapter.m; sourceTree = "<group>"; };
+		41D89618155F341C355FE614B37C6D16 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
 		47B8147DC6434174D9E3054DA3CB4484 /* Pods-IGListKitMessageExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-IGListKitMessageExample.modulemap"; sourceTree = "<group>"; };
 		482B69229E7DAC666D1463F3576E98ED /* IGListKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-umbrella.h"; sourceTree = "<group>"; };
+		4B389B8E5BC779507885D93445D9D53D /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionController.h; sourceTree = "<group>"; };
+		4E8A886E845A5D11E528AA6E0C712E2C /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListCollectionView.m; sourceTree = "<group>"; };
 		4F9A8086AF09CCA586431BFEE5DE2CA3 /* Pods-IGListKitMessageExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitMessageExample.debug.xcconfig"; sourceTree = "<group>"; };
+		5179581402D4978BE620F88728CC9EEF /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
+		523D60563CFBF708BA49A5F8BC4542A2 /* IGListStackedSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionController.h; sourceTree = "<group>"; };
 		5566AE25970A51436D6E32AE60BE5E87 /* Pods-IGListKitMessageExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitMessageExample-umbrella.h"; sourceTree = "<group>"; };
+		563BC3BA9D8E7B1A46267CC7F9858BB8 /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadDataUpdater.m; sourceTree = "<group>"; };
 		568FA20FCC9D77DF4FF3A77159CB66AA /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
+		57986540EDFA0C908FD91C4751B9D16E /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
 		57D6B0172E92F207DDCC38AA57BBD76C /* Pods_IGListKitMessageExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitMessageExample.framework; path = "Pods-IGListKitMessageExample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		59E8EC874B990948E73E650DB37477CC /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
-		5AC1734AD455F39EF4B49F5E224AAD53 /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
-		5B4975E02606CFC350EBA563444B0EDA /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionView.h; sourceTree = "<group>"; };
-		5C18B1B5A77AE27443F1161960638FBF /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
-		5CE75DA4021EEECE4B725496154A1B82 /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListCollectionView.m; sourceTree = "<group>"; };
+		594D84B7ECEC395242AE02F6A1A99F5F /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDataSource.h; sourceTree = "<group>"; };
 		5EC090A99FE4CA3786E651AF9C907913 /* Pods-IGListKitTodayExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitTodayExample.debug.xcconfig"; sourceTree = "<group>"; };
+		5FD7763164C2BA94D0D59DAE9CD2E083 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
 		60C3700A55A1751BE6C71BAEBADD7E7A /* Pods-IGListKitTodayExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitTodayExample-dummy.m"; sourceTree = "<group>"; };
+		60FA236E400942885D16B1CC58A232E7 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListScrollDelegate.h; sourceTree = "<group>"; };
 		616BEB51ECCAD129BDBCB7A956B56CC6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		623530BAAE53E0498F40FF5643E68D03 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
+		62C9393B5198E696E44FBEEE3E9D8A04 /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterUpdater.m; sourceTree = "<group>"; };
+		62F45A4E061FAE66F50E25BB14BD337C /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		64053C4B797AD59DC4FAD139773770D6 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
 		65A1389E308E5581D73D099A74A15628 /* Pods-IGListKitMessageExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitMessageExample.release.xcconfig"; sourceTree = "<group>"; };
-		66BCC337218B28E039E7622C2FDC7557 /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListKit.h; sourceTree = "<group>"; };
 		66BCE978937FA23EB0DDD5A64BBA1980 /* IGListKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-prefix.pch"; sourceTree = "<group>"; };
-		67B5038DA275A8077E443CBA4B4F5900 /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadDataUpdater.m; sourceTree = "<group>"; };
+		6BC744C3B9DB1FFC1EACB3778CE9B238 /* IGListSectionType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionType.h; sourceTree = "<group>"; };
 		6C792A2E75C47ACECE83DE04FE1F9F39 /* IGListKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListKit.modulemap; sourceTree = "<group>"; };
+		6DC02DA7BF6C70969ABB28FF9E443273 /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
+		6FD6613F5C1050ECA7A566DAD5021497 /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
 		7200C49C89FA68816227219403B87DBE /* Pods-IGListKitMessageExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitMessageExample-acknowledgements.plist"; sourceTree = "<group>"; };
-		760700BE1D1EB3C0933CE198882E155B /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
-		76103495A13E89B0A806236D8B2EC60C /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
-		76FAFA532584EF262276772345D9DC4C /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
-		76FC7798B67EB39486764BC9D5B75B42 /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
+		77020C5424C48F544B6285E8B07B9ABC /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
+		7923F491D78CBBEC0C299BDCA15B79F4 /* IGListGridCollectionViewLayout.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListGridCollectionViewLayout.m; sourceTree = "<group>"; };
 		7ACA5B41E2D11D0ECE0F0A2D8B3370D5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		7B5038D622E0FD1FF5C618669743C0A2 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
+		7DA9A6DBD20676788CB0568CDE94256A /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionController.m; sourceTree = "<group>"; };
 		7EC994CDC2D681BA26389F78A7E4B325 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		809D4D4F95847C671ECC1826108B121C /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayDelegate.h; sourceTree = "<group>"; };
-		86A47A3867E32653663D543FFA238B66 /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
-		86BB792552EF8843679311A49564E1E1 /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
-		91ED6CD3D3F1DE558DDA5EEEE30F725E /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
+		7FD1790AD6E2CBAD69EF5F77D8878F9E /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
 		922574DF06D0AD5E3964986609327D1F /* Pods-IGListKitTodayExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitTodayExample.release.xcconfig"; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9507E646FDB2D9764FC70560DD8DBEF2 /* Pods-IGListKitTodayExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitTodayExample-acknowledgements.markdown"; sourceTree = "<group>"; };
-		973C0111567909ABEC4F9E595938270D /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
-		9927E33F639FCE21AE92766AC127B909 /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
-		99DAC1DACF3D9B8B953D89F250392A97 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSingleSectionController.m; sourceTree = "<group>"; };
-		9E6D1448395A3825AB772744AD44885D /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSingleSectionController.h; sourceTree = "<group>"; };
-		A0464AF7C9464A4BF23ABC042FF52E85 /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
-		A0EC54C40D53368520151851056C3040 /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
-		A1718D4D1AA43835D06443E7BC37A254 /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapter.m; sourceTree = "<group>"; };
+		96DA04F35F0621FB8E5203BD488D7986 /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
+		9894E767D495C11A93244B229495BA16 /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
+		99B3350B7764EF0CD5D8CECDB6CED56C /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapter.h; sourceTree = "<group>"; };
+		9FE9537AF75299E876FEDC9559872EB8 /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
+		A6AC86CA2031A234EF8A2E542289FC1C /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
 		A72EA0FFEA9D25CBF9BD8F7F2CE9F2FE /* Pods-IGListKitExamples-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitExamples-acknowledgements.plist"; sourceTree = "<group>"; };
 		A8E514E9DA595A3527E8C938A6CAEB1E /* Pods-IGListKitExamples-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitExamples-umbrella.h"; sourceTree = "<group>"; };
-		AE3C53F655C7BA38BA03398173503B81 /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
+		ACCE0225FC713111C5679C81283FA790 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
+		B17A8809A55BE2B46A542858C913F546 /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
 		B2806858B5ED353CF2D8B37BFAE4171C /* Pods-IGListKitMessageExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitMessageExample-dummy.m"; sourceTree = "<group>"; };
-		B5C4899828474D4672DCD4ED732C44DA /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdater.h; sourceTree = "<group>"; };
+		B59D5AE3A62A2FFEB60845A0F952AB9B /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
 		B66E6B5AEB9406EAEFA9710E6E9962F2 /* Pods-IGListKitMessageExample-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitMessageExample-resources.sh"; sourceTree = "<group>"; };
+		BC0F5BC5190AD44D8A5D3158F2675E39 /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
 		BC1C46146C230C9011237AAC07BFBD9C /* Pods-IGListKitExamples.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-IGListKitExamples.modulemap"; sourceTree = "<group>"; };
-		C6A4CB34DE558A070DC4B39B45377EF4 /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapter.h; sourceTree = "<group>"; };
-		C6A758DF5D1AD164EDDC65D5CAC4CD34 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListScrollDelegate.h; sourceTree = "<group>"; };
+		C06B8DE68EE4471F5EE4C9BABC0FE87D /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
+		C13E7AFD4D3A4DE811FEA37ED3C51788 /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
+		C3C618C76DF0511336959278B00D496D /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSingleSectionController.h; sourceTree = "<group>"; };
 		C6A8BD108D2490E4BA19FA93AD18A83C /* Pods-IGListKitTodayExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitTodayExample-acknowledgements.plist"; sourceTree = "<group>"; };
-		C99BEB9FCE7C1DDFA618B44541C7E5C0 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
-		CA1535DE686A69C69B513A561FC02516 /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDataSource.h; sourceTree = "<group>"; };
 		CA234CE99FD05714C2A7AF7708B24C51 /* IGListKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IGListKit.xcconfig; sourceTree = "<group>"; };
-		CAFAD20DCEA25457B0CB34D4AB91B0D7 /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
+		CBF111A0B1CFDC94A3F16694031ACFDB /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionView.h; sourceTree = "<group>"; };
 		CDDAB8A20B8596ACE7CC916120EE2489 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D163104286844FCF5DDA6FE4AD25280F /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
-		D2C6B1F15ACE47288C4EC2DC85D1CA76 /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
-		D7B45D73ED6E8DB34A85221717E37C5C /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		D01EC818FA6B15FF713362350793ADE9 /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
+		D08280C80ED23650988759D725955C42 /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
+		D541476B839EBDCCB7707E90F95824C9 /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListKit.h; sourceTree = "<group>"; };
+		D76B4AC988CFD788DCE9EB2F35FE3347 /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
+		DA0D300B7C9A06B33151AFE3583408B5 /* IGListStackedSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionControllerInternal.h; sourceTree = "<group>"; };
 		DE5CE5A84B8F2E7646B7E32B1F54007D /* Pods-IGListKitExamples-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitExamples-dummy.m"; sourceTree = "<group>"; };
-		DED8A8B0486FDA758CAD0BEAB83EA95F /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
-		E05417E0198793F136BDDDEF7BC18948 /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		E008556D74E9DFCDB57437E2FBDAE70E /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
 		E1915F3ED5785508E2E252B0D5CD0AB9 /* Pods-IGListKitExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		E2748CA379DCBB1629ED26423FAE70A7 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
 		E37246CEB51FFBAABB027FA9502D3172 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E58D9C9EFA3CB0E5A7A9B6E78270D613 /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
+		E71F9961B7B176987D477ADAB574FD72 /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		EB462594F4EE05E99D8E3400A9E21E84 /* IGListGridCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListGridCollectionViewLayout.h; sourceTree = "<group>"; };
 		EC95D5B65CC92046D33001EC1BE7B9A3 /* Pods-IGListKitExamples-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitExamples-acknowledgements.markdown"; sourceTree = "<group>"; };
-		EF033C31ACBB393122D6B69FF9DF0928 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
-		EF27BC1D2E5D17F4B1540CDACD6D96E8 /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
 		EF77CF1069D312C499D2898F20FB8DC1 /* Pods-IGListKitTodayExample-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitTodayExample-resources.sh"; sourceTree = "<group>"; };
-		F194BE184048FF1EECA6FE4826E89DBD /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
-		F8D2BE56328DBC118F72FA48C54744E5 /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
-		FB66656E7E1D0A20CF22FBA7BBD64F85 /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
-		FC34577174C0EACD1AE1DFDC35A2401B /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterUpdater.m; sourceTree = "<group>"; };
-		FC3B4AFAC77A68C8D85528505D738FE9 /* IGListSectionType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionType.h; sourceTree = "<group>"; };
-		FDEFF9D44CF56743F4F14151C2C42426 /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
-		FE818A58D20171396C3BCE9707079537 /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionController.h; sourceTree = "<group>"; };
+		F0F0D86BE08A0360D4E8CD65175AB917 /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
+		F39646F30DD551ED9A4979D513CA4958 /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
+		F53B11F32F27AD82E9F3BECC5753B5E2 /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
+		F75839327A3FC6DCFF60F95127B2F544 /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
+		F9E11EBF9FAD302321BFF4ED169D446C /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
+		FE8592FBEB9DC4A6E4A08610E5D52283 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		676279F9D230F11E09570AE3DA250FC3 /* Frameworks */ = {
+		56774D8F74203FBD49A94FCFD02348AB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				10F9438B40D41F2BEDC9B5D474B4F184 /* Foundation.framework in Frameworks */,
-				C0265ABA36762C82F6338723A465F61E /* UIKit.framework in Frameworks */,
+				D2BE741EE63C36C4BDD3F50507FEB5E9 /* Foundation.framework in Frameworks */,
+				99DFF77291442C1EF8A473DA65A028D3 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,35 +265,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0ED844068328E1759E692A09212D3F42 /* Common */ = {
+		174B6E0AFB4CAA35EF5C95ADE27AD8ED /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				5AC1734AD455F39EF4B49F5E224AAD53 /* IGListAssert.h */,
-				623530BAAE53E0498F40FF5643E68D03 /* IGListBatchUpdateData.h */,
-				EF033C31ACBB393122D6B69FF9DF0928 /* IGListBatchUpdateData.mm */,
-				5C18B1B5A77AE27443F1161960638FBF /* IGListCompatibility.h */,
-				45A488444D3E4C30D596D2E59667E2E7 /* IGListDiff.h */,
-				D163104286844FCF5DDA6FE4AD25280F /* IGListDiff.mm */,
-				DED8A8B0486FDA758CAD0BEAB83EA95F /* IGListDiffable.h */,
-				3B209AB6A816AD4426B79C12BFACB791 /* IGListDiffKit.h */,
-				EF27BC1D2E5D17F4B1540CDACD6D96E8 /* IGListExperiments.h */,
-				170E77C17F016E872ED9CCCBE86197BC /* IGListIndexPathResult.h */,
-				D2C6B1F15ACE47288C4EC2DC85D1CA76 /* IGListIndexPathResult.m */,
-				479B17E3CE9E2FA31D12375164698567 /* IGListIndexSetResult.h */,
-				7B5038D622E0FD1FF5C618669743C0A2 /* IGListIndexSetResult.m */,
-				E2748CA379DCBB1629ED26423FAE70A7 /* IGListMacros.h */,
-				F194BE184048FF1EECA6FE4826E89DBD /* IGListMoveIndex.h */,
-				0D62857279428D46468E4514C858CCCE /* IGListMoveIndex.m */,
-				76FC7798B67EB39486764BC9D5B75B42 /* IGListMoveIndexPath.h */,
-				3B93BF9BE09FDC2BCE22C9C93FD982CB /* IGListMoveIndexPath.m */,
-				86BB792552EF8843679311A49564E1E1 /* NSNumber+IGListDiffable.h */,
-				AE3C53F655C7BA38BA03398173503B81 /* NSNumber+IGListDiffable.m */,
-				1C90612ABE05D39FA23544371C674E81 /* NSString+IGListDiffable.h */,
-				76FAFA532584EF262276772345D9DC4C /* NSString+IGListDiffable.m */,
-				CE6A74497A65C7A4F8AC13473ED0BCD2 /* Internal */,
+				0F29F8A5D216D9EEF9D82060F5B06810 /* IGListIndexPathResultInternal.h */,
+				192DEA0DB1ACE440C834607A7CF4CF0B /* IGListIndexSetResultInternal.h */,
+				41D89618155F341C355FE614B37C6D16 /* IGListMoveIndexInternal.h */,
+				1B7B68693081EFC6ED277E99674BD2AE /* IGListMoveIndexPathInternal.h */,
 			);
-			name = Common;
-			path = Common;
+			name = Internal;
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		1AACE8ABFEF468BC3BDBAFFC4566FC36 /* Default */ = {
+			isa = PBXGroup;
+			children = (
+				71DD62263837EBC8387C3D05904112E9 /* Source */,
+			);
+			name = Default;
 			sourceTree = "<group>";
 		};
 		1C4A812D7A721E4F8A5203A23D92CB45 /* Development Pods */ = {
@@ -336,43 +329,6 @@
 			path = Internal;
 			sourceTree = "<group>";
 		};
-		33F43C3731AA134E09E43DEBC108F2B8 /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				C6A4CB34DE558A070DC4B39B45377EF4 /* IGListAdapter.h */,
-				A1718D4D1AA43835D06443E7BC37A254 /* IGListAdapter.m */,
-				CA1535DE686A69C69B513A561FC02516 /* IGListAdapterDataSource.h */,
-				32A1DD1DF7F87BC0F1D8B71D32A4610A /* IGListAdapterDelegate.h */,
-				B5C4899828474D4672DCD4ED732C44DA /* IGListAdapterUpdater.h */,
-				FC34577174C0EACD1AE1DFDC35A2401B /* IGListAdapterUpdater.m */,
-				FB66656E7E1D0A20CF22FBA7BBD64F85 /* IGListAdapterUpdaterDelegate.h */,
-				46CB3DC86D72062BDCDD5156E2CC1BAD /* IGListCollectionContext.h */,
-				5B4975E02606CFC350EBA563444B0EDA /* IGListCollectionView.h */,
-				5CE75DA4021EEECE4B725496154A1B82 /* IGListCollectionView.m */,
-				809D4D4F95847C671ECC1826108B121C /* IGListDisplayDelegate.h */,
-				0649342E621753776E9D8FC495CA9F27 /* IGListGridCollectionViewLayout.h */,
-				149A38753F3483410BBC4FC831B3CF57 /* IGListGridCollectionViewLayout.m */,
-				66BCC337218B28E039E7622C2FDC7557 /* IGListKit.h */,
-				2009EB38BF6EB4C980D61AB4614894A9 /* IGListReloadDataUpdater.h */,
-				67B5038DA275A8077E443CBA4B4F5900 /* IGListReloadDataUpdater.m */,
-				C6A758DF5D1AD164EDDC65D5CAC4CD34 /* IGListScrollDelegate.h */,
-				FE818A58D20171396C3BCE9707079537 /* IGListSectionController.h */,
-				115B584D90D1BB4A3F8F9DD991D4B0F4 /* IGListSectionController.m */,
-				FC3B4AFAC77A68C8D85528505D738FE9 /* IGListSectionType.h */,
-				9E6D1448395A3825AB772744AD44885D /* IGListSingleSectionController.h */,
-				99DAC1DACF3D9B8B953D89F250392A97 /* IGListSingleSectionController.m */,
-				138F4F27D60FA07F60E7CC6AC0729890 /* IGListStackedSectionController.h */,
-				436B138446F1B9CD983855D18CF2B53C /* IGListStackedSectionController.m */,
-				59E8EC874B990948E73E650DB37477CC /* IGListSupplementaryViewSource.h */,
-				E05417E0198793F136BDDDEF7BC18948 /* IGListUpdatingDelegate.h */,
-				CAFAD20DCEA25457B0CB34D4AB91B0D7 /* IGListWorkingRangeDelegate.h */,
-				0ED844068328E1759E692A09212D3F42 /* Common */,
-				EF34FA9DA1461106C81BB7A284353EA8 /* Internal */,
-			);
-			name = Source;
-			path = Source;
-			sourceTree = "<group>";
-		};
 		3EE9680535CB73BCFDE6DD41E95799B5 /* Pods-IGListKitTodayExample */ = {
 			isa = PBXGroup;
 			children = (
@@ -388,6 +344,28 @@
 			);
 			name = "Pods-IGListKitTodayExample";
 			path = "Target Support Files/Pods-IGListKitTodayExample";
+			sourceTree = "<group>";
+		};
+		421C6874E950889C2F6B149578A7F06C /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				B59D5AE3A62A2FFEB60845A0F952AB9B /* IGListAdapterInternal.h */,
+				6FD6613F5C1050ECA7A566DAD5021497 /* IGListAdapterProxy.h */,
+				F0F0D86BE08A0360D4E8CD65175AB917 /* IGListAdapterProxy.m */,
+				E71F9961B7B176987D477ADAB574FD72 /* IGListAdapterUpdaterInternal.h */,
+				3D4623AB557C67C59E26579977C08917 /* IGListDisplayHandler.h */,
+				96DA04F35F0621FB8E5203BD488D7986 /* IGListDisplayHandler.m */,
+				5179581402D4978BE620F88728CC9EEF /* IGListSectionControllerInternal.h */,
+				C06B8DE68EE4471F5EE4C9BABC0FE87D /* IGListSectionMap.h */,
+				9894E767D495C11A93244B229495BA16 /* IGListSectionMap.m */,
+				DA0D300B7C9A06B33151AFE3583408B5 /* IGListStackedSectionControllerInternal.h */,
+				007CD14840FF786EC7E8AD6CD9DDE8C2 /* IGListWorkingRangeHandler.h */,
+				BC0F5BC5190AD44D8A5D3158F2675E39 /* IGListWorkingRangeHandler.mm */,
+				0D30748A6212C6F8312F054C01695750 /* UICollectionView+IGListBatchUpdateData.h */,
+				77020C5424C48F544B6285E8B07B9ABC /* UICollectionView+IGListBatchUpdateData.m */,
+			);
+			name = Internal;
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		433CD3331B6C3787F473C941B61FC68F /* Frameworks */ = {
@@ -412,6 +390,45 @@
 			path = "Examples/Examples-iOS/Pods/Target Support Files/IGListKit";
 			sourceTree = "<group>";
 		};
+		71DD62263837EBC8387C3D05904112E9 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				99B3350B7764EF0CD5D8CECDB6CED56C /* IGListAdapter.h */,
+				4127C35F50D6467B19CE522B90A50BFA /* IGListAdapter.m */,
+				594D84B7ECEC395242AE02F6A1A99F5F /* IGListAdapterDataSource.h */,
+				27C7946695CF383F60B180D3E1E25F39 /* IGListAdapterDelegate.h */,
+				038013D514A1854C7BB8A5E1E0383DBE /* IGListAdapterUpdater.h */,
+				62C9393B5198E696E44FBEEE3E9D8A04 /* IGListAdapterUpdater.m */,
+				F75839327A3FC6DCFF60F95127B2F544 /* IGListAdapterUpdaterDelegate.h */,
+				21615F3D9DCC5260312EBDBE25FF791C /* IGListCollectionContext.h */,
+				CBF111A0B1CFDC94A3F16694031ACFDB /* IGListCollectionView.h */,
+				4E8A886E845A5D11E528AA6E0C712E2C /* IGListCollectionView.m */,
+				25BDE272AEE5CF850E5AA432D7166C96 /* IGListCollectionViewLayout.h */,
+				3C086829337C7DD6374184979AB83B11 /* IGListCollectionViewLayout.mm */,
+				38302CBFD52834AEAE52C181445E0969 /* IGListDisplayDelegate.h */,
+				EB462594F4EE05E99D8E3400A9E21E84 /* IGListGridCollectionViewLayout.h */,
+				7923F491D78CBBEC0C299BDCA15B79F4 /* IGListGridCollectionViewLayout.m */,
+				D541476B839EBDCCB7707E90F95824C9 /* IGListKit.h */,
+				2E3969BE68622EDB983721F131EABA51 /* IGListReloadDataUpdater.h */,
+				563BC3BA9D8E7B1A46267CC7F9858BB8 /* IGListReloadDataUpdater.m */,
+				60FA236E400942885D16B1CC58A232E7 /* IGListScrollDelegate.h */,
+				4B389B8E5BC779507885D93445D9D53D /* IGListSectionController.h */,
+				7DA9A6DBD20676788CB0568CDE94256A /* IGListSectionController.m */,
+				6BC744C3B9DB1FFC1EACB3778CE9B238 /* IGListSectionType.h */,
+				C3C618C76DF0511336959278B00D496D /* IGListSingleSectionController.h */,
+				1380ACDA4B11A7EC148A8781933A5DE0 /* IGListSingleSectionController.m */,
+				523D60563CFBF708BA49A5F8BC4542A2 /* IGListStackedSectionController.h */,
+				1D8BDDDB6FEEAAAD815FC74FC628363F /* IGListStackedSectionController.m */,
+				107BB6A5158CDDD83AFFCE5CD5AFF561 /* IGListSupplementaryViewSource.h */,
+				62F45A4E061FAE66F50E25BB14BD337C /* IGListUpdatingDelegate.h */,
+				F39646F30DD551ED9A4979D513CA4958 /* IGListWorkingRangeDelegate.h */,
+				D2CF5D8CB92B2CA718F17B1B06125FE7 /* Common */,
+				421C6874E950889C2F6B149578A7F06C /* Internal */,
+			);
+			name = Source;
+			path = Source;
+			sourceTree = "<group>";
+		};
 		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
@@ -421,14 +438,6 @@
 				CF9909136132DE20E8D2AD0C67AA0C49 /* Products */,
 				2816B4C23FC52ADE9F73C37F72652FD0 /* Targets Support Files */,
 			);
-			sourceTree = "<group>";
-		};
-		876F144353B9FDB4FA60C84381998795 /* Default */ = {
-			isa = PBXGroup;
-			children = (
-				33F43C3731AA134E09E43DEBC108F2B8 /* Source */,
-			);
-			name = Default;
 			sourceTree = "<group>";
 		};
 		8F7A3DF8D470AB3D415AAA6D8CCC3498 /* Pods-IGListKitMessageExample */ = {
@@ -465,18 +474,6 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
-		CE6A74497A65C7A4F8AC13473ED0BCD2 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				86A47A3867E32653663D543FFA238B66 /* IGListIndexPathResultInternal.h */,
-				9927E33F639FCE21AE92766AC127B909 /* IGListIndexSetResultInternal.h */,
-				C99BEB9FCE7C1DDFA618B44541C7E5C0 /* IGListMoveIndexInternal.h */,
-				437D3F32477ED0F197276F74F7BCF5F9 /* IGListMoveIndexPathInternal.h */,
-			);
-			name = Internal;
-			path = Internal;
-			sourceTree = "<group>";
-		};
 		CF9909136132DE20E8D2AD0C67AA0C49 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -488,10 +485,41 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		D2CF5D8CB92B2CA718F17B1B06125FE7 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				E008556D74E9DFCDB57437E2FBDAE70E /* IGListAssert.h */,
+				64053C4B797AD59DC4FAD139773770D6 /* IGListBatchUpdateData.h */,
+				ACCE0225FC713111C5679C81283FA790 /* IGListBatchUpdateData.mm */,
+				C13E7AFD4D3A4DE811FEA37ED3C51788 /* IGListCompatibility.h */,
+				B17A8809A55BE2B46A542858C913F546 /* IGListDiff.h */,
+				D76B4AC988CFD788DCE9EB2F35FE3347 /* IGListDiff.mm */,
+				397BDE6BE132E18BCEC7962674692D46 /* IGListDiffable.h */,
+				F53B11F32F27AD82E9F3BECC5753B5E2 /* IGListDiffKit.h */,
+				6DC02DA7BF6C70969ABB28FF9E443273 /* IGListExperiments.h */,
+				3F674CC9F81D4EAE5B8F7391F5AE65B5 /* IGListIndexPathResult.h */,
+				9FE9537AF75299E876FEDC9559872EB8 /* IGListIndexPathResult.m */,
+				57986540EDFA0C908FD91C4751B9D16E /* IGListIndexSetResult.h */,
+				FE8592FBEB9DC4A6E4A08610E5D52283 /* IGListIndexSetResult.m */,
+				5FD7763164C2BA94D0D59DAE9CD2E083 /* IGListMacros.h */,
+				D08280C80ED23650988759D725955C42 /* IGListMoveIndex.h */,
+				7FD1790AD6E2CBAD69EF5F77D8878F9E /* IGListMoveIndex.m */,
+				F9E11EBF9FAD302321BFF4ED169D446C /* IGListMoveIndexPath.h */,
+				D01EC818FA6B15FF713362350793ADE9 /* IGListMoveIndexPath.m */,
+				A6AC86CA2031A234EF8A2E542289FC1C /* NSNumber+IGListDiffable.h */,
+				09413730A9D64C2187472F52BAC1FC64 /* NSNumber+IGListDiffable.m */,
+				1D6C9CEB4A46FB3810BE348030BC804F /* NSString+IGListDiffable.h */,
+				06E5980D2B4CA19F0BB013572F92F9F1 /* NSString+IGListDiffable.m */,
+				174B6E0AFB4CAA35EF5C95ADE27AD8ED /* Internal */,
+			);
+			name = Common;
+			path = Common;
+			sourceTree = "<group>";
+		};
 		DF0E1DB7FA55BDD05813C966546E36A5 /* IGListKit */ = {
 			isa = PBXGroup;
 			children = (
-				876F144353B9FDB4FA60C84381998795 /* Default */,
+				1AACE8ABFEF468BC3BDBAFFC4566FC36 /* Default */,
 				9CD524C5C9EDB23C1086EF8F6AB5C5A5 /* Diffing */,
 				4938518413AB5FF53AC9FD7D3B4EAA03 /* Support Files */,
 			);
@@ -517,90 +545,69 @@
 			path = Source;
 			sourceTree = "<group>";
 		};
-		EF34FA9DA1461106C81BB7A284353EA8 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				760700BE1D1EB3C0933CE198882E155B /* IGListAdapterInternal.h */,
-				F8D2BE56328DBC118F72FA48C54744E5 /* IGListAdapterProxy.h */,
-				3BFE3F67D2A2DE42E042EEEF009B924A /* IGListAdapterProxy.m */,
-				D7B45D73ED6E8DB34A85221717E37C5C /* IGListAdapterUpdaterInternal.h */,
-				A0EC54C40D53368520151851056C3040 /* IGListDisplayHandler.h */,
-				3474A2DD0EFBC2D80CA54B8964FF36C1 /* IGListDisplayHandler.m */,
-				973C0111567909ABEC4F9E595938270D /* IGListSectionControllerInternal.h */,
-				76103495A13E89B0A806236D8B2EC60C /* IGListSectionMap.h */,
-				A0464AF7C9464A4BF23ABC042FF52E85 /* IGListSectionMap.m */,
-				25935E7FC2F5908FC21DC3E32333A9F1 /* IGListStackedSectionControllerInternal.h */,
-				1CD4699F62A4900F2E29B6888FF51B2C /* IGListWorkingRangeHandler.h */,
-				FDEFF9D44CF56743F4F14151C2C42426 /* IGListWorkingRangeHandler.mm */,
-				91ED6CD3D3F1DE558DDA5EEEE30F725E /* UICollectionView+IGListBatchUpdateData.h */,
-				E58D9C9EFA3CB0E5A7A9B6E78270D613 /* UICollectionView+IGListBatchUpdateData.m */,
-			);
-			name = Internal;
-			path = Internal;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		8326470A44614024567D27E763C15D6F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7025B5FD1E713D99EB130037FDD9920A /* IGListAdapter.h in Headers */,
+				A7076D98D4A84CF84A7D1114435E08C2 /* IGListAdapterDataSource.h in Headers */,
+				1B58DD85CAB309DFD10AC8371784C1C6 /* IGListAdapterDelegate.h in Headers */,
+				FAADDDFD575939F342DC0EB33C46102E /* IGListAdapterInternal.h in Headers */,
+				3DA7F209EFA56B0FE51B2D2F74A764F4 /* IGListAdapterProxy.h in Headers */,
+				52A165DB4F13E4B383D1F9B8E725716D /* IGListAdapterUpdater.h in Headers */,
+				D351299A0B6FABFD60835D26A071934A /* IGListAdapterUpdaterDelegate.h in Headers */,
+				24671B7BB1B273DDF93C0F84436FE83F /* IGListAdapterUpdaterInternal.h in Headers */,
+				684E29407CC45D82238936D271F817B5 /* IGListAssert.h in Headers */,
+				49E2D0633E49EFDF5E81CEF258D6FA9F /* IGListBatchUpdateData.h in Headers */,
+				9939E6F72560E556DBBC193523EA1565 /* IGListCollectionContext.h in Headers */,
+				FBAE002D5D392B1C0B1513758CAC2F95 /* IGListCollectionView.h in Headers */,
+				9942D193832F197046B2606FC0DF8B4D /* IGListCollectionViewLayout.h in Headers */,
+				FABBE08E7C27E02F72B072CF42FD9619 /* IGListCompatibility.h in Headers */,
+				2D71A0E1CE80BD6382B43803D93E7A0B /* IGListDiff.h in Headers */,
+				94F5112620D580A88C0A0E495871AFD5 /* IGListDiffable.h in Headers */,
+				4D91C3E61B324897958DCE8965EC0D86 /* IGListDiffKit.h in Headers */,
+				2A7A79F69BE70FF3E26E5B5F1E6D9389 /* IGListDisplayDelegate.h in Headers */,
+				18C83DBC6EE5A90364983B388CD9F9AA /* IGListDisplayHandler.h in Headers */,
+				752376C890CF4BAB2F04C29F343C51A0 /* IGListExperiments.h in Headers */,
+				7EA100A6EAEBB641FA6FCFF32C35E36D /* IGListGridCollectionViewLayout.h in Headers */,
+				802D9E93BF6999351D7410DB58D55BDE /* IGListIndexPathResult.h in Headers */,
+				5BA3992DFE1D781FC63FE6DA01FA9A94 /* IGListIndexPathResultInternal.h in Headers */,
+				6BFB986E530B6684679742EF2AEA2D8D /* IGListIndexSetResult.h in Headers */,
+				E46248A5BA890CF52B2D99D22E80EB78 /* IGListIndexSetResultInternal.h in Headers */,
+				69BE65435B8C06B8D7BB2432CD42CEFE /* IGListKit-umbrella.h in Headers */,
+				01D960147A50B0AD89063323798E95A5 /* IGListKit.h in Headers */,
+				D6BC5A25B977372C1795830B2FE80BB7 /* IGListMacros.h in Headers */,
+				E469EB08F12FCD2777918299B5CC8EEB /* IGListMoveIndex.h in Headers */,
+				B5B4C2CD7C6D966C2A7791D4C94347D6 /* IGListMoveIndexInternal.h in Headers */,
+				B74CE62D05C4BF0B09D8D6F47C117D2C /* IGListMoveIndexPath.h in Headers */,
+				577C8C904DDB755609EEDA5ABEF3025D /* IGListMoveIndexPathInternal.h in Headers */,
+				8A08F7FC9BC02D22D544D8F3B58ACC09 /* IGListReloadDataUpdater.h in Headers */,
+				4D6885C5F1380275DDF40178E0170014 /* IGListScrollDelegate.h in Headers */,
+				FC2AD36A65985DF0B6039CDFDDD495D2 /* IGListSectionController.h in Headers */,
+				69DBA1085FB0EC6401FF67947EB47451 /* IGListSectionControllerInternal.h in Headers */,
+				522742C0B97521E0633735AD6532B482 /* IGListSectionMap.h in Headers */,
+				F02EC7E844F17A792A7A47B2ED54810D /* IGListSectionType.h in Headers */,
+				D53CE6BFDE81C2849E2D655816D40D83 /* IGListSingleSectionController.h in Headers */,
+				15EBEE41EB35F173F1223522B0361668 /* IGListStackedSectionController.h in Headers */,
+				E894EDACBC44D5909E6191181C7100B7 /* IGListStackedSectionControllerInternal.h in Headers */,
+				B913048F3FEFBCF8E92DF4FEC2327D08 /* IGListSupplementaryViewSource.h in Headers */,
+				7AF1A995D99680AE42E9827F3938AFA3 /* IGListUpdatingDelegate.h in Headers */,
+				55C2E3F3FA5E34475A161E1E150C7550 /* IGListWorkingRangeDelegate.h in Headers */,
+				06F8E88488FE810B9E172CFE33ED41F7 /* IGListWorkingRangeHandler.h in Headers */,
+				99CAC417EE670DC893C2EF2CD1ABB618 /* NSNumber+IGListDiffable.h in Headers */,
+				707397172DA3CAFA8E0935B4E9BB5C94 /* NSString+IGListDiffable.h in Headers */,
+				C27A53137529E6E1523E25E1472B0D77 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A8FD7A8DF5CE870AA2A619FE79FE81D9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				E353B40949D9675B8B2B03C7569F96F5 /* Pods-IGListKitMessageExample-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DC870AF655C7F74AEC6246B9FC3D3475 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E3F3D0B97462F6EBAD13EA91F0F6212A /* IGListAdapter.h in Headers */,
-				7201CDE3182F7CCAA0D9EDAA5346EB00 /* IGListAdapterDataSource.h in Headers */,
-				3CB9FF8EE402C8EE978F7827538982C0 /* IGListAdapterDelegate.h in Headers */,
-				83D4E09F31A387ADCDE669B3185B8849 /* IGListAdapterInternal.h in Headers */,
-				4087748A7E033F7B113F008696F10100 /* IGListAdapterProxy.h in Headers */,
-				5049064A9255B5B681AE820BF054CF18 /* IGListAdapterUpdater.h in Headers */,
-				580A85CE009B9B1B19E2FEAF5446FE19 /* IGListAdapterUpdaterDelegate.h in Headers */,
-				F376B87428013B5FB2AC705A90E084A2 /* IGListAdapterUpdaterInternal.h in Headers */,
-				6E47CEDB94A176B0CB142CA479DFEDB2 /* IGListAssert.h in Headers */,
-				56BC154A684A2CE83B207A7A79B2AA79 /* IGListBatchUpdateData.h in Headers */,
-				5C490928BABB0EF533E0E54CD4A0102D /* IGListCollectionContext.h in Headers */,
-				81F1C424E560910B109D4BB6ECBE2EC6 /* IGListCollectionView.h in Headers */,
-				20C776592B599DACFBEA25CEBE2BD5B5 /* IGListCompatibility.h in Headers */,
-				06E48130C61B46DD674D2D6BFC11901D /* IGListDiff.h in Headers */,
-				70F593265D74E691B47D4EBE8536517E /* IGListDiffable.h in Headers */,
-				D44A1AE4A2AD83B4D81015DA09F35450 /* IGListDiffKit.h in Headers */,
-				97682876C9B6181D19D746AE3C2278F4 /* IGListDisplayDelegate.h in Headers */,
-				ED4C4D8C79179EF7D0F7A9D6A78B3028 /* IGListDisplayHandler.h in Headers */,
-				2C2747A131B2BF3C9FF512B68597998B /* IGListExperiments.h in Headers */,
-				C506D8A24A14D01EEC1BE8CE7CD2C164 /* IGListGridCollectionViewLayout.h in Headers */,
-				76B1E85B1B2AE0BF0F3EFE20E96D65CA /* IGListIndexPathResult.h in Headers */,
-				3EFBC9584ED9BDA7DA02206B4A1BE3D7 /* IGListIndexPathResultInternal.h in Headers */,
-				63F2505138750A7498D3C948AFCCCD23 /* IGListIndexSetResult.h in Headers */,
-				CFFF332D28FB693561D6D2DDAE8B7EF6 /* IGListIndexSetResultInternal.h in Headers */,
-				F41FEEE5690485539BCAC553974FE6A7 /* IGListKit-umbrella.h in Headers */,
-				4083D1A227353B9CEA104788D83D4BA4 /* IGListKit.h in Headers */,
-				AC5FA1790BCB08D8BE6CF6124FF300C0 /* IGListMacros.h in Headers */,
-				0E45609BB284A81673F917EFA1C79F00 /* IGListMoveIndex.h in Headers */,
-				EC4BD0B3B63D7B876AB2FB2035F82E61 /* IGListMoveIndexInternal.h in Headers */,
-				DFAACC0AF49FAE11E092F2EA2C35D48E /* IGListMoveIndexPath.h in Headers */,
-				0F2729D06BF400CF3E8590E67608EA2D /* IGListMoveIndexPathInternal.h in Headers */,
-				D099903FB310D5A12B23B3A43BCCED8D /* IGListReloadDataUpdater.h in Headers */,
-				984C2F0951A593458769BBFD5C845B96 /* IGListScrollDelegate.h in Headers */,
-				ED97249B08390763C07ECA48A6C2089E /* IGListSectionController.h in Headers */,
-				11BB692868610B1C1A89053F713C4236 /* IGListSectionControllerInternal.h in Headers */,
-				D78A53EA678B4828CD033E20D8084292 /* IGListSectionMap.h in Headers */,
-				0E4EF7D9F292CE93E8253E29728D6DC7 /* IGListSectionType.h in Headers */,
-				0B8647DEC498B2E89EE01BEB006275D6 /* IGListSingleSectionController.h in Headers */,
-				F822A5D8EF3791FACBE74C754D579489 /* IGListStackedSectionController.h in Headers */,
-				E860594EC0FAF157159C0C0DAE33C6BA /* IGListStackedSectionControllerInternal.h in Headers */,
-				6E05E9BFD9B91DB07DCCB2CD8B18CDC3 /* IGListSupplementaryViewSource.h in Headers */,
-				968D6E4549F53AB3151B434AE102711B /* IGListUpdatingDelegate.h in Headers */,
-				D5DB2A7D796C1EA166A4D719D785FECF /* IGListWorkingRangeDelegate.h in Headers */,
-				73B92B0EC06263755BA5960BC8A65B02 /* IGListWorkingRangeHandler.h in Headers */,
-				5E2452BF11067A611340CB9C654037D1 /* NSNumber+IGListDiffable.h in Headers */,
-				CE6A0032D5362E3EEE3CBF08FAB8CCD5 /* NSString+IGListDiffable.h in Headers */,
-				F8CEF7EE893CEBE0F01D3D6F91DC1FD2 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -659,13 +666,13 @@
 			productReference = 3DFBEA9D0D85DB9366D3C949C20332DD /* Pods_IGListKitExamples.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */ = {
+		C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8DADDAFB45D948BB78A504DFD61C6FB3 /* Build configuration list for PBXNativeTarget "IGListKit" */;
+			buildConfigurationList = F71F0CDD33B849DD0FE9EF7A6721683A /* Build configuration list for PBXNativeTarget "IGListKit" */;
 			buildPhases = (
-				6836496CD48A06C080823962A1F1C20B /* Sources */,
-				676279F9D230F11E09570AE3DA250FC3 /* Frameworks */,
-				DC870AF655C7F74AEC6246B9FC3D3475 /* Headers */,
+				1AF34C6050B00806D96719AB748F3C58 /* Sources */,
+				56774D8F74203FBD49A94FCFD02348AB /* Frameworks */,
+				8326470A44614024567D27E763C15D6F /* Headers */,
 			);
 			buildRules = (
 			);
@@ -715,7 +722,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */,
+				C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */,
 				6B7DA8C024D099705CF771FF16E6FC16 /* Pods-IGListKitExamples */,
 				401DEFF5B4204434A3367C3A45C172EE /* Pods-IGListKitMessageExample */,
 				FA6C50153578D5634418D6966B7AAEDD /* Pods-IGListKitTodayExample */,
@@ -732,40 +739,41 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1AF34C6050B00806D96719AB748F3C58 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5921F3BF43B02C6C9FD1612FA4D69FDB /* IGListAdapter.m in Sources */,
+				0C92682C2F3006D7850E1ED5BD76B866 /* IGListAdapterProxy.m in Sources */,
+				7D5CE5E55109BF2D2E72F4DC4418E4EE /* IGListAdapterUpdater.m in Sources */,
+				B4247B838DEB8037E98E0171BC46CFA3 /* IGListBatchUpdateData.mm in Sources */,
+				BC084214AE6061F593784CFBB66226DF /* IGListCollectionView.m in Sources */,
+				4F7F4F7BB3D07B3A9DE3E0858B02F63C /* IGListCollectionViewLayout.mm in Sources */,
+				38D672CA93D1AE1EAB3F89212B5B7D40 /* IGListDiff.mm in Sources */,
+				320A1C4C3413EB1AA898DBBC513A1F35 /* IGListDisplayHandler.m in Sources */,
+				C36489FE69B295502E1CD6D943E332E4 /* IGListGridCollectionViewLayout.m in Sources */,
+				EAD4262C7C09BD4E217D6E40D1A68655 /* IGListIndexPathResult.m in Sources */,
+				4502A5A9A265E5A901223721FE3FD45B /* IGListIndexSetResult.m in Sources */,
+				1C9880BCCC1110014B8977006A2671A4 /* IGListKit-dummy.m in Sources */,
+				31C48B86CE9E325FCB4FB69A87494105 /* IGListMoveIndex.m in Sources */,
+				DE95203F33CB5EE5DF5F9671BA6CBA26 /* IGListMoveIndexPath.m in Sources */,
+				1BF9D4830CFC408E66D65D49271A47CE /* IGListReloadDataUpdater.m in Sources */,
+				DBCF13DA01CA7B8E23EC60436A9B54CF /* IGListSectionController.m in Sources */,
+				5F3BD5B484A8FE2554BD1FACEE219516 /* IGListSectionMap.m in Sources */,
+				3CCA6A6721A6CC5F13A5CE7886C08C4D /* IGListSingleSectionController.m in Sources */,
+				F952415DF594C60359C82BA2B3CE3E00 /* IGListStackedSectionController.m in Sources */,
+				74AC5B625D916B9901881A951510E87C /* IGListWorkingRangeHandler.mm in Sources */,
+				AB27911ABADEC8A211A2A71223901F37 /* NSNumber+IGListDiffable.m in Sources */,
+				6DD3C165ACE9D427248805159BBFDEF6 /* NSString+IGListDiffable.m in Sources */,
+				FB1BF9A9C0ABAD993CEF66EDABFDCD71 /* UICollectionView+IGListBatchUpdateData.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2FF6C4068B8331D4FA2A47EB9F42A336 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				4DC076C43C4AA5A3C88EEC49F5097581 /* Pods-IGListKitMessageExample-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6836496CD48A06C080823962A1F1C20B /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8D3C2055830CBB009FD573A573EE81B2 /* IGListAdapter.m in Sources */,
-				8E1D2B5ED4785D929E6C6886ED21DA15 /* IGListAdapterProxy.m in Sources */,
-				1871E1D447E0C147C84B1BB5AB2A8289 /* IGListAdapterUpdater.m in Sources */,
-				8894FBD9663EE633E6B19497BB6FDBD0 /* IGListBatchUpdateData.mm in Sources */,
-				BC3054D66CE4FA6E84CE82C696F446FA /* IGListCollectionView.m in Sources */,
-				86C91F3A89F9683BA3A8F5AA54E8AA08 /* IGListDiff.mm in Sources */,
-				02538AD450DD078DE24C22B03CA856D7 /* IGListDisplayHandler.m in Sources */,
-				0E77DF509A11BEA2B4FC9096323B57A1 /* IGListGridCollectionViewLayout.m in Sources */,
-				A524BD6FA5B85CB1839A10ADA68ACE77 /* IGListIndexPathResult.m in Sources */,
-				E230A3E09D2E48BCF7EB60F565F18690 /* IGListIndexSetResult.m in Sources */,
-				D922D112237DBFE7C3FAC62DF2D07F3D /* IGListKit-dummy.m in Sources */,
-				517439F690B63858DFF5104AF8DAAB58 /* IGListMoveIndex.m in Sources */,
-				9ABE87D3484334FD79EDD6FABE32EAAC /* IGListMoveIndexPath.m in Sources */,
-				F42CD0C401C2B1D2B183535DA794302B /* IGListReloadDataUpdater.m in Sources */,
-				CA1A85850EE450CD49CBD54E595577A6 /* IGListSectionController.m in Sources */,
-				4D7AC944906022E9C1CA8CA31705D5D8 /* IGListSectionMap.m in Sources */,
-				484458D2F230B607F24B61470F484B73 /* IGListSingleSectionController.m in Sources */,
-				CCA6CB8E8819B9D032B90F3CD0015550 /* IGListStackedSectionController.m in Sources */,
-				5A8A597D0274374C6C283294A5E99EA7 /* IGListWorkingRangeHandler.mm in Sources */,
-				89CB98DBDE68549E708D91862247F905 /* NSNumber+IGListDiffable.m in Sources */,
-				734D0DD10CA2837A43EFF5929B63CC38 /* NSString+IGListDiffable.m in Sources */,
-				0516BDDE5DB0048ECFFEC0EC8ACE404F /* UICollectionView+IGListBatchUpdateData.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -783,19 +791,19 @@
 		36C541B7631C30D80576C418E9F06C18 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */;
+			target = C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */;
 			targetProxy = 42B122D03058E7C3E34ACF0AC2A72140 /* PBXContainerItemProxy */;
 		};
 		9B463355891949F736B3B5D678FE8D02 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */;
+			target = C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */;
 			targetProxy = A0A5426482C447F640D6A192E71D5F5B /* PBXContainerItemProxy */;
 		};
 		BFAF67A08B878C67ABE4BF370ECEA0C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */;
+			target = C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */;
 			targetProxy = 7D332B346FFC0D5E5159546D185DAFEF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -881,7 +889,7 @@
 			};
 			name = Debug;
 		};
-		37167DDEF0A6B3C65B30FFC9BC714848 /* Debug */ = {
+		3B15937F52C4B01CF7486D92196B4A47 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CA234CE99FD05714C2A7AF7708B24C51 /* IGListKit.xcconfig */;
 			buildSettings = {
@@ -890,7 +898,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -903,7 +911,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = IGListKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -912,7 +920,7 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
 		44CDBB6D11DE06DB64D6268622BDC47E /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -989,7 +997,7 @@
 			};
 			name = Debug;
 		};
-		909D59FB2F970BE866F6E5A76B597330 /* Release */ = {
+		6E258C453331BCCC8EECD9CC99421815 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CA234CE99FD05714C2A7AF7708B24C51 /* IGListKit.xcconfig */;
 			buildSettings = {
@@ -998,7 +1006,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1011,7 +1019,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = IGListKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1020,7 +1028,7 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		ACA8A168549269FFC475C4357D635084 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1204,11 +1212,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8DADDAFB45D948BB78A504DFD61C6FB3 /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
+		F71F0CDD33B849DD0FE9EF7A6721683A /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				37167DDEF0A6B3C65B30FFC9BC714848 /* Debug */,
-				909D59FB2F970BE866F6E5A76B597330 /* Release */,
+				6E258C453331BCCC8EECD9CC99421815 /* Debug */,
+				3B15937F52C4B01CF7486D92196B4A47 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/Examples-iOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
+++ b/Examples/Examples-iOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
@@ -23,6 +23,7 @@
 #import "IGListAdapterUpdaterDelegate.h"
 #import "IGListCollectionContext.h"
 #import "IGListCollectionView.h"
+#import "IGListCollectionViewLayout.h"
 #import "IGListDisplayDelegate.h"
 #import "IGListGridCollectionViewLayout.h"
 #import "IGListKit.h"

--- a/Examples/Examples-tvOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Examples-tvOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,80 +7,82 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		02538AD450DD078DE24C22B03CA856D7 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 085E3578876E8830FEB0A7B38BE5B188 /* IGListDisplayHandler.m */; };
-		0516BDDE5DB0048ECFFEC0EC8ACE404F /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = CA8EF882B40179FFCDBE248BC29DD73D /* UICollectionView+IGListBatchUpdateData.m */; };
-		06E48130C61B46DD674D2D6BFC11901D /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = 943B4B26C72318591920AE4C4E2BB9B8 /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0B8647DEC498B2E89EE01BEB006275D6 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = D7EF1C1DD1765A8E8004F3C3B18FFAEE /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E45609BB284A81673F917EFA1C79F00 /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 11EA4F25F3580D9FA3807AE30DF460C3 /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E4EF7D9F292CE93E8253E29728D6DC7 /* IGListSectionType.h in Headers */ = {isa = PBXBuildFile; fileRef = 54174D7D374B425718A92BD2CE893C99 /* IGListSectionType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E77DF509A11BEA2B4FC9096323B57A1 /* IGListGridCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = 83B504AD14E6B4D01EA2A377304C1CEB /* IGListGridCollectionViewLayout.m */; };
-		0F2729D06BF400CF3E8590E67608EA2D /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 58A9B3EC590F0AF474D2E52EF418CA83 /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		11BB692868610B1C1A89053F713C4236 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DDE1DA12937AA0946FEB90E2739CC14C /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1871E1D447E0C147C84B1BB5AB2A8289 /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CE7EF88A010E5A35B250287E956D445 /* IGListAdapterUpdater.m */; };
+		01D960147A50B0AD89063323798E95A5 /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C2A0577C1902B3D0E423FA91BE9C3C /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06F8E88488FE810B9E172CFE33ED41F7 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 316B64D40DAC0700C0F9C8CD24A69F48 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0C92682C2F3006D7850E1ED5BD76B866 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 75FE57F9D38E1CEB8D13D1962D7E5F30 /* IGListAdapterProxy.m */; };
+		15EBEE41EB35F173F1223522B0361668 /* IGListStackedSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = F60A259E23D35D49857F23FA5D13920E /* IGListStackedSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		18C83DBC6EE5A90364983B388CD9F9AA /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 97B199B6A09C09049D0982F0E76DC115 /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1A89AF7CCCD65D9D5B946363776D05AE /* Pods-IGListKitExamples-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 52054AE893A0AE7FBFC54333D8ABD345 /* Pods-IGListKitExamples-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		20C776592B599DACFBEA25CEBE2BD5B5 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A47CA2A158E3620E1F26E872BD32327 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2C2747A131B2BF3C9FF512B68597998B /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = 10D727D11F4332F6DA19EACE9342A6EE /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CB9FF8EE402C8EE978F7827538982C0 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5296D28B9A0555B81CEF071496A04DD5 /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3EFBC9584ED9BDA7DA02206B4A1BE3D7 /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3941E9CD636DDDAB7E4061549E94D2BD /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		4083D1A227353B9CEA104788D83D4BA4 /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 646C56F2C6B1C295E6BD5C110802CF03 /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4087748A7E033F7B113F008696F10100 /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = B09077F3DFB97E915D6A2A1D3C5545AF /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		484458D2F230B607F24B61470F484B73 /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = AB11EB12064D3352C26FB85D273CB9D9 /* IGListSingleSectionController.m */; };
-		4D7AC944906022E9C1CA8CA31705D5D8 /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 1169AEC6171A0A7AE34BC7D5CAE67C6F /* IGListSectionMap.m */; };
-		5049064A9255B5B681AE820BF054CF18 /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 1124D984EB5F7AE78734FEECF159B97A /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		517439F690B63858DFF5104AF8DAAB58 /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = EA44A1506A965754F508FE7E6787B6F6 /* IGListMoveIndex.m */; };
-		56BC154A684A2CE83B207A7A79B2AA79 /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = FE2E9121D30C841E5270620194D340D0 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		580A85CE009B9B1B19E2FEAF5446FE19 /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = CD71E3890CC58066AF4A757746526BB5 /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5A8A597D0274374C6C283294A5E99EA7 /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C61455C066A8D3E4D1FB0BA5582298F /* IGListWorkingRangeHandler.mm */; };
-		5C490928BABB0EF533E0E54CD4A0102D /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E7F421F40C3DDD78ACD29E6889DFBFC /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5E2452BF11067A611340CB9C654037D1 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E3191C490AF6C3204BC95C35C51EE13 /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63F2505138750A7498D3C948AFCCCD23 /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 23FD9D40E9DA4DBDC981FEA2E36FBB5A /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1B58DD85CAB309DFD10AC8371784C1C6 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 93534800B7B361322F107A85CD3C8B4C /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1BF9D4830CFC408E66D65D49271A47CE /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = C928FBB74BD7E89442B60D846BA328B5 /* IGListReloadDataUpdater.m */; };
+		1C9880BCCC1110014B8977006A2671A4 /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C21A7CA00A0F4B5304CF04AF01BD52EF /* IGListKit-dummy.m */; };
+		24671B7BB1B273DDF93C0F84436FE83F /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D8C81E5730BBD035DEED8B23724964F /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A7A79F69BE70FF3E26E5B5F1E6D9389 /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B07F8EB741375F2BA0F3425526C68170 /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D71A0E1CE80BD6382B43803D93E7A0B /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = B1E666D5734AE6165634E79C57822F15 /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		31C48B86CE9E325FCB4FB69A87494105 /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 278CDF87A5986509B94ADEF8D9F27FB5 /* IGListMoveIndex.m */; };
+		320A1C4C3413EB1AA898DBBC513A1F35 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = BA46A3908001DCDE7C0549AD7E657392 /* IGListDisplayHandler.m */; };
+		38D672CA93D1AE1EAB3F89212B5B7D40 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 959691397B039E95265F4ACE5F8ECAF9 /* IGListDiff.mm */; };
+		3CCA6A6721A6CC5F13A5CE7886C08C4D /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 47153303D1E3F2A7C7A293D812E6CE92 /* IGListSingleSectionController.m */; };
+		3DA7F209EFA56B0FE51B2D2F74A764F4 /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = F138A3E22D6DA4AB8EBFDE3B730A9D70 /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4502A5A9A265E5A901223721FE3FD45B /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 90DA30866D2D8325EC6D63AACBFD5089 /* IGListIndexSetResult.m */; };
+		49E2D0633E49EFDF5E81CEF258D6FA9F /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = F098CA1A21FC56BDC2C137DF21CBC1CF /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D6885C5F1380275DDF40178E0170014 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B2E59B7C3ACF72D8661C19C1358EB6 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D91C3E61B324897958DCE8965EC0D86 /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A267FE34B99BC6F2E94423B173BD776 /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F7F4F7BB3D07B3A9DE3E0858B02F63C /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7B20CAC621D971E8BB2EA69F5DD99FC /* IGListCollectionViewLayout.mm */; };
+		522742C0B97521E0633735AD6532B482 /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = C0ABC14C11E94AABA7E779C41DDC8759 /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		52A165DB4F13E4B383D1F9B8E725716D /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E6C5C492750A12228E4C3F3C22D52C2 /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55C2E3F3FA5E34475A161E1E150C7550 /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = A6C2DF3D1CD7CEF1B446D7F4DE1DB41B /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		577C8C904DDB755609EEDA5ABEF3025D /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 38010057DBCDCF79B6025556CE641F9E /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5921F3BF43B02C6C9FD1612FA4D69FDB /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B8BA11081DCC84454D3BEA77B2AAD7DE /* IGListAdapter.m */; };
+		5BA3992DFE1D781FC63FE6DA01FA9A94 /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C5FD5DC3382EBAF28CE17EB55087CB02 /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5F3BD5B484A8FE2554BD1FACEE219516 /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C5A6BC2986E88AA6275B449BF72CA4D /* IGListSectionMap.m */; };
 		6585F8BC4AE0EA2DC16B62B159CAE397 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D44B887663E8A7D2752C9ED2356648 /* Foundation.framework */; };
-		6E05E9BFD9B91DB07DCCB2CD8B18CDC3 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 080119E4F6D6CEF21F508083ACB4BF73 /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6E47CEDB94A176B0CB142CA479DFEDB2 /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 29671FCF6680310ECB0AF6DD08DCFC00 /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		70F593265D74E691B47D4EBE8536517E /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = FF71E22114DCCABAD081380F33C6A8D8 /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7201CDE3182F7CCAA0D9EDAA5346EB00 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = ABA4C9F3CA93D08C5A202417C8A635C3 /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		734D0DD10CA2837A43EFF5929B63CC38 /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = DF4C3E784E1FA06A6E1B19E4B00FA901 /* NSString+IGListDiffable.m */; };
-		73B92B0EC06263755BA5960BC8A65B02 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ABCB47C65615D78E7E32639B4910937 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		76B1E85B1B2AE0BF0F3EFE20E96D65CA /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A1FA4D7D8F72D7BDFD49D8E004E0D0 /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81F1C424E560910B109D4BB6ECBE2EC6 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9766F3C35BDEE3B3DB501F22B2F8F4B8 /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		83D4E09F31A387ADCDE669B3185B8849 /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F9B9756596244450CDC33EAE08C5F6A /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		86C91F3A89F9683BA3A8F5AA54E8AA08 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7CA382AEB6E22A5A96AE3E195E1A7355 /* IGListDiff.mm */; };
-		8894FBD9663EE633E6B19497BB6FDBD0 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 043B139A33DFAA38FBDC1EFE7812B099 /* IGListBatchUpdateData.mm */; };
-		89CB98DBDE68549E708D91862247F905 /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = A755EC8AF13C011782DA798C437338DB /* NSNumber+IGListDiffable.m */; };
-		8D3C2055830CBB009FD573A573EE81B2 /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 048E34044F70E19B27EA5C031FAB24CB /* IGListAdapter.m */; };
-		8E1D2B5ED4785D929E6C6886ED21DA15 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = EB13557EA46D8B6A8B037DB51E6A95CB /* IGListAdapterProxy.m */; };
-		968D6E4549F53AB3151B434AE102711B /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D9F7B6D3E0924236BC11EA21EE300E1 /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97682876C9B6181D19D746AE3C2278F4 /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8050F244C733936C2F1761C02033E7AE /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		984C2F0951A593458769BBFD5C845B96 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BD1AE34815F6729F58FD19CDFCECB514 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9ABE87D3484334FD79EDD6FABE32EAAC /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EB43BA5778517EB683957E69E7287D9 /* IGListMoveIndexPath.m */; };
-		A524BD6FA5B85CB1839A10ADA68ACE77 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A01AD1DA76574C07064AC03414DD23E /* IGListIndexPathResult.m */; };
-		AC5FA1790BCB08D8BE6CF6124FF300C0 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EF0DB26C9F468230CF6A5AC8E1BEABFF /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B4AD7676612D295C20AE41655763F42D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D44B887663E8A7D2752C9ED2356648 /* Foundation.framework */; };
-		BC3054D66CE4FA6E84CE82C696F446FA /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B07D2F3DC7EBC34C6D4BD2E09EE6168 /* IGListCollectionView.m */; };
-		BE98D9E362B09006F178AEF6B5CA8460 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB4C132D7BA00C1384E27FAFD43A44B6 /* UIKit.framework */; };
+		684E29407CC45D82238936D271F817B5 /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BA9073BE2412CAB09971D9CC040A787 /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69BE65435B8C06B8D7BB2432CD42CEFE /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9699862731767A477E47D42C41975A56 /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		69DBA1085FB0EC6401FF67947EB47451 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C23F17740AF9DF30FD401B3A6B901909 /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6BFB986E530B6684679742EF2AEA2D8D /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F7F42D29F1416E12A3CA9B758DF8A22 /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DD3C165ACE9D427248805159BBFDEF6 /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = DDA0B8E96A8BBD92033B00032C8B987F /* NSString+IGListDiffable.m */; };
+		7025B5FD1E713D99EB130037FDD9920A /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E571FAC80DA98BCCB608086E20A52DE /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		707397172DA3CAFA8E0935B4E9BB5C94 /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F577BEE2642E4863F79B70091358490 /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		74AC5B625D916B9901881A951510E87C /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52811104A3D4D278591F628DD32AD53D /* IGListWorkingRangeHandler.mm */; };
+		752376C890CF4BAB2F04C29F343C51A0 /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = B24A3DA0BF2517609FF6E7796C4C7D15 /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7AF1A995D99680AE42E9827F3938AFA3 /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4398B241E89ED47A57D9518834307543 /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7D5CE5E55109BF2D2E72F4DC4418E4EE /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = E1FBFC4D5641BC6125490BEE115407EA /* IGListAdapterUpdater.m */; };
+		7EA100A6EAEBB641FA6FCFF32C35E36D /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FA719B462564BC9A2527E14D960B69C /* IGListGridCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		802D9E93BF6999351D7410DB58D55BDE /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AB88A22C231575AB7FFE0A173B12D28 /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8A08F7FC9BC02D22D544D8F3B58ACC09 /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 067FA52ABE56CBA00D6F579954F37489 /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94F5112620D580A88C0A0E495871AFD5 /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 466ACE48AF49273E10DA7D568B353CCC /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9939E6F72560E556DBBC193523EA1565 /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 47D39852188A57074D8C006731E9AF80 /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9942D193832F197046B2606FC0DF8B4D /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = A487D5172128C128086E4F3A13AB5694 /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		99CAC417EE670DC893C2EF2CD1ABB618 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 972F5B2D66A23A895AF6D7AF131B5A88 /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A7076D98D4A84CF84A7D1114435E08C2 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 12322B386E670A6D69595370718A4933 /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AB27911ABADEC8A211A2A71223901F37 /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 678D8E98F3BE866D7F3A97072728299F /* NSNumber+IGListDiffable.m */; };
+		B4247B838DEB8037E98E0171BC46CFA3 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 06DF8C24026CF38174CDCC0D27EE7751 /* IGListBatchUpdateData.mm */; };
+		B5B4C2CD7C6D966C2A7791D4C94347D6 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FCA366ADD099DB3B9DACD51553BAFC37 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B74CE62D05C4BF0B09D8D6F47C117D2C /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 92005BAC60F7299F9DB4E5724F6102BD /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B913048F3FEFBCF8E92DF4FEC2327D08 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 73F5D0D7ADDE4C13BBE2D4A95BD3D65B /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BC084214AE6061F593784CFBB66226DF /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = CD073F0BF52AE65CC0DCEE7C1A03A3BB /* IGListCollectionView.m */; };
+		C27A53137529E6E1523E25E1472B0D77 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B139C4F878940362A15BBBBCB654EB3 /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C36489FE69B295502E1CD6D943E332E4 /* IGListGridCollectionViewLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = FBAB3E76D0D88D0943639ACA7E60FDE8 /* IGListGridCollectionViewLayout.m */; };
 		C4C4C1B02AFD7277F00A40570658152C /* Pods-IGListKitExamples-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F5AE0385534EC7E6CA75003A7280492 /* Pods-IGListKitExamples-dummy.m */; };
-		C506D8A24A14D01EEC1BE8CE7CD2C164 /* IGListGridCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 858D95ACAA310E3FD786F87B6484423B /* IGListGridCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CA1A85850EE450CD49CBD54E595577A6 /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = AF5EB9114BE546DE99E0218F7CCF3E69 /* IGListSectionController.m */; };
-		CCA6CB8E8819B9D032B90F3CD0015550 /* IGListStackedSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EF2C5B280694F0F27B9C3C100050152 /* IGListStackedSectionController.m */; };
-		CE6A0032D5362E3EEE3CBF08FAB8CCD5 /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CF11DA440B0D2CE69016EE14E237D60 /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CFFF332D28FB693561D6D2DDAE8B7EF6 /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F19DADF473B46635E38A4450B1F9B96 /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D099903FB310D5A12B23B3A43BCCED8D /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 430AFA8424CB7AD8B738903FF3A76B1E /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D44A1AE4A2AD83B4D81015DA09F35450 /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DE1B1584F5A67B701443F1AC5A7DF3E /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D5DB2A7D796C1EA166A4D719D785FECF /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 857A1509B449087F7DFB7501450C6D1D /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D78A53EA678B4828CD033E20D8084292 /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = E08BD32B6482D0DA523DAD2879F6C59C /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D922D112237DBFE7C3FAC62DF2D07F3D /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C21A7CA00A0F4B5304CF04AF01BD52EF /* IGListKit-dummy.m */; };
-		DFAACC0AF49FAE11E092F2EA2C35D48E /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AA5963C11F2745B3F368449883C1858 /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E230A3E09D2E48BCF7EB60F565F18690 /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = ADC4DCF78CDC8E170F10A882627A6C70 /* IGListIndexSetResult.m */; };
-		E3F3D0B97462F6EBAD13EA91F0F6212A /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = ADAB328495B1698658BE1302C3665DF5 /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E860594EC0FAF157159C0C0DAE33C6BA /* IGListStackedSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AD7A054EF9122B02F919014DD1791F0 /* IGListStackedSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EC4BD0B3B63D7B876AB2FB2035F82E61 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C1651840D6E3A00F81FA4A933861B8EF /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ED4C4D8C79179EF7D0F7A9D6A78B3028 /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = BE6C6DFC7DF1D34CDBDD776835531F6F /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ED97249B08390763C07ECA48A6C2089E /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B1EDEFF830174F1EC40CB3826C87EAC4 /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F376B87428013B5FB2AC705A90E084A2 /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E0D46D2D682A428D66209FE6BA14D9A /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F41FEEE5690485539BCAC553974FE6A7 /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9699862731767A477E47D42C41975A56 /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F42CD0C401C2B1D2B183535DA794302B /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = C938F229AE318B89FF44857D449D22D6 /* IGListReloadDataUpdater.m */; };
-		F822A5D8EF3791FACBE74C754D579489 /* IGListStackedSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AE14CF6D326E764C8193685779E9EF /* IGListStackedSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F8CEF7EE893CEBE0F01D3D6F91DC1FD2 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = AC88C732DEFE844817FFAB2551FA5D75 /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		D351299A0B6FABFD60835D26A071934A /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A1AAADDF904925B188C01AA1034F350 /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D42590D23FF9454239269699AEBDC3F7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB4C132D7BA00C1384E27FAFD43A44B6 /* UIKit.framework */; };
+		D53CE6BFDE81C2849E2D655816D40D83 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 49ADF7794886A94EA55E10BF81D050E1 /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6BC5A25B977372C1795830B2FE80BB7 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = AE8083AC94564DE6B57A77067BBAFB99 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBCF13DA01CA7B8E23EC60436A9B54CF /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 44101B7EC9941E2DAF102A147BA45538 /* IGListSectionController.m */; };
+		DE95203F33CB5EE5DF5F9671BA6CBA26 /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = A511D1D31FCB9473B0A0C0757AD691ED /* IGListMoveIndexPath.m */; };
+		E46248A5BA890CF52B2D99D22E80EB78 /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B021D11F96D3F1EA9B99055DBCA000E /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E469EB08F12FCD2777918299B5CC8EEB /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 322D1A72D3E30AB50D9464EDF3B703ED /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E894EDACBC44D5909E6191181C7100B7 /* IGListStackedSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DB9F460FE6C7D4B50A9941BC0537D086 /* IGListStackedSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EAD4262C7C09BD4E217D6E40D1A68655 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = EA618C61AA0A3EC9B73D80FBBFA7555A /* IGListIndexPathResult.m */; };
+		F02EC7E844F17A792A7A47B2ED54810D /* IGListSectionType.h in Headers */ = {isa = PBXBuildFile; fileRef = B66DD022BFDB9A96E2F854C5E96A1DF9 /* IGListSectionType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F27439472EC00AF82FE64B8CD2DC6A87 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71D44B887663E8A7D2752C9ED2356648 /* Foundation.framework */; };
+		F952415DF594C60359C82BA2B3CE3E00 /* IGListStackedSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8521A2D40EC8D38A765CF7A872E9615D /* IGListStackedSectionController.m */; };
+		FAADDDFD575939F342DC0EB33C46102E /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3249C1622540620AF93E66D3985B569A /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FABBE08E7C27E02F72B072CF42FD9619 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = E37BDBCC215FFAC6EC90A309F9917A95 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB1BF9A9C0ABAD993CEF66EDABFDCD71 /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = 56924D9A37C881D64DE514F00968E8CF /* UICollectionView+IGListBatchUpdateData.m */; };
+		FBAE002D5D392B1C0B1513758CAC2F95 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BF086E44AD2C0322F3F1038C23693CD /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FC2AD36A65985DF0B6039CDFDDD495D2 /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = C6BD4C6336664F3F5A5546B771D889CA /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,109 +90,111 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9CE1FC57ED556647A09C53464FF9EB5A;
+			remoteGlobalIDString = C8FFE709A50B36A8E6CEEFA81A6E808D;
 			remoteInfo = IGListKit;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		043B139A33DFAA38FBDC1EFE7812B099 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
-		048E34044F70E19B27EA5C031FAB24CB /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapter.m; sourceTree = "<group>"; };
-		080119E4F6D6CEF21F508083ACB4BF73 /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
-		085E3578876E8830FEB0A7B38BE5B188 /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
-		0ABCB47C65615D78E7E32639B4910937 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
-		10D727D11F4332F6DA19EACE9342A6EE /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
-		1124D984EB5F7AE78734FEECF159B97A /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdater.h; sourceTree = "<group>"; };
-		1169AEC6171A0A7AE34BC7D5CAE67C6F /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
-		11EA4F25F3580D9FA3807AE30DF460C3 /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
-		1AA5963C11F2745B3F368449883C1858 /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
+		03B2E59B7C3ACF72D8661C19C1358EB6 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListScrollDelegate.h; sourceTree = "<group>"; };
+		067FA52ABE56CBA00D6F579954F37489 /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadDataUpdater.h; sourceTree = "<group>"; };
+		06DF8C24026CF38174CDCC0D27EE7751 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
+		0B139C4F878940362A15BBBBCB654EB3 /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
+		0D8C81E5730BBD035DEED8B23724964F /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		0E571FAC80DA98BCCB608086E20A52DE /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapter.h; sourceTree = "<group>"; };
+		12322B386E670A6D69595370718A4933 /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDataSource.h; sourceTree = "<group>"; };
+		1A267FE34B99BC6F2E94423B173BD776 /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
 		1B2B14BA3AB402D9CC387EEB27A2F746 /* Pods-IGListKitExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		1CF11DA440B0D2CE69016EE14E237D60 /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
+		1C5A6BC2986E88AA6275B449BF72CA4D /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
 		1DC4F8DCC1835BACB957FEAD24EF8700 /* IGListKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IGListKit.xcconfig; sourceTree = "<group>"; };
-		1E3191C490AF6C3204BC95C35C51EE13 /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
-		1EF2C5B280694F0F27B9C3C100050152 /* IGListStackedSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListStackedSectionController.m; sourceTree = "<group>"; };
-		23FD9D40E9DA4DBDC981FEA2E36FBB5A /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
-		29671FCF6680310ECB0AF6DD08DCFC00 /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
-		2A01AD1DA76574C07064AC03414DD23E /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
-		2B07D2F3DC7EBC34C6D4BD2E09EE6168 /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListCollectionView.m; sourceTree = "<group>"; };
-		2DE1B1584F5A67B701443F1AC5A7DF3E /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
-		2EB43BA5778517EB683957E69E7287D9 /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
-		2F19DADF473B46635E38A4450B1F9B96 /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
+		278CDF87A5986509B94ADEF8D9F27FB5 /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
+		2AB88A22C231575AB7FFE0A173B12D28 /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
+		2BF086E44AD2C0322F3F1038C23693CD /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionView.h; sourceTree = "<group>"; };
 		2F5AE0385534EC7E6CA75003A7280492 /* Pods-IGListKitExamples-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitExamples-dummy.m"; sourceTree = "<group>"; };
-		3941E9CD636DDDAB7E4061549E94D2BD /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
-		3A47CA2A158E3620E1F26E872BD32327 /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
-		3C61455C066A8D3E4D1FB0BA5582298F /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
-		3E7F421F40C3DDD78ACD29E6889DFBFC /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionContext.h; sourceTree = "<group>"; };
+		316B64D40DAC0700C0F9C8CD24A69F48 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
+		322D1A72D3E30AB50D9464EDF3B703ED /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
+		3249C1622540620AF93E66D3985B569A /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
+		38010057DBCDCF79B6025556CE641F9E /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
+		3BA9073BE2412CAB09971D9CC040A787 /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
+		3F7F42D29F1416E12A3CA9B758DF8A22 /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
 		428C13C7C57B2D91F00D94ECF1FA71F8 /* Pods-IGListKitExamples-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitExamples-resources.sh"; sourceTree = "<group>"; };
-		430AFA8424CB7AD8B738903FF3A76B1E /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadDataUpdater.h; sourceTree = "<group>"; };
-		4CE7EF88A010E5A35B250287E956D445 /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterUpdater.m; sourceTree = "<group>"; };
-		4E0D46D2D682A428D66209FE6BA14D9A /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		4398B241E89ED47A57D9518834307543 /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		44101B7EC9941E2DAF102A147BA45538 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionController.m; sourceTree = "<group>"; };
+		466ACE48AF49273E10DA7D568B353CCC /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
+		47153303D1E3F2A7C7A293D812E6CE92 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSingleSectionController.m; sourceTree = "<group>"; };
+		47D39852188A57074D8C006731E9AF80 /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionContext.h; sourceTree = "<group>"; };
+		49ADF7794886A94EA55E10BF81D050E1 /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSingleSectionController.h; sourceTree = "<group>"; };
+		4FA719B462564BC9A2527E14D960B69C /* IGListGridCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListGridCollectionViewLayout.h; sourceTree = "<group>"; };
 		52054AE893A0AE7FBFC54333D8ABD345 /* Pods-IGListKitExamples-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitExamples-umbrella.h"; sourceTree = "<group>"; };
-		5296D28B9A0555B81CEF071496A04DD5 /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDelegate.h; sourceTree = "<group>"; };
-		54174D7D374B425718A92BD2CE893C99 /* IGListSectionType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionType.h; sourceTree = "<group>"; };
+		52811104A3D4D278591F628DD32AD53D /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
+		56924D9A37C881D64DE514F00968E8CF /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
 		572DECC5D68B18C3039F4C6A1FEB4A02 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		58A9B3EC590F0AF474D2E52EF418CA83 /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
 		592B0560566B9C72D5FBCFD021AD5884 /* IGListKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListKit.modulemap; sourceTree = "<group>"; };
-		646C56F2C6B1C295E6BD5C110802CF03 /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListKit.h; sourceTree = "<group>"; };
-		6D9F7B6D3E0924236BC11EA21EE300E1 /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		678D8E98F3BE866D7F3A97072728299F /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
 		71D44B887663E8A7D2752C9ED2356648 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		72A1FA4D7D8F72D7BDFD49D8E004E0D0 /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
-		7CA382AEB6E22A5A96AE3E195E1A7355 /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
-		8050F244C733936C2F1761C02033E7AE /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayDelegate.h; sourceTree = "<group>"; };
-		83B504AD14E6B4D01EA2A377304C1CEB /* IGListGridCollectionViewLayout.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListGridCollectionViewLayout.m; sourceTree = "<group>"; };
-		857A1509B449087F7DFB7501450C6D1D /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
-		858D95ACAA310E3FD786F87B6484423B /* IGListGridCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListGridCollectionViewLayout.h; sourceTree = "<group>"; };
-		8F9B9756596244450CDC33EAE08C5F6A /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
+		73F5D0D7ADDE4C13BBE2D4A95BD3D65B /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
+		75FE57F9D38E1CEB8D13D1962D7E5F30 /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
+		8521A2D40EC8D38A765CF7A872E9615D /* IGListStackedSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListStackedSectionController.m; sourceTree = "<group>"; };
+		8B021D11F96D3F1EA9B99055DBCA000E /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
+		8E6C5C492750A12228E4C3F3C22D52C2 /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdater.h; sourceTree = "<group>"; };
+		8F577BEE2642E4863F79B70091358490 /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
+		90DA30866D2D8325EC6D63AACBFD5089 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
+		92005BAC60F7299F9DB4E5724F6102BD /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
+		93534800B7B361322F107A85CD3C8B4C /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDelegate.h; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		943B4B26C72318591920AE4C4E2BB9B8 /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
+		959691397B039E95265F4ACE5F8ECAF9 /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
 		9699862731767A477E47D42C41975A56 /* IGListKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-umbrella.h"; sourceTree = "<group>"; };
-		9766F3C35BDEE3B3DB501F22B2F8F4B8 /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionView.h; sourceTree = "<group>"; };
-		9AD7A054EF9122B02F919014DD1791F0 /* IGListStackedSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionControllerInternal.h; sourceTree = "<group>"; };
+		972F5B2D66A23A895AF6D7AF131B5A88 /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
+		97B199B6A09C09049D0982F0E76DC115 /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
+		9A1AAADDF904925B188C01AA1034F350 /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
 		9D11DCAE06F644E6CCE659622CD8E616 /* IGListKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = IGListKit.framework; path = IGListKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A198E265B2C6E673C7C9C5050F92D9F0 /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
-		A755EC8AF13C011782DA798C437338DB /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
+		A487D5172128C128086E4F3A13AB5694 /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayout.h; sourceTree = "<group>"; };
+		A511D1D31FCB9473B0A0C0757AD691ED /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
+		A6C2DF3D1CD7CEF1B446D7F4DE1DB41B /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
 		A7BBE69D34859663403DA26F14CC4DDB /* Pods-IGListKitExamples-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitExamples-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A851A4ACB8C0DE98BFFBC6FD4D1BACEE /* Pods-IGListKitExamples-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitExamples-frameworks.sh"; sourceTree = "<group>"; };
-		AB11EB12064D3352C26FB85D273CB9D9 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSingleSectionController.m; sourceTree = "<group>"; };
 		AB4C132D7BA00C1384E27FAFD43A44B6 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		ABA4C9F3CA93D08C5A202417C8A635C3 /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterDataSource.h; sourceTree = "<group>"; };
 		ABF549428FEA18696E5358F599E11A24 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AC88C732DEFE844817FFAB2551FA5D75 /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
-		ADAB328495B1698658BE1302C3665DF5 /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapter.h; sourceTree = "<group>"; };
-		ADC4DCF78CDC8E170F10A882627A6C70 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
-		AF5EB9114BE546DE99E0218F7CCF3E69 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionController.m; sourceTree = "<group>"; };
-		B09077F3DFB97E915D6A2A1D3C5545AF /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
-		B1EDEFF830174F1EC40CB3826C87EAC4 /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionController.h; sourceTree = "<group>"; };
-		BD1AE34815F6729F58FD19CDFCECB514 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListScrollDelegate.h; sourceTree = "<group>"; };
-		BE6C6DFC7DF1D34CDBDD776835531F6F /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
-		C1651840D6E3A00F81FA4A933861B8EF /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
+		AE8083AC94564DE6B57A77067BBAFB99 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
+		B07F8EB741375F2BA0F3425526C68170 /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayDelegate.h; sourceTree = "<group>"; };
+		B1E666D5734AE6165634E79C57822F15 /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
+		B24A3DA0BF2517609FF6E7796C4C7D15 /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
+		B66DD022BFDB9A96E2F854C5E96A1DF9 /* IGListSectionType.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionType.h; sourceTree = "<group>"; };
+		B8BA11081DCC84454D3BEA77B2AAD7DE /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapter.m; sourceTree = "<group>"; };
+		BA46A3908001DCDE7C0549AD7E657392 /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
+		C0ABC14C11E94AABA7E779C41DDC8759 /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
 		C21A7CA00A0F4B5304CF04AF01BD52EF /* IGListKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListKit-dummy.m"; sourceTree = "<group>"; };
+		C23F17740AF9DF30FD401B3A6B901909 /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
+		C5FD5DC3382EBAF28CE17EB55087CB02 /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
+		C6BD4C6336664F3F5A5546B771D889CA /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionController.h; sourceTree = "<group>"; };
 		C7F454644FEBF5DB647AE1728D1FD067 /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitExamples.framework; path = "Pods-IGListKitExamples.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C938F229AE318B89FF44857D449D22D6 /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadDataUpdater.m; sourceTree = "<group>"; };
-		CA8EF882B40179FFCDBE248BC29DD73D /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
-		CD71E3890CC58066AF4A757746526BB5 /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
-		D7EF1C1DD1765A8E8004F3C3B18FFAEE /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSingleSectionController.h; sourceTree = "<group>"; };
+		C928FBB74BD7E89442B60D846BA328B5 /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadDataUpdater.m; sourceTree = "<group>"; };
+		CD073F0BF52AE65CC0DCEE7C1A03A3BB /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListCollectionView.m; sourceTree = "<group>"; };
 		D803D538BF4074498E5ADB84A16E0395 /* Pods-IGListKitExamples-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitExamples-acknowledgements.plist"; sourceTree = "<group>"; };
-		D8AE14CF6D326E764C8193685779E9EF /* IGListStackedSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionController.h; sourceTree = "<group>"; };
-		DDE1DA12937AA0946FEB90E2739CC14C /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
+		DB9F460FE6C7D4B50A9941BC0537D086 /* IGListStackedSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionControllerInternal.h; sourceTree = "<group>"; };
+		DDA0B8E96A8BBD92033B00032C8B987F /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
 		DDF922EBFB237C1B42E8B07306D987E8 /* Pods-IGListKitExamples.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-IGListKitExamples.modulemap"; sourceTree = "<group>"; };
-		DF4C3E784E1FA06A6E1B19E4B00FA901 /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
-		E08BD32B6482D0DA523DAD2879F6C59C /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
-		EA44A1506A965754F508FE7E6787B6F6 /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
-		EB13557EA46D8B6A8B037DB51E6A95CB /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
-		EF0DB26C9F468230CF6A5AC8E1BEABFF /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
+		E1FBFC4D5641BC6125490BEE115407EA /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterUpdater.m; sourceTree = "<group>"; };
+		E37BDBCC215FFAC6EC90A309F9917A95 /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
+		E3C2A0577C1902B3D0E423FA91BE9C3C /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListKit.h; sourceTree = "<group>"; };
+		EA618C61AA0A3EC9B73D80FBBFA7555A /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
+		F098CA1A21FC56BDC2C137DF21CBC1CF /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
+		F138A3E22D6DA4AB8EBFDE3B730A9D70 /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
 		F59E7B2DB26D99FB12B7F05A0171A69B /* IGListKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-prefix.pch"; sourceTree = "<group>"; };
-		FE2E9121D30C841E5270620194D340D0 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
-		FF71E22114DCCABAD081380F33C6A8D8 /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
+		F60A259E23D35D49857F23FA5D13920E /* IGListStackedSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionController.h; sourceTree = "<group>"; };
+		F7B20CAC621D971E8BB2EA69F5DD99FC /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
+		FBAB3E76D0D88D0943639ACA7E60FDE8 /* IGListGridCollectionViewLayout.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListGridCollectionViewLayout.m; sourceTree = "<group>"; };
+		FCA366ADD099DB3B9DACD51553BAFC37 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		676279F9D230F11E09570AE3DA250FC3 /* Frameworks */ = {
+		56774D8F74203FBD49A94FCFD02348AB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B4AD7676612D295C20AE41655763F42D /* Foundation.framework in Frameworks */,
-				BE98D9E362B09006F178AEF6B5CA8460 /* UIKit.framework in Frameworks */,
+				F27439472EC00AF82FE64B8CD2DC6A87 /* Foundation.framework in Frameworks */,
+				D42590D23FF9454239269699AEBDC3F7 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -230,43 +234,6 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		5E134878607ECDBEDD33D1D73D979C83 /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				ADAB328495B1698658BE1302C3665DF5 /* IGListAdapter.h */,
-				048E34044F70E19B27EA5C031FAB24CB /* IGListAdapter.m */,
-				ABA4C9F3CA93D08C5A202417C8A635C3 /* IGListAdapterDataSource.h */,
-				5296D28B9A0555B81CEF071496A04DD5 /* IGListAdapterDelegate.h */,
-				1124D984EB5F7AE78734FEECF159B97A /* IGListAdapterUpdater.h */,
-				4CE7EF88A010E5A35B250287E956D445 /* IGListAdapterUpdater.m */,
-				CD71E3890CC58066AF4A757746526BB5 /* IGListAdapterUpdaterDelegate.h */,
-				3E7F421F40C3DDD78ACD29E6889DFBFC /* IGListCollectionContext.h */,
-				9766F3C35BDEE3B3DB501F22B2F8F4B8 /* IGListCollectionView.h */,
-				2B07D2F3DC7EBC34C6D4BD2E09EE6168 /* IGListCollectionView.m */,
-				8050F244C733936C2F1761C02033E7AE /* IGListDisplayDelegate.h */,
-				858D95ACAA310E3FD786F87B6484423B /* IGListGridCollectionViewLayout.h */,
-				83B504AD14E6B4D01EA2A377304C1CEB /* IGListGridCollectionViewLayout.m */,
-				646C56F2C6B1C295E6BD5C110802CF03 /* IGListKit.h */,
-				430AFA8424CB7AD8B738903FF3A76B1E /* IGListReloadDataUpdater.h */,
-				C938F229AE318B89FF44857D449D22D6 /* IGListReloadDataUpdater.m */,
-				BD1AE34815F6729F58FD19CDFCECB514 /* IGListScrollDelegate.h */,
-				B1EDEFF830174F1EC40CB3826C87EAC4 /* IGListSectionController.h */,
-				AF5EB9114BE546DE99E0218F7CCF3E69 /* IGListSectionController.m */,
-				54174D7D374B425718A92BD2CE893C99 /* IGListSectionType.h */,
-				D7EF1C1DD1765A8E8004F3C3B18FFAEE /* IGListSingleSectionController.h */,
-				AB11EB12064D3352C26FB85D273CB9D9 /* IGListSingleSectionController.m */,
-				D8AE14CF6D326E764C8193685779E9EF /* IGListStackedSectionController.h */,
-				1EF2C5B280694F0F27B9C3C100050152 /* IGListStackedSectionController.m */,
-				080119E4F6D6CEF21F508083ACB4BF73 /* IGListSupplementaryViewSource.h */,
-				6D9F7B6D3E0924236BC11EA21EE300E1 /* IGListUpdatingDelegate.h */,
-				857A1509B449087F7DFB7501450C6D1D /* IGListWorkingRangeDelegate.h */,
-				7544501CEAC4B4D682B2FF7022438B98 /* Common */,
-				95C533EF4771978765630D9448D9F088 /* Internal */,
-			);
-			name = Source;
-			path = Source;
-			sourceTree = "<group>";
-		};
 		61F96534B3AFE724944526CC9F6F2EFE /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -284,6 +251,14 @@
 			path = Internal;
 			sourceTree = "<group>";
 		};
+		6A8EE60BF5506541FC2A3F296D948FB3 /* Default */ = {
+			isa = PBXGroup;
+			children = (
+				A53AE53AAC183B9C5A7A78A57A83EED1 /* Source */,
+			);
+			name = Default;
+			sourceTree = "<group>";
+		};
 		6EC461C1435A31577346ED4ADA0BD5A9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -292,43 +267,69 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		7544501CEAC4B4D682B2FF7022438B98 /* Common */ = {
+		6FB065C2DAD61837A1EC7AD071BAC95B /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				29671FCF6680310ECB0AF6DD08DCFC00 /* IGListAssert.h */,
-				FE2E9121D30C841E5270620194D340D0 /* IGListBatchUpdateData.h */,
-				043B139A33DFAA38FBDC1EFE7812B099 /* IGListBatchUpdateData.mm */,
-				3A47CA2A158E3620E1F26E872BD32327 /* IGListCompatibility.h */,
-				943B4B26C72318591920AE4C4E2BB9B8 /* IGListDiff.h */,
-				7CA382AEB6E22A5A96AE3E195E1A7355 /* IGListDiff.mm */,
-				FF71E22114DCCABAD081380F33C6A8D8 /* IGListDiffable.h */,
-				2DE1B1584F5A67B701443F1AC5A7DF3E /* IGListDiffKit.h */,
-				10D727D11F4332F6DA19EACE9342A6EE /* IGListExperiments.h */,
-				72A1FA4D7D8F72D7BDFD49D8E004E0D0 /* IGListIndexPathResult.h */,
-				2A01AD1DA76574C07064AC03414DD23E /* IGListIndexPathResult.m */,
-				23FD9D40E9DA4DBDC981FEA2E36FBB5A /* IGListIndexSetResult.h */,
-				ADC4DCF78CDC8E170F10A882627A6C70 /* IGListIndexSetResult.m */,
-				EF0DB26C9F468230CF6A5AC8E1BEABFF /* IGListMacros.h */,
-				11EA4F25F3580D9FA3807AE30DF460C3 /* IGListMoveIndex.h */,
-				EA44A1506A965754F508FE7E6787B6F6 /* IGListMoveIndex.m */,
-				1AA5963C11F2745B3F368449883C1858 /* IGListMoveIndexPath.h */,
-				2EB43BA5778517EB683957E69E7287D9 /* IGListMoveIndexPath.m */,
-				1E3191C490AF6C3204BC95C35C51EE13 /* NSNumber+IGListDiffable.h */,
-				A755EC8AF13C011782DA798C437338DB /* NSNumber+IGListDiffable.m */,
-				1CF11DA440B0D2CE69016EE14E237D60 /* NSString+IGListDiffable.h */,
-				DF4C3E784E1FA06A6E1B19E4B00FA901 /* NSString+IGListDiffable.m */,
-				999637C30E0BCAD6ADE4EC74EF7BBDD1 /* Internal */,
+				3BA9073BE2412CAB09971D9CC040A787 /* IGListAssert.h */,
+				F098CA1A21FC56BDC2C137DF21CBC1CF /* IGListBatchUpdateData.h */,
+				06DF8C24026CF38174CDCC0D27EE7751 /* IGListBatchUpdateData.mm */,
+				E37BDBCC215FFAC6EC90A309F9917A95 /* IGListCompatibility.h */,
+				B1E666D5734AE6165634E79C57822F15 /* IGListDiff.h */,
+				959691397B039E95265F4ACE5F8ECAF9 /* IGListDiff.mm */,
+				466ACE48AF49273E10DA7D568B353CCC /* IGListDiffable.h */,
+				1A267FE34B99BC6F2E94423B173BD776 /* IGListDiffKit.h */,
+				B24A3DA0BF2517609FF6E7796C4C7D15 /* IGListExperiments.h */,
+				2AB88A22C231575AB7FFE0A173B12D28 /* IGListIndexPathResult.h */,
+				EA618C61AA0A3EC9B73D80FBBFA7555A /* IGListIndexPathResult.m */,
+				3F7F42D29F1416E12A3CA9B758DF8A22 /* IGListIndexSetResult.h */,
+				90DA30866D2D8325EC6D63AACBFD5089 /* IGListIndexSetResult.m */,
+				AE8083AC94564DE6B57A77067BBAFB99 /* IGListMacros.h */,
+				322D1A72D3E30AB50D9464EDF3B703ED /* IGListMoveIndex.h */,
+				278CDF87A5986509B94ADEF8D9F27FB5 /* IGListMoveIndex.m */,
+				92005BAC60F7299F9DB4E5724F6102BD /* IGListMoveIndexPath.h */,
+				A511D1D31FCB9473B0A0C0757AD691ED /* IGListMoveIndexPath.m */,
+				972F5B2D66A23A895AF6D7AF131B5A88 /* NSNumber+IGListDiffable.h */,
+				678D8E98F3BE866D7F3A97072728299F /* NSNumber+IGListDiffable.m */,
+				8F577BEE2642E4863F79B70091358490 /* NSString+IGListDiffable.h */,
+				DDA0B8E96A8BBD92033B00032C8B987F /* NSString+IGListDiffable.m */,
+				77EB705CBB5B26405E5991172365B18A /* Internal */,
 			);
 			name = Common;
 			path = Common;
 			sourceTree = "<group>";
 		};
-		76B43F3090BFABA38F93DB589E47C042 /* Default */ = {
+		77EB705CBB5B26405E5991172365B18A /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				5E134878607ECDBEDD33D1D73D979C83 /* Source */,
+				C5FD5DC3382EBAF28CE17EB55087CB02 /* IGListIndexPathResultInternal.h */,
+				8B021D11F96D3F1EA9B99055DBCA000E /* IGListIndexSetResultInternal.h */,
+				FCA366ADD099DB3B9DACD51553BAFC37 /* IGListMoveIndexInternal.h */,
+				38010057DBCDCF79B6025556CE641F9E /* IGListMoveIndexPathInternal.h */,
 			);
-			name = Default;
+			name = Internal;
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		78EBE2321AC5F9C83B825331D0181EDA /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				3249C1622540620AF93E66D3985B569A /* IGListAdapterInternal.h */,
+				F138A3E22D6DA4AB8EBFDE3B730A9D70 /* IGListAdapterProxy.h */,
+				75FE57F9D38E1CEB8D13D1962D7E5F30 /* IGListAdapterProxy.m */,
+				0D8C81E5730BBD035DEED8B23724964F /* IGListAdapterUpdaterInternal.h */,
+				97B199B6A09C09049D0982F0E76DC115 /* IGListDisplayHandler.h */,
+				BA46A3908001DCDE7C0549AD7E657392 /* IGListDisplayHandler.m */,
+				C23F17740AF9DF30FD401B3A6B901909 /* IGListSectionControllerInternal.h */,
+				C0ABC14C11E94AABA7E779C41DDC8759 /* IGListSectionMap.h */,
+				1C5A6BC2986E88AA6275B449BF72CA4D /* IGListSectionMap.m */,
+				DB9F460FE6C7D4B50A9941BC0537D086 /* IGListStackedSectionControllerInternal.h */,
+				316B64D40DAC0700C0F9C8CD24A69F48 /* IGListWorkingRangeHandler.h */,
+				52811104A3D4D278591F628DD32AD53D /* IGListWorkingRangeHandler.mm */,
+				0B139C4F878940362A15BBBBCB654EB3 /* UICollectionView+IGListBatchUpdateData.h */,
+				56924D9A37C881D64DE514F00968E8CF /* UICollectionView+IGListBatchUpdateData.m */,
+			);
+			name = Internal;
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
@@ -342,38 +343,43 @@
 			);
 			sourceTree = "<group>";
 		};
-		95C533EF4771978765630D9448D9F088 /* Internal */ = {
+		A53AE53AAC183B9C5A7A78A57A83EED1 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				8F9B9756596244450CDC33EAE08C5F6A /* IGListAdapterInternal.h */,
-				B09077F3DFB97E915D6A2A1D3C5545AF /* IGListAdapterProxy.h */,
-				EB13557EA46D8B6A8B037DB51E6A95CB /* IGListAdapterProxy.m */,
-				4E0D46D2D682A428D66209FE6BA14D9A /* IGListAdapterUpdaterInternal.h */,
-				BE6C6DFC7DF1D34CDBDD776835531F6F /* IGListDisplayHandler.h */,
-				085E3578876E8830FEB0A7B38BE5B188 /* IGListDisplayHandler.m */,
-				DDE1DA12937AA0946FEB90E2739CC14C /* IGListSectionControllerInternal.h */,
-				E08BD32B6482D0DA523DAD2879F6C59C /* IGListSectionMap.h */,
-				1169AEC6171A0A7AE34BC7D5CAE67C6F /* IGListSectionMap.m */,
-				9AD7A054EF9122B02F919014DD1791F0 /* IGListStackedSectionControllerInternal.h */,
-				0ABCB47C65615D78E7E32639B4910937 /* IGListWorkingRangeHandler.h */,
-				3C61455C066A8D3E4D1FB0BA5582298F /* IGListWorkingRangeHandler.mm */,
-				AC88C732DEFE844817FFAB2551FA5D75 /* UICollectionView+IGListBatchUpdateData.h */,
-				CA8EF882B40179FFCDBE248BC29DD73D /* UICollectionView+IGListBatchUpdateData.m */,
+				0E571FAC80DA98BCCB608086E20A52DE /* IGListAdapter.h */,
+				B8BA11081DCC84454D3BEA77B2AAD7DE /* IGListAdapter.m */,
+				12322B386E670A6D69595370718A4933 /* IGListAdapterDataSource.h */,
+				93534800B7B361322F107A85CD3C8B4C /* IGListAdapterDelegate.h */,
+				8E6C5C492750A12228E4C3F3C22D52C2 /* IGListAdapterUpdater.h */,
+				E1FBFC4D5641BC6125490BEE115407EA /* IGListAdapterUpdater.m */,
+				9A1AAADDF904925B188C01AA1034F350 /* IGListAdapterUpdaterDelegate.h */,
+				47D39852188A57074D8C006731E9AF80 /* IGListCollectionContext.h */,
+				2BF086E44AD2C0322F3F1038C23693CD /* IGListCollectionView.h */,
+				CD073F0BF52AE65CC0DCEE7C1A03A3BB /* IGListCollectionView.m */,
+				A487D5172128C128086E4F3A13AB5694 /* IGListCollectionViewLayout.h */,
+				F7B20CAC621D971E8BB2EA69F5DD99FC /* IGListCollectionViewLayout.mm */,
+				B07F8EB741375F2BA0F3425526C68170 /* IGListDisplayDelegate.h */,
+				4FA719B462564BC9A2527E14D960B69C /* IGListGridCollectionViewLayout.h */,
+				FBAB3E76D0D88D0943639ACA7E60FDE8 /* IGListGridCollectionViewLayout.m */,
+				E3C2A0577C1902B3D0E423FA91BE9C3C /* IGListKit.h */,
+				067FA52ABE56CBA00D6F579954F37489 /* IGListReloadDataUpdater.h */,
+				C928FBB74BD7E89442B60D846BA328B5 /* IGListReloadDataUpdater.m */,
+				03B2E59B7C3ACF72D8661C19C1358EB6 /* IGListScrollDelegate.h */,
+				C6BD4C6336664F3F5A5546B771D889CA /* IGListSectionController.h */,
+				44101B7EC9941E2DAF102A147BA45538 /* IGListSectionController.m */,
+				B66DD022BFDB9A96E2F854C5E96A1DF9 /* IGListSectionType.h */,
+				49ADF7794886A94EA55E10BF81D050E1 /* IGListSingleSectionController.h */,
+				47153303D1E3F2A7C7A293D812E6CE92 /* IGListSingleSectionController.m */,
+				F60A259E23D35D49857F23FA5D13920E /* IGListStackedSectionController.h */,
+				8521A2D40EC8D38A765CF7A872E9615D /* IGListStackedSectionController.m */,
+				73F5D0D7ADDE4C13BBE2D4A95BD3D65B /* IGListSupplementaryViewSource.h */,
+				4398B241E89ED47A57D9518834307543 /* IGListUpdatingDelegate.h */,
+				A6C2DF3D1CD7CEF1B446D7F4DE1DB41B /* IGListWorkingRangeDelegate.h */,
+				6FB065C2DAD61837A1EC7AD071BAC95B /* Common */,
+				78EBE2321AC5F9C83B825331D0181EDA /* Internal */,
 			);
-			name = Internal;
-			path = Internal;
-			sourceTree = "<group>";
-		};
-		999637C30E0BCAD6ADE4EC74EF7BBDD1 /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				3941E9CD636DDDAB7E4061549E94D2BD /* IGListIndexPathResultInternal.h */,
-				2F19DADF473B46635E38A4450B1F9B96 /* IGListIndexSetResultInternal.h */,
-				C1651840D6E3A00F81FA4A933861B8EF /* IGListMoveIndexInternal.h */,
-				58A9B3EC590F0AF474D2E52EF418CA83 /* IGListMoveIndexPathInternal.h */,
-			);
-			name = Internal;
-			path = Internal;
+			name = Source;
+			path = Source;
 			sourceTree = "<group>";
 		};
 		BEBFF9E5DE688C85D9EA208AFED4879F /* Source */ = {
@@ -428,7 +434,7 @@
 		F2C5A40FFA2E4FDDEA3BEEA6B5D9F911 /* IGListKit */ = {
 			isa = PBXGroup;
 			children = (
-				76B43F3090BFABA38F93DB589E47C042 /* Default */,
+				6A8EE60BF5506541FC2A3F296D948FB3 /* Default */,
 				E593A79088D6203A7F30089971215267 /* Diffing */,
 				D998550EE75611561B6DAB60A976F7D0 /* Support Files */,
 			);
@@ -448,57 +454,58 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		DC870AF655C7F74AEC6246B9FC3D3475 /* Headers */ = {
+		8326470A44614024567D27E763C15D6F /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E3F3D0B97462F6EBAD13EA91F0F6212A /* IGListAdapter.h in Headers */,
-				7201CDE3182F7CCAA0D9EDAA5346EB00 /* IGListAdapterDataSource.h in Headers */,
-				3CB9FF8EE402C8EE978F7827538982C0 /* IGListAdapterDelegate.h in Headers */,
-				83D4E09F31A387ADCDE669B3185B8849 /* IGListAdapterInternal.h in Headers */,
-				4087748A7E033F7B113F008696F10100 /* IGListAdapterProxy.h in Headers */,
-				5049064A9255B5B681AE820BF054CF18 /* IGListAdapterUpdater.h in Headers */,
-				580A85CE009B9B1B19E2FEAF5446FE19 /* IGListAdapterUpdaterDelegate.h in Headers */,
-				F376B87428013B5FB2AC705A90E084A2 /* IGListAdapterUpdaterInternal.h in Headers */,
-				6E47CEDB94A176B0CB142CA479DFEDB2 /* IGListAssert.h in Headers */,
-				56BC154A684A2CE83B207A7A79B2AA79 /* IGListBatchUpdateData.h in Headers */,
-				5C490928BABB0EF533E0E54CD4A0102D /* IGListCollectionContext.h in Headers */,
-				81F1C424E560910B109D4BB6ECBE2EC6 /* IGListCollectionView.h in Headers */,
-				20C776592B599DACFBEA25CEBE2BD5B5 /* IGListCompatibility.h in Headers */,
-				06E48130C61B46DD674D2D6BFC11901D /* IGListDiff.h in Headers */,
-				70F593265D74E691B47D4EBE8536517E /* IGListDiffable.h in Headers */,
-				D44A1AE4A2AD83B4D81015DA09F35450 /* IGListDiffKit.h in Headers */,
-				97682876C9B6181D19D746AE3C2278F4 /* IGListDisplayDelegate.h in Headers */,
-				ED4C4D8C79179EF7D0F7A9D6A78B3028 /* IGListDisplayHandler.h in Headers */,
-				2C2747A131B2BF3C9FF512B68597998B /* IGListExperiments.h in Headers */,
-				C506D8A24A14D01EEC1BE8CE7CD2C164 /* IGListGridCollectionViewLayout.h in Headers */,
-				76B1E85B1B2AE0BF0F3EFE20E96D65CA /* IGListIndexPathResult.h in Headers */,
-				3EFBC9584ED9BDA7DA02206B4A1BE3D7 /* IGListIndexPathResultInternal.h in Headers */,
-				63F2505138750A7498D3C948AFCCCD23 /* IGListIndexSetResult.h in Headers */,
-				CFFF332D28FB693561D6D2DDAE8B7EF6 /* IGListIndexSetResultInternal.h in Headers */,
-				F41FEEE5690485539BCAC553974FE6A7 /* IGListKit-umbrella.h in Headers */,
-				4083D1A227353B9CEA104788D83D4BA4 /* IGListKit.h in Headers */,
-				AC5FA1790BCB08D8BE6CF6124FF300C0 /* IGListMacros.h in Headers */,
-				0E45609BB284A81673F917EFA1C79F00 /* IGListMoveIndex.h in Headers */,
-				EC4BD0B3B63D7B876AB2FB2035F82E61 /* IGListMoveIndexInternal.h in Headers */,
-				DFAACC0AF49FAE11E092F2EA2C35D48E /* IGListMoveIndexPath.h in Headers */,
-				0F2729D06BF400CF3E8590E67608EA2D /* IGListMoveIndexPathInternal.h in Headers */,
-				D099903FB310D5A12B23B3A43BCCED8D /* IGListReloadDataUpdater.h in Headers */,
-				984C2F0951A593458769BBFD5C845B96 /* IGListScrollDelegate.h in Headers */,
-				ED97249B08390763C07ECA48A6C2089E /* IGListSectionController.h in Headers */,
-				11BB692868610B1C1A89053F713C4236 /* IGListSectionControllerInternal.h in Headers */,
-				D78A53EA678B4828CD033E20D8084292 /* IGListSectionMap.h in Headers */,
-				0E4EF7D9F292CE93E8253E29728D6DC7 /* IGListSectionType.h in Headers */,
-				0B8647DEC498B2E89EE01BEB006275D6 /* IGListSingleSectionController.h in Headers */,
-				F822A5D8EF3791FACBE74C754D579489 /* IGListStackedSectionController.h in Headers */,
-				E860594EC0FAF157159C0C0DAE33C6BA /* IGListStackedSectionControllerInternal.h in Headers */,
-				6E05E9BFD9B91DB07DCCB2CD8B18CDC3 /* IGListSupplementaryViewSource.h in Headers */,
-				968D6E4549F53AB3151B434AE102711B /* IGListUpdatingDelegate.h in Headers */,
-				D5DB2A7D796C1EA166A4D719D785FECF /* IGListWorkingRangeDelegate.h in Headers */,
-				73B92B0EC06263755BA5960BC8A65B02 /* IGListWorkingRangeHandler.h in Headers */,
-				5E2452BF11067A611340CB9C654037D1 /* NSNumber+IGListDiffable.h in Headers */,
-				CE6A0032D5362E3EEE3CBF08FAB8CCD5 /* NSString+IGListDiffable.h in Headers */,
-				F8CEF7EE893CEBE0F01D3D6F91DC1FD2 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
+				7025B5FD1E713D99EB130037FDD9920A /* IGListAdapter.h in Headers */,
+				A7076D98D4A84CF84A7D1114435E08C2 /* IGListAdapterDataSource.h in Headers */,
+				1B58DD85CAB309DFD10AC8371784C1C6 /* IGListAdapterDelegate.h in Headers */,
+				FAADDDFD575939F342DC0EB33C46102E /* IGListAdapterInternal.h in Headers */,
+				3DA7F209EFA56B0FE51B2D2F74A764F4 /* IGListAdapterProxy.h in Headers */,
+				52A165DB4F13E4B383D1F9B8E725716D /* IGListAdapterUpdater.h in Headers */,
+				D351299A0B6FABFD60835D26A071934A /* IGListAdapterUpdaterDelegate.h in Headers */,
+				24671B7BB1B273DDF93C0F84436FE83F /* IGListAdapterUpdaterInternal.h in Headers */,
+				684E29407CC45D82238936D271F817B5 /* IGListAssert.h in Headers */,
+				49E2D0633E49EFDF5E81CEF258D6FA9F /* IGListBatchUpdateData.h in Headers */,
+				9939E6F72560E556DBBC193523EA1565 /* IGListCollectionContext.h in Headers */,
+				FBAE002D5D392B1C0B1513758CAC2F95 /* IGListCollectionView.h in Headers */,
+				9942D193832F197046B2606FC0DF8B4D /* IGListCollectionViewLayout.h in Headers */,
+				FABBE08E7C27E02F72B072CF42FD9619 /* IGListCompatibility.h in Headers */,
+				2D71A0E1CE80BD6382B43803D93E7A0B /* IGListDiff.h in Headers */,
+				94F5112620D580A88C0A0E495871AFD5 /* IGListDiffable.h in Headers */,
+				4D91C3E61B324897958DCE8965EC0D86 /* IGListDiffKit.h in Headers */,
+				2A7A79F69BE70FF3E26E5B5F1E6D9389 /* IGListDisplayDelegate.h in Headers */,
+				18C83DBC6EE5A90364983B388CD9F9AA /* IGListDisplayHandler.h in Headers */,
+				752376C890CF4BAB2F04C29F343C51A0 /* IGListExperiments.h in Headers */,
+				7EA100A6EAEBB641FA6FCFF32C35E36D /* IGListGridCollectionViewLayout.h in Headers */,
+				802D9E93BF6999351D7410DB58D55BDE /* IGListIndexPathResult.h in Headers */,
+				5BA3992DFE1D781FC63FE6DA01FA9A94 /* IGListIndexPathResultInternal.h in Headers */,
+				6BFB986E530B6684679742EF2AEA2D8D /* IGListIndexSetResult.h in Headers */,
+				E46248A5BA890CF52B2D99D22E80EB78 /* IGListIndexSetResultInternal.h in Headers */,
+				69BE65435B8C06B8D7BB2432CD42CEFE /* IGListKit-umbrella.h in Headers */,
+				01D960147A50B0AD89063323798E95A5 /* IGListKit.h in Headers */,
+				D6BC5A25B977372C1795830B2FE80BB7 /* IGListMacros.h in Headers */,
+				E469EB08F12FCD2777918299B5CC8EEB /* IGListMoveIndex.h in Headers */,
+				B5B4C2CD7C6D966C2A7791D4C94347D6 /* IGListMoveIndexInternal.h in Headers */,
+				B74CE62D05C4BF0B09D8D6F47C117D2C /* IGListMoveIndexPath.h in Headers */,
+				577C8C904DDB755609EEDA5ABEF3025D /* IGListMoveIndexPathInternal.h in Headers */,
+				8A08F7FC9BC02D22D544D8F3B58ACC09 /* IGListReloadDataUpdater.h in Headers */,
+				4D6885C5F1380275DDF40178E0170014 /* IGListScrollDelegate.h in Headers */,
+				FC2AD36A65985DF0B6039CDFDDD495D2 /* IGListSectionController.h in Headers */,
+				69DBA1085FB0EC6401FF67947EB47451 /* IGListSectionControllerInternal.h in Headers */,
+				522742C0B97521E0633735AD6532B482 /* IGListSectionMap.h in Headers */,
+				F02EC7E844F17A792A7A47B2ED54810D /* IGListSectionType.h in Headers */,
+				D53CE6BFDE81C2849E2D655816D40D83 /* IGListSingleSectionController.h in Headers */,
+				15EBEE41EB35F173F1223522B0361668 /* IGListStackedSectionController.h in Headers */,
+				E894EDACBC44D5909E6191181C7100B7 /* IGListStackedSectionControllerInternal.h in Headers */,
+				B913048F3FEFBCF8E92DF4FEC2327D08 /* IGListSupplementaryViewSource.h in Headers */,
+				7AF1A995D99680AE42E9827F3938AFA3 /* IGListUpdatingDelegate.h in Headers */,
+				55C2E3F3FA5E34475A161E1E150C7550 /* IGListWorkingRangeDelegate.h in Headers */,
+				06F8E88488FE810B9E172CFE33ED41F7 /* IGListWorkingRangeHandler.h in Headers */,
+				99CAC417EE670DC893C2EF2CD1ABB618 /* NSNumber+IGListDiffable.h in Headers */,
+				707397172DA3CAFA8E0935B4E9BB5C94 /* NSString+IGListDiffable.h in Headers */,
+				C27A53137529E6E1523E25E1472B0D77 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,13 +538,13 @@
 			productReference = C7F454644FEBF5DB647AE1728D1FD067 /* Pods_IGListKitExamples.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */ = {
+		C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8DADDAFB45D948BB78A504DFD61C6FB3 /* Build configuration list for PBXNativeTarget "IGListKit" */;
+			buildConfigurationList = F71F0CDD33B849DD0FE9EF7A6721683A /* Build configuration list for PBXNativeTarget "IGListKit" */;
 			buildPhases = (
-				6836496CD48A06C080823962A1F1C20B /* Sources */,
-				676279F9D230F11E09570AE3DA250FC3 /* Frameworks */,
-				DC870AF655C7F74AEC6246B9FC3D3475 /* Headers */,
+				1AF34C6050B00806D96719AB748F3C58 /* Sources */,
+				56774D8F74203FBD49A94FCFD02348AB /* Frameworks */,
+				8326470A44614024567D27E763C15D6F /* Headers */,
 			);
 			buildRules = (
 			);
@@ -569,7 +576,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */,
+				C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */,
 				6B7DA8C024D099705CF771FF16E6FC16 /* Pods-IGListKitExamples */,
 			);
 		};
@@ -584,32 +591,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6836496CD48A06C080823962A1F1C20B /* Sources */ = {
+		1AF34C6050B00806D96719AB748F3C58 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8D3C2055830CBB009FD573A573EE81B2 /* IGListAdapter.m in Sources */,
-				8E1D2B5ED4785D929E6C6886ED21DA15 /* IGListAdapterProxy.m in Sources */,
-				1871E1D447E0C147C84B1BB5AB2A8289 /* IGListAdapterUpdater.m in Sources */,
-				8894FBD9663EE633E6B19497BB6FDBD0 /* IGListBatchUpdateData.mm in Sources */,
-				BC3054D66CE4FA6E84CE82C696F446FA /* IGListCollectionView.m in Sources */,
-				86C91F3A89F9683BA3A8F5AA54E8AA08 /* IGListDiff.mm in Sources */,
-				02538AD450DD078DE24C22B03CA856D7 /* IGListDisplayHandler.m in Sources */,
-				0E77DF509A11BEA2B4FC9096323B57A1 /* IGListGridCollectionViewLayout.m in Sources */,
-				A524BD6FA5B85CB1839A10ADA68ACE77 /* IGListIndexPathResult.m in Sources */,
-				E230A3E09D2E48BCF7EB60F565F18690 /* IGListIndexSetResult.m in Sources */,
-				D922D112237DBFE7C3FAC62DF2D07F3D /* IGListKit-dummy.m in Sources */,
-				517439F690B63858DFF5104AF8DAAB58 /* IGListMoveIndex.m in Sources */,
-				9ABE87D3484334FD79EDD6FABE32EAAC /* IGListMoveIndexPath.m in Sources */,
-				F42CD0C401C2B1D2B183535DA794302B /* IGListReloadDataUpdater.m in Sources */,
-				CA1A85850EE450CD49CBD54E595577A6 /* IGListSectionController.m in Sources */,
-				4D7AC944906022E9C1CA8CA31705D5D8 /* IGListSectionMap.m in Sources */,
-				484458D2F230B607F24B61470F484B73 /* IGListSingleSectionController.m in Sources */,
-				CCA6CB8E8819B9D032B90F3CD0015550 /* IGListStackedSectionController.m in Sources */,
-				5A8A597D0274374C6C283294A5E99EA7 /* IGListWorkingRangeHandler.mm in Sources */,
-				89CB98DBDE68549E708D91862247F905 /* NSNumber+IGListDiffable.m in Sources */,
-				734D0DD10CA2837A43EFF5929B63CC38 /* NSString+IGListDiffable.m in Sources */,
-				0516BDDE5DB0048ECFFEC0EC8ACE404F /* UICollectionView+IGListBatchUpdateData.m in Sources */,
+				5921F3BF43B02C6C9FD1612FA4D69FDB /* IGListAdapter.m in Sources */,
+				0C92682C2F3006D7850E1ED5BD76B866 /* IGListAdapterProxy.m in Sources */,
+				7D5CE5E55109BF2D2E72F4DC4418E4EE /* IGListAdapterUpdater.m in Sources */,
+				B4247B838DEB8037E98E0171BC46CFA3 /* IGListBatchUpdateData.mm in Sources */,
+				BC084214AE6061F593784CFBB66226DF /* IGListCollectionView.m in Sources */,
+				4F7F4F7BB3D07B3A9DE3E0858B02F63C /* IGListCollectionViewLayout.mm in Sources */,
+				38D672CA93D1AE1EAB3F89212B5B7D40 /* IGListDiff.mm in Sources */,
+				320A1C4C3413EB1AA898DBBC513A1F35 /* IGListDisplayHandler.m in Sources */,
+				C36489FE69B295502E1CD6D943E332E4 /* IGListGridCollectionViewLayout.m in Sources */,
+				EAD4262C7C09BD4E217D6E40D1A68655 /* IGListIndexPathResult.m in Sources */,
+				4502A5A9A265E5A901223721FE3FD45B /* IGListIndexSetResult.m in Sources */,
+				1C9880BCCC1110014B8977006A2671A4 /* IGListKit-dummy.m in Sources */,
+				31C48B86CE9E325FCB4FB69A87494105 /* IGListMoveIndex.m in Sources */,
+				DE95203F33CB5EE5DF5F9671BA6CBA26 /* IGListMoveIndexPath.m in Sources */,
+				1BF9D4830CFC408E66D65D49271A47CE /* IGListReloadDataUpdater.m in Sources */,
+				DBCF13DA01CA7B8E23EC60436A9B54CF /* IGListSectionController.m in Sources */,
+				5F3BD5B484A8FE2554BD1FACEE219516 /* IGListSectionMap.m in Sources */,
+				3CCA6A6721A6CC5F13A5CE7886C08C4D /* IGListSingleSectionController.m in Sources */,
+				F952415DF594C60359C82BA2B3CE3E00 /* IGListStackedSectionController.m in Sources */,
+				74AC5B625D916B9901881A951510E87C /* IGListWorkingRangeHandler.mm in Sources */,
+				AB27911ABADEC8A211A2A71223901F37 /* NSNumber+IGListDiffable.m in Sources */,
+				6DD3C165ACE9D427248805159BBFDEF6 /* NSString+IGListDiffable.m in Sources */,
+				FB1BF9A9C0ABAD993CEF66EDABFDCD71 /* UICollectionView+IGListBatchUpdateData.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -619,12 +627,44 @@
 		9B463355891949F736B3B5D678FE8D02 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 9CE1FC57ED556647A09C53464FF9EB5A /* IGListKit */;
+			target = C8FFE709A50B36A8E6CEEFA81A6E808D /* IGListKit */;
 			targetProxy = A0A5426482C447F640D6A192E71D5F5B /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		18D4E12BFCDE69FC40678F1DB3211B6F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1DC4F8DCC1835BACB957FEAD24EF8700 /* IGListKit.xcconfig */;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/IGListKit/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = IGListKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		1DD1CFF0DC5554065098F7DC1848365A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -700,7 +740,7 @@
 			};
 			name = Debug;
 		};
-		7ACF955A961A5E8526967ED157855AA4 /* Release */ = {
+		72E1B26341B85F9DECC7FC8B508397DD /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1DC4F8DCC1835BACB957FEAD24EF8700 /* IGListKit.xcconfig */;
 			buildSettings = {
@@ -776,38 +816,6 @@
 			};
 			name = Debug;
 		};
-		93B6A0432D75A801A8BA6D1EE8CE45C6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1DC4F8DCC1835BACB957FEAD24EF8700 /* IGListKit.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/IGListKit/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = IGListKit;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		D04E368E88FCE29BD15438FCE317E815 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A198E265B2C6E673C7C9C5050F92D9F0 /* Pods-IGListKitExamples.release.xcconfig */;
@@ -864,11 +872,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8DADDAFB45D948BB78A504DFD61C6FB3 /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
+		F71F0CDD33B849DD0FE9EF7A6721683A /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				93B6A0432D75A801A8BA6D1EE8CE45C6 /* Debug */,
-				7ACF955A961A5E8526967ED157855AA4 /* Release */,
+				18D4E12BFCDE69FC40678F1DB3211B6F /* Debug */,
+				72E1B26341B85F9DECC7FC8B508397DD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/Examples-tvOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
+++ b/Examples/Examples-tvOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
@@ -23,6 +23,7 @@
 #import "IGListAdapterUpdaterDelegate.h"
 #import "IGListCollectionContext.h"
 #import "IGListCollectionView.h"
+#import "IGListCollectionViewLayout.h"
 #import "IGListDisplayDelegate.h"
 #import "IGListGridCollectionViewLayout.h"
 #import "IGListKit.h"

--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -172,6 +172,18 @@
 		2914BEE91DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
 		2914BEEA1DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
 		294AC6321DDE4C19002FCE5D /* IGListDiffResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */; };
+		298DDA1F1E3B0DC800F76F50 /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 298DDA1D1E3B0DC800F76F50 /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		298DDA201E3B0DC800F76F50 /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 298DDA1D1E3B0DC800F76F50 /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		298DDA211E3B0DC800F76F50 /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA1E1E3B0DC800F76F50 /* IGListCollectionViewLayout.mm */; };
+		298DDA221E3B0DC800F76F50 /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA1E1E3B0DC800F76F50 /* IGListCollectionViewLayout.mm */; };
+		298DDA241E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA231E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m */; };
+		298DDA251E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA231E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m */; };
+		298DDA381E3B168E00F76F50 /* IGLayoutTestItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA291E3B166100F76F50 /* IGLayoutTestItem.m */; };
+		298DDA391E3B168F00F76F50 /* IGLayoutTestItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA291E3B166100F76F50 /* IGLayoutTestItem.m */; };
+		298DDA3A1E3B16F600F76F50 /* IGLayoutTestDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA271E3B166100F76F50 /* IGLayoutTestDataSource.m */; };
+		298DDA3B1E3B16F800F76F50 /* IGLayoutTestDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA271E3B166100F76F50 /* IGLayoutTestDataSource.m */; };
+		298DDA3C1E3B170300F76F50 /* IGLayoutTestSection.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA2B1E3B166100F76F50 /* IGLayoutTestSection.m */; };
+		298DDA3D1E3B170400F76F50 /* IGLayoutTestSection.m in Sources */ = {isa = PBXBuildFile; fileRef = 298DDA2B1E3B166100F76F50 /* IGLayoutTestSection.m */; };
 		2997D4971DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */; };
 		29C4748C1DDF45F400AE68CE /* IGListAdapterProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29C4748A1DDF45E700AE68CE /* IGListAdapterProxyTests.m */; };
 		29C4748D1DDF45F900AE68CE /* IGListAdapterProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 29C4748A1DDF45E700AE68CE /* IGListAdapterProxyTests.m */; };
@@ -369,6 +381,15 @@
 		2904861F1DCD02750007F41D /* IGTestNibSupplementaryView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGTestNibSupplementaryView.m; sourceTree = "<group>"; };
 		294369B01DB1B7AE0025F6E7 /* IGTestNibCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IGTestNibCell.xib; sourceTree = "<group>"; };
 		294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGListDiffResultTests.m; sourceTree = "<group>"; };
+		298DDA1D1E3B0DC800F76F50 /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayout.h; sourceTree = "<group>"; };
+		298DDA1E1E3B0DC800F76F50 /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
+		298DDA231E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGListCollectionViewLayoutTests.m; sourceTree = "<group>"; };
+		298DDA261E3B166100F76F50 /* IGLayoutTestDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGLayoutTestDataSource.h; sourceTree = "<group>"; };
+		298DDA271E3B166100F76F50 /* IGLayoutTestDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGLayoutTestDataSource.m; sourceTree = "<group>"; };
+		298DDA281E3B166100F76F50 /* IGLayoutTestItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGLayoutTestItem.h; sourceTree = "<group>"; };
+		298DDA291E3B166100F76F50 /* IGLayoutTestItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGLayoutTestItem.m; sourceTree = "<group>"; };
+		298DDA2A1E3B166100F76F50 /* IGLayoutTestSection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGLayoutTestSection.h; sourceTree = "<group>"; };
+		298DDA2B1E3B166100F76F50 /* IGLayoutTestSection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGLayoutTestSection.m; sourceTree = "<group>"; };
 		2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGReloadDataUpdaterTests.m; sourceTree = "<group>"; };
 		29C4748A1DDF45E700AE68CE /* IGListAdapterProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxyTests.m; sourceTree = "<group>"; };
 		529C388FDB3DF79737F3496A /* Pods_IGListKit_tvOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IGListKit_tvOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -508,6 +529,8 @@
 				0B3B92A11E08D7F5008390ED /* IGListCollectionContext.h */,
 				0B3B92A21E08D7F5008390ED /* IGListCollectionView.h */,
 				0B3B92A31E08D7F5008390ED /* IGListCollectionView.m */,
+				298DDA1D1E3B0DC800F76F50 /* IGListCollectionViewLayout.h */,
+				298DDA1E1E3B0DC800F76F50 /* IGListCollectionViewLayout.mm */,
 				0B3B92A41E08D7F5008390ED /* IGListDisplayDelegate.h */,
 				0B3B92A51E08D7F5008390ED /* IGListGridCollectionViewLayout.h */,
 				0B3B92A61E08D7F5008390ED /* IGListGridCollectionViewLayout.m */,
@@ -617,6 +640,12 @@
 		88144EF01D870EDC007C7F66 /* Objects */ = {
 			isa = PBXGroup;
 			children = (
+				298DDA261E3B166100F76F50 /* IGLayoutTestDataSource.h */,
+				298DDA271E3B166100F76F50 /* IGLayoutTestDataSource.m */,
+				298DDA281E3B166100F76F50 /* IGLayoutTestItem.h */,
+				298DDA291E3B166100F76F50 /* IGLayoutTestItem.m */,
+				298DDA2A1E3B166100F76F50 /* IGLayoutTestSection.h */,
+				298DDA2B1E3B166100F76F50 /* IGLayoutTestSection.m */,
 				88144EF11D870EDC007C7F66 /* IGListTestAdapterDataSource.h */,
 				88144EF21D870EDC007C7F66 /* IGListTestAdapterDataSource.m */,
 				8285404E1DE40D2D00118B94 /* IGListTestAdapterHorizontalDataSource.h */,
@@ -699,7 +728,8 @@
 				88144EE31D870EDC007C7F66 /* IGListAdapterTests.m */,
 				88144EE41D870EDC007C7F66 /* IGListAdapterUpdaterTests.m */,
 				88144EE51D870EDC007C7F66 /* IGListBatchUpdateDataTests.m */,
-				2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */,
+				298DDA231E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m */,
+				1F0A68C41DF8D5B9009E8ADE /* IGListCollectionViewTests.m */,
 				294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */,
 				88144EE61D870EDC007C7F66 /* IGListDiffSwiftTests.swift */,
 				88144EE81D870EDC007C7F66 /* IGListDiffTests.m */,
@@ -712,7 +742,7 @@
 				821BC4BE1DB8C95300172ED0 /* IGListSingleStoryboardItemControllerTests.m */,
 				88144EEE1D870EDC007C7F66 /* IGListStackSectionControllerTests.m */,
 				88144EEF1D870EDC007C7F66 /* IGListWorkingRangeHandlerTests.m */,
-				1F0A68C41DF8D5B9009E8ADE /* IGListCollectionViewTests.m */,
+				2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */,
 				887D0B571D870E1E009E01F7 /* Info.plist */,
 				88144EF01D870EDC007C7F66 /* Objects */,
 			);
@@ -777,6 +807,7 @@
 				0B3B931B1E08D7F5008390ED /* IGListSectionType.h in Headers */,
 				0B3B92E31E08D7F5008390ED /* IGListMoveIndexPath.h in Headers */,
 				0B3B93111E08D7F5008390ED /* IGListReloadDataUpdater.h in Headers */,
+				298DDA201E3B0DC800F76F50 /* IGListCollectionViewLayout.h in Headers */,
 				0B3B92FF1E08D7F5008390ED /* IGListAdapterUpdater.h in Headers */,
 				0B3B93151E08D7F5008390ED /* IGListScrollDelegate.h in Headers */,
 				0B3B93071E08D7F5008390ED /* IGListCollectionView.h in Headers */,
@@ -830,6 +861,7 @@
 				0B3B931A1E08D7F5008390ED /* IGListSectionType.h in Headers */,
 				0B3B92E21E08D7F5008390ED /* IGListMoveIndexPath.h in Headers */,
 				0B3B93101E08D7F5008390ED /* IGListReloadDataUpdater.h in Headers */,
+				298DDA1F1E3B0DC800F76F50 /* IGListCollectionViewLayout.h in Headers */,
 				0B3B92FE1E08D7F5008390ED /* IGListAdapterUpdater.h in Headers */,
 				0B3B93141E08D7F5008390ED /* IGListScrollDelegate.h in Headers */,
 				0B3B93061E08D7F5008390ED /* IGListCollectionView.h in Headers */,
@@ -1193,6 +1225,7 @@
 				0B3B92D91E08D7F5008390ED /* IGListIndexSetResult.m in Sources */,
 				0B3B93431E08D7F5008390ED /* IGListWorkingRangeHandler.mm in Sources */,
 				0B3B92F11E08D7F5008390ED /* NSNumber+IGListDiffable.m in Sources */,
+				298DDA221E3B0DC800F76F50 /* IGListCollectionViewLayout.mm in Sources */,
 				0B3B93311E08D7F5008390ED /* IGListAdapterProxy.m in Sources */,
 				0B3B92CD1E08D7F5008390ED /* IGListDiff.mm in Sources */,
 				0B3B931F1E08D7F5008390ED /* IGListSingleSectionController.m in Sources */,
@@ -1215,14 +1248,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				298DDA381E3B168E00F76F50 /* IGLayoutTestItem.m in Sources */,
 				885FE2361DC51B76009CE2B4 /* IGListStackSectionControllerTests.m in Sources */,
 				885FE2311DC51B76009CE2B4 /* IGListDisplayHandlerTests.m in Sources */,
 				0B40C5F41E01CBCB00378109 /* IGListCollectionViewTests.m in Sources */,
+				298DDA3B1E3B16F800F76F50 /* IGLayoutTestDataSource.m in Sources */,
 				29C474901DDF460500AE68CE /* IGListSectionMapTests.m in Sources */,
 				29C579321DE0DA8A003A149B /* IGTestStoryboardSupplementarySource.m in Sources */,
 				29C5792F1DE0DA8A003A149B /* IGListTestAdapterStoryboardDataSource.m in Sources */,
 				885FE23B1DC51B86009CE2B4 /* IGListTestUICollectionViewDataSource.m in Sources */,
 				885FE23D1DC51B86009CE2B4 /* IGTestDelegateController.m in Sources */,
+				298DDA251E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m in Sources */,
 				885FE22B1DC51B76009CE2B4 /* IGListAdapterE2ETests.m in Sources */,
 				885FE2331DC51B76009CE2B4 /* IGListSingleSectionControllerTests.m in Sources */,
 				29C579311DE0DA8A003A149B /* IGTestNibSupplementaryView.m in Sources */,
@@ -1244,6 +1280,7 @@
 				885FE2421DC51B86009CE2B4 /* IGTestSingleStoryboardItemDataSource.m in Sources */,
 				885FE2301DC51B76009CE2B4 /* IGListDiffTests.m in Sources */,
 				885FE22E1DC51B76009CE2B4 /* IGListBatchUpdateDataTests.m in Sources */,
+				298DDA3C1E3B170300F76F50 /* IGLayoutTestSection.m in Sources */,
 				29C4748D1DDF45F900AE68CE /* IGListAdapterProxyTests.m in Sources */,
 				885FE22C1DC51B76009CE2B4 /* IGListAdapterTests.m in Sources */,
 				885FE22D1DC51B76009CE2B4 /* IGListAdapterUpdaterTests.m in Sources */,
@@ -1269,6 +1306,7 @@
 				0B3B92D81E08D7F5008390ED /* IGListIndexSetResult.m in Sources */,
 				0B3B93421E08D7F5008390ED /* IGListWorkingRangeHandler.mm in Sources */,
 				0B3B92F01E08D7F5008390ED /* NSNumber+IGListDiffable.m in Sources */,
+				298DDA211E3B0DC800F76F50 /* IGListCollectionViewLayout.mm in Sources */,
 				0B3B93301E08D7F5008390ED /* IGListAdapterProxy.m in Sources */,
 				0B3B92CC1E08D7F5008390ED /* IGListDiff.mm in Sources */,
 				0B3B931E1E08D7F5008390ED /* IGListSingleSectionController.m in Sources */,
@@ -1291,14 +1329,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				298DDA391E3B168F00F76F50 /* IGLayoutTestItem.m in Sources */,
 				88144F1C1D870EDC007C7F66 /* IGTestStackedDataSource.m in Sources */,
 				88144F181D870EDC007C7F66 /* IGTestDelegateController.m in Sources */,
 				1F0A68C51DF8D5B9009E8ADE /* IGListCollectionViewTests.m in Sources */,
+				298DDA3A1E3B16F600F76F50 /* IGLayoutTestDataSource.m in Sources */,
 				828540481DDFF5D400118B94 /* IGListGridCollectionViewLayoutTests.m in Sources */,
 				88144F0D1D870EDC007C7F66 /* IGListDisplayHandlerTests.m in Sources */,
 				8240C7F51DC2D99300B3AAE7 /* IGTestStoryboardSupplementarySource.m in Sources */,
 				88144F1B1D870EDC007C7F66 /* IGTestSingleItemDataSource.m in Sources */,
 				88144F171D870EDC007C7F66 /* IGTestCell.m in Sources */,
+				298DDA241E3B15EE00F76F50 /* IGListCollectionViewLayoutTests.m in Sources */,
 				821BC4C01DB8C9D500172ED0 /* IGListSingleStoryboardItemControllerTests.m in Sources */,
 				294AC6321DDE4C19002FCE5D /* IGListDiffResultTests.m in Sources */,
 				88144F141D870EDC007C7F66 /* IGListTestOffsettingLayout.m in Sources */,
@@ -1320,6 +1361,7 @@
 				88144F101D870EDC007C7F66 /* IGListSingleSectionControllerTests.m in Sources */,
 				88144F121D870EDC007C7F66 /* IGListWorkingRangeHandlerTests.m in Sources */,
 				821BC4D31DB981AB00172ED0 /* IGTestSingleStoryboardItemDataSource.m in Sources */,
+				298DDA3D1E3B170400F76F50 /* IGLayoutTestSection.m in Sources */,
 				88144F151D870EDC007C7F66 /* IGListTestSection.m in Sources */,
 				88144F1D1D870EDC007C7F66 /* IGTestSupplementarySource.m in Sources */,
 				88144F081D870EDC007C7F66 /* IGListAdapterTests.m in Sources */,

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <IGListKit/IGListMacros.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ This UICollectionViewLayout subclass is for vertically-scrolling lists of data with variable widths and heights. It
+ supports an infinite number of sections and items. All work is done on the main thread, and while extremely efficient,
+ care must be taken not to stall the main thread in sizing delegate methods.
+
+ This layout piggybacks on the mechanics of UICollectionViewFlowLayout in that:
+
+ - Your UICollectionView data source must also conform to UICollectionViewDelegateFlowLayout
+ - Header support given via UICollectionElementKindSectionHeader
+
+ All UICollectionViewDelegateFlowLayout methods are required and used by this layout:
+
+ - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
+ - (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section;
+ - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumLineSpacingForSectionAtIndex:(NSInteger)section;
+ - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumInteritemSpacingForSectionAtIndex:(NSInteger)section;
+ - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section;
+
+ Sections and items are put into the same horizontal row until the max-x position of an item extends beyond the width
+ of the collection view. When that happens, the item is "newlined" to the next row. The y position of that row is
+ deteremined by the maximum height (including section insets) of the section/item of the previous row.
+
+ Ex. of a section (2,0) with a large width causing a newline.
+ |[ 0,0 ][ 1,0 ]         |
+ |[         2,0         ]|
+
+ A section with a non-zero height header will always cause that section to newline. Headers are always stretched to the
+ width of the collection view, pinched with the section insets.
+
+ Ex. of a section (2,0) with a header inset on the left/right.
+ |[ 0,0 ][ 1,0 ]         |
+ | >======header=======< |
+ | [ 2,0 ]               |
+
+ Section insets apply to items in the section no matter if they begin on a new row or are on the same row as a previous
+ section.
+
+ Ex. of a section (2) with multiple items and a left inset.
+ |[ 0,0 ][ 1,0 ] >[ 2,0 ]|
+ | >[ 2,1 ][ 2,2 ][ 2,3 ]|
+
+ Interitem spacing applies to items and sections within the same row. Line spacing only applies to items within the same
+ section.
+
+ Please see the unit tests for more configuration examples and expected output.
+ */
+IGLK_SUBCLASSING_RESTRICTED
+@interface IGListCollectionViewLayout : UICollectionViewLayout
+
+/**
+ Set this to adjust the offset of the sticky headers. Can be used to change the sticky header position as UI like the
+ navigation bar is scrolled offscreen. Changing this to the height of the navigation bar will give the effect of the
+ headers sticking to the nav as it is collapsed.
+
+ @discussion Changing the value on this method will invalidat the layout every time.
+ */
+@property (nonatomic, assign) CGFloat stickyHeaderOriginYAdjustment;
+
+/**
+ Create and return a new collection view layout.
+ @param stickyHeaders       Set to YES to stick section headers to the top of the bounds while scrolling.
+ @param topContentInset     The top content inset used to offset the sticky headers. Ignored if stickyHeaders is NO.
+ @param maximumContentWidth A maximum width that content can fill. If the container is larger, content is centered.
+ @return A new collection view layout.
+ */
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                      topContentInset:(CGFloat)topContentInset
+                  maximumContentWidth:(CGFloat)maximumContentWidth
+                decorationBorderClass:(nullable Class)decorationBorderClass NS_DESIGNATED_INITIALIZER;
+
+/**
+ Convenience initializer creating a layout with an unbounded content width and no decoration view.
+ @param stickyHeaders   Set to YES to stick section headers to the top of the bounds while scrolling.
+ @param topContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is NO.
+ @return A new collection view layout.
+ */
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                      topContentInset:(CGFloat)topContentInset;
+
+/**
+ :nodoc:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ :nodoc:
+ */
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -25,34 +25,42 @@ NS_ASSUME_NONNULL_BEGIN
 
  All UICollectionViewDelegateFlowLayout methods are required and used by this layout:
 
+ ```
  - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
  - (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section;
  - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumLineSpacingForSectionAtIndex:(NSInteger)section;
  - (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumInteritemSpacingForSectionAtIndex:(NSInteger)section;
  - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section;
+ ```
 
  Sections and items are put into the same horizontal row until the max-x position of an item extends beyond the width
  of the collection view. When that happens, the item is "newlined" to the next row. The y position of that row is
  deteremined by the maximum height (including section insets) of the section/item of the previous row.
 
  Ex. of a section (2,0) with a large width causing a newline.
+ ```
  |[ 0,0 ][ 1,0 ]         |
  |[         2,0         ]|
+ ```
 
  A section with a non-zero height header will always cause that section to newline. Headers are always stretched to the
  width of the collection view, pinched with the section insets.
 
  Ex. of a section (2,0) with a header inset on the left/right.
+ ```
  |[ 0,0 ][ 1,0 ]         |
  | >======header=======< |
  | [ 2,0 ]               |
+ ```
 
  Section insets apply to items in the section no matter if they begin on a new row or are on the same row as a previous
  section.
 
  Ex. of a section (2) with multiple items and a left inset.
+ ```
  |[ 0,0 ][ 1,0 ] >[ 2,0 ]|
  | >[ 2,1 ][ 2,2 ][ 2,3 ]|
+ ```
 
  Interitem spacing applies to items and sections within the same row. Line spacing only applies to items within the same
  section.
@@ -67,14 +75,14 @@ IGLK_SUBCLASSING_RESTRICTED
  navigation bar is scrolled offscreen. Changing this to the height of the navigation bar will give the effect of the
  headers sticking to the nav as it is collapsed.
 
- @discussion Changing the value on this method will invalidat the layout every time.
+ @discussion Changing the value on this method will invalidate the layout every time.
  */
 @property (nonatomic, assign) CGFloat stickyHeaderOriginYAdjustment;
 
 /**
  Create and return a new collection view layout.
- @param stickyHeaders       Set to YES to stick section headers to the top of the bounds while scrolling.
- @param topContentInset     The top content inset used to offset the sticky headers. Ignored if stickyHeaders is NO.
+ @param stickyHeaders       Set to `YES` to stick section headers to the top of the bounds while scrolling.
+ @param topContentInset     The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
  @return A new collection view layout.
  */
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -80,8 +80,7 @@ IGLK_SUBCLASSING_RESTRICTED
  */
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
                       topContentInset:(CGFloat)topContentInset
-                  maximumContentWidth:(CGFloat)maximumContentWidth
-                decorationBorderClass:(nullable Class)decorationBorderClass NS_DESIGNATED_INITIALIZER;
+                  maximumContentWidth:(CGFloat)maximumContentWidth NS_DESIGNATED_INITIALIZER;
 
 /**
  Convenience initializer creating a layout with an unbounded content width and no decoration view.

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -75,21 +75,10 @@ IGLK_SUBCLASSING_RESTRICTED
  Create and return a new collection view layout.
  @param stickyHeaders       Set to YES to stick section headers to the top of the bounds while scrolling.
  @param topContentInset     The top content inset used to offset the sticky headers. Ignored if stickyHeaders is NO.
- @param maximumContentWidth A maximum width that content can fill. If the container is larger, content is centered.
  @return A new collection view layout.
  */
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
-                      topContentInset:(CGFloat)topContentInset
-                  maximumContentWidth:(CGFloat)maximumContentWidth NS_DESIGNATED_INITIALIZER;
-
-/**
- Convenience initializer creating a layout with an unbounded content width and no decoration view.
- @param stickyHeaders   Set to YES to stick section headers to the top of the bounds while scrolling.
- @param topContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is NO.
- @return A new collection view layout.
- */
-- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
-                      topContentInset:(CGFloat)topContentInset;
+                      topContentInset:(CGFloat)topContentInset NS_DESIGNATED_INITIALIZER;
 
 /**
  :nodoc:

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -129,8 +129,8 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-    IGAssert(NO, @"Layout initialized from storybaords not yet supported");
-    return [self initWithStickyHeaders:0 topContentInset:0 maximumContentWidth:0 decorationBorderClass:nil];
+    IGAssert(NO, @"Layout initialized from storyboards not yet supported");
+    return [self initWithStickyHeaders:NO topContentInset:0 maximumContentWidth:CGFLOAT_MAX decorationBorderClass:nil];
 }
 
 #pragma mark - UICollectionViewLayout

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -63,12 +63,12 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     }
 }
 
-@interface IGVerticalCollectionViewLayoutInvalidationContext : UICollectionViewLayoutInvalidationContext
+@interface IGListCollectionViewLayoutInvalidationContext : UICollectionViewLayoutInvalidationContext
 @property (nonatomic, assign) BOOL ig_invalidateSupplementaryAttributes;
 @property (nonatomic, assign) BOOL ig_invalidateAllAttributes;
 @end
 
-@implementation IGVerticalCollectionViewLayoutInvalidationContext
+@implementation IGListCollectionViewLayoutInvalidationContext
 @end
 
 @interface IGListCollectionViewLayout ()
@@ -232,7 +232,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     return CGSizeMake(CGRectGetWidth(collectionView.bounds) - contentInset.left - contentInset.right, height);
 }
 
-- (void)invalidateLayoutWithContext:(IGVerticalCollectionViewLayoutInvalidationContext *)context {
+- (void)invalidateLayoutWithContext:(IGListCollectionViewLayoutInvalidationContext *)context {
     BOOL hasInvalidatedItemIndexPaths = NO;
     if ([context respondsToSelector:@selector(invalidatedItemIndexPaths)]) {
         hasInvalidatedItemIndexPaths = [context invalidatedItemIndexPaths].count > 0;
@@ -253,14 +253,14 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 }
 
 + (Class)invalidationContextClass {
-    return [IGVerticalCollectionViewLayoutInvalidationContext class];
+    return [IGListCollectionViewLayoutInvalidationContext class];
 }
 
 - (UICollectionViewLayoutInvalidationContext *)invalidationContextForBoundsChange:(CGRect)newBounds {
     const CGRect oldBounds = self.collectionView.bounds;
 
-    IGVerticalCollectionViewLayoutInvalidationContext *context =
-    (IGVerticalCollectionViewLayoutInvalidationContext *)[super invalidationContextForBoundsChange:newBounds];
+    IGListCollectionViewLayoutInvalidationContext *context =
+    (IGListCollectionViewLayoutInvalidationContext *)[super invalidationContextForBoundsChange:newBounds];
     context.ig_invalidateSupplementaryAttributes = YES;
     if (!CGSizeEqualToSize(oldBounds.size, newBounds.size)) {
         context.ig_invalidateAllAttributes = YES;
@@ -294,7 +294,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     if (_stickyHeaderOriginYAdjustment != stickyHeaderOriginYAdjustment) {
         _stickyHeaderOriginYAdjustment = stickyHeaderOriginYAdjustment;
 
-        IGVerticalCollectionViewLayoutInvalidationContext *invalidationContext = [[IGVerticalCollectionViewLayoutInvalidationContext alloc] init];
+        IGListCollectionViewLayoutInvalidationContext *invalidationContext = [[IGListCollectionViewLayoutInvalidationContext alloc] init];
         invalidationContext.ig_invalidateSupplementaryAttributes = YES;
         [self invalidateLayoutWithContext:invalidationContext];
     }

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -1,0 +1,512 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "IGListCollectionViewLayout.h"
+
+#import <vector>
+
+#import <IGListKit/IGListAssert.h>
+
+static NSString *const kDecorationBorderViewIdentifier = @"kDecorationBorderViewIdentifier";
+
+static NSIndexPath *headerIndexPathForSection(NSInteger section) {
+    return [NSIndexPath indexPathForItem:0 inSection:section];
+}
+
+struct IGSectionEntry {
+    /**
+     Represents the minimum-bounding box of every element in the section. This includes all item frames as well as the
+     header bounds. It is made simply by unioning all item and header frames. Use this to find section intersections
+     to build layout attributes given a rect.
+     */
+    CGRect bounds;
+
+    // The insets for the section. Used to find total content size of the section.
+    UIEdgeInsets insets;
+
+    // The RESTING frame of the header view (e.g. when the header is not sticking to the top of the scroll view).
+    CGRect headerBounds;
+
+    // An array of frames for each cell in the section.
+    std::vector<CGRect> itemBounds;
+
+    // Returns YES when the section has visible content (header and/or items).
+    BOOL isValid() {
+        return !CGSizeEqualToSize(bounds.size, CGSizeZero);
+    }
+};
+
+// Each section has a base zIndex of section * maxZIndexPerSection;
+// section header adds (maxZIndexPerSection - 1) to the base zIndex;
+// other cells adds (item) to the base zIndex.
+// This allows us to present tooltips that can grow from the cell to its top.
+static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attributes) {
+    const NSInteger maxZIndexPerSection = 1000;
+    const NSInteger baseZIndex = attributes.indexPath.section * maxZIndexPerSection;
+
+    switch (attributes.representedElementCategory) {
+        case UICollectionElementCategoryCell:
+            attributes.zIndex = baseZIndex + attributes.indexPath.item;
+            break;
+        case UICollectionElementCategorySupplementaryView:
+            IGAssert([attributes.representedElementKind isEqualToString:UICollectionElementKindSectionHeader],
+                     @"Only support for element kind header, not %@", attributes.representedElementKind);
+            attributes.zIndex = baseZIndex + maxZIndexPerSection - 1;
+            break;
+        case UICollectionElementCategoryDecorationView:
+            attributes.zIndex = baseZIndex - 1;
+            break;
+    }
+}
+
+@interface IGVerticalCollectionViewLayoutInvalidationContext : UICollectionViewLayoutInvalidationContext
+@property (nonatomic, assign) BOOL ig_invalidateSupplementaryAttributes;
+@property (nonatomic, assign) BOOL ig_invalidateAllAttributes;
+@end
+
+@implementation IGVerticalCollectionViewLayoutInvalidationContext
+@end
+
+@interface IGListCollectionViewLayout ()
+
+@property (nonatomic, assign, readonly) BOOL stickyHeaders;
+@property (nonatomic, assign, readonly) CGFloat topContentInset;
+@property (nonatomic, assign, readonly) CGFloat maximumContentWidth;
+
+@end
+
+@implementation IGListCollectionViewLayout {
+    std::vector<IGSectionEntry> _sectionData;
+    NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *_attributesCache;
+    BOOL _cachedLayoutInvalid;
+
+    /**
+     The workflow for getting sticky headers working:
+     1. Use a custom invalidation context to mark supplementary attributes invalid.
+     2. Return YES from -shouldInvalidateLayoutForBoundsChange:
+     3. In -invalidationContextForBoundsChange: mark supplementary attributes invalid on the custom context.
+     4. Purge supplementary caches in -invalidateLayoutWithContext: if context says they are invalid
+     5. Use cached attributes in -layoutAttributesForSupplementaryViewOfKind:atIndexPath: if they exist, else rebuild
+     6. Make sure -layoutAttributesForElementsInRect: always uses the attributes returned from
+     -layoutAttributesForSupplementaryViewOfKind:atIndexPath:.
+     */
+    NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *_headerAttributesCache;
+    NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *_borderAttributesCache;
+}
+
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                      topContentInset:(CGFloat)topContentInset {
+    return [self initWithStickyHeaders:stickyHeaders
+                       topContentInset:topContentInset
+                   maximumContentWidth:CGFLOAT_MAX
+                 decorationBorderClass:nil];
+}
+
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                      topContentInset:(CGFloat)topContentInset
+                  maximumContentWidth:(CGFloat)maximumContentWidth
+                decorationBorderClass:(Class)decorationBorderClass  {
+    if (self = [super init]) {
+        _stickyHeaders = stickyHeaders;
+        _topContentInset = topContentInset;
+        _maximumContentWidth = maximumContentWidth;
+        _attributesCache = [NSMutableDictionary new];
+        _headerAttributesCache = [NSMutableDictionary new];
+        _borderAttributesCache = [NSMutableDictionary new];
+        _cachedLayoutInvalid = YES;
+
+        if (decorationBorderClass != nil) {
+            [self registerClass:decorationBorderClass forDecorationViewOfKind:kDecorationBorderViewIdentifier];
+        }
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    IGAssert(NO, @"Layout initialized from storybaords not yet supported");
+    return [self initWithStickyHeaders:0 topContentInset:0 maximumContentWidth:0 decorationBorderClass:nil];
+}
+
+#pragma mark - UICollectionViewLayout
+
+- (NSArray<UICollectionViewLayoutAttributes *> *)layoutAttributesForElementsInRect:(CGRect)rect {
+    IGAssertMainThread();
+
+    NSMutableArray *result = [NSMutableArray new];
+
+    // since we iterate through sections ascending, we may hit a section who is only partially visible
+    // in that case we short circuit building layout attributes
+    BOOL remainingCellsOutOfRect = NO;
+
+    const NSRange range = [self rangeOfSectionsInRect:rect];
+    if (range.location == NSNotFound) {
+        return nil;
+    }
+
+    for (NSInteger section = range.location; section < NSMaxRange(range); section++) {
+        const NSInteger itemCount = _sectionData[section].itemBounds.size();
+
+        // do not add headers if there are no items
+        if (itemCount > 0) {
+            NSIndexPath *headerIndexPath = headerIndexPathForSection(section);
+            UICollectionViewLayoutAttributes *attributes = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                                                                                atIndexPath:headerIndexPath];
+            // do not add zero height headers or headers that are outside the rect
+            const CGRect frame = attributes.frame;
+            const CGRect intersection = CGRectIntersection(frame, rect);
+            if (!CGRectIsEmpty(intersection) || CGRectGetHeight(frame) == 0.0) {
+                if (CGRectGetHeight(frame) > 0.0) {
+                    [result addObject:attributes];
+                }
+
+                if (CGRectGetWidth(frame) >= self.maximumContentWidth) {
+                    UICollectionViewLayoutAttributes *borderAttributes = [self layoutAttributesForDecorationViewOfKind:kDecorationBorderViewIdentifier atIndexPath:headerIndexPath];
+                    [result addObject:borderAttributes];
+                }
+            }
+        }
+
+        // add all cells within the rect, return early if it starts iterating outside
+        for (NSInteger item = 0; item < itemCount; item++) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
+            UICollectionViewLayoutAttributes *attributes = [self layoutAttributesForItemAtIndexPath:indexPath];
+            if (!CGRectIntersectsRect(attributes.frame, rect)) {
+                if (remainingCellsOutOfRect) {
+                    return result;
+                }
+            } else {
+                remainingCellsOutOfRect = YES;
+                [result addObject:attributes];
+            }
+        }
+    }
+
+    return result;
+}
+
+- (UICollectionViewLayoutAttributes *)layoutAttributesForItemAtIndexPath:(NSIndexPath *)indexPath {
+    IGAssertMainThread();
+    IGParameterAssert(indexPath != nil);
+
+    UICollectionViewLayoutAttributes *attributes = _attributesCache[indexPath];
+    if (attributes != nil) {
+        return attributes;
+    }
+
+    attributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
+    attributes.frame = _sectionData[indexPath.section].itemBounds[indexPath.item];
+    adjustZIndexForAttributes(attributes);
+    _attributesCache[indexPath] = attributes;
+    return attributes;
+}
+
+- (UICollectionViewLayoutAttributes *)layoutAttributesForSupplementaryViewOfKind:(NSString *)elementKind atIndexPath:(NSIndexPath *)indexPath {
+    IGAssertMainThread();
+    IGParameterAssert([elementKind isEqualToString:UICollectionElementKindSectionHeader]);
+    IGParameterAssert(indexPath != nil);
+
+    UICollectionViewLayoutAttributes *attributes = _headerAttributesCache[indexPath];
+    if (attributes != nil) {
+        return attributes;
+    }
+
+    UICollectionView *collectionView = self.collectionView;
+    const NSInteger section = indexPath.section;
+    const IGSectionEntry entry = _sectionData[section];
+    const CGFloat minY = CGRectGetMinY(entry.bounds);
+
+    CGRect frame = entry.headerBounds;
+
+    if (self.stickyHeaders) {
+        const CGFloat yOffset = collectionView.contentOffset.y + self.topContentInset + self.stickyHeaderOriginYAdjustment;
+
+        if (section + 1 == _sectionData.size()) {
+            frame.origin.y = MAX(minY, yOffset);
+        } else {
+            const CGFloat maxY = CGRectGetMinY(_sectionData[section + 1].bounds) - CGRectGetHeight(frame);
+            frame.origin.y = MIN(MAX(minY, yOffset), maxY);
+        }
+    }
+
+    attributes = [UICollectionViewLayoutAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];
+    attributes.frame = frame;
+    adjustZIndexForAttributes(attributes);
+    _headerAttributesCache[indexPath] = attributes;
+    return attributes;
+}
+
+- (UICollectionViewLayoutAttributes *)decorationBorderViewOfKind:(NSString *)kind
+                                                     atIndexPath:(NSIndexPath *)indexPath
+                                     withSectionHeaderAttributes:(UICollectionViewLayoutAttributes *)headerAttributes {
+    NSInteger section = headerAttributes.indexPath.section;
+    NSInteger numberOfItemsInSection = [self.collectionView numberOfItemsInSection:section];
+    UICollectionViewLayoutAttributes *decorationViewAttributes = nil;
+
+    NSIndexPath *firstObjectIndexPath = [NSIndexPath indexPathForItem:0 inSection:section];
+    NSIndexPath *lastObjectIndexPath = [NSIndexPath indexPathForItem:MAX(0, (numberOfItemsInSection - 1)) inSection:section];
+
+    CGRect headerFrame = headerAttributes.frame;
+    CGRect firstObjectFrame;
+    CGRect lastObjectFrame;
+    if (numberOfItemsInSection > 0) {
+        firstObjectFrame = [self layoutAttributesForItemAtIndexPath:firstObjectIndexPath].frame;
+        lastObjectFrame = [self layoutAttributesForItemAtIndexPath:lastObjectIndexPath].frame;
+    } else {
+        firstObjectFrame = headerFrame;
+        lastObjectFrame = headerFrame;
+    }
+
+    decorationViewAttributes = [UICollectionViewLayoutAttributes layoutAttributesForDecorationViewOfKind:kind withIndexPath:firstObjectIndexPath];
+    decorationViewAttributes.frame = CGRectMake(CGRectGetMinX(headerFrame) - 1,
+                                                MIN(CGRectGetMinY(headerFrame), CGRectGetMinY(firstObjectFrame)) - 1,
+                                                CGRectGetWidth(headerFrame) + 2,
+                                                MAX(CGRectGetMaxY(lastObjectFrame), CGRectGetMaxY(headerFrame)) - MIN(CGRectGetMinY(headerFrame), CGRectGetMinY(firstObjectFrame)) + 2);
+    return decorationViewAttributes;
+}
+
+- (UICollectionViewLayoutAttributes *)layoutAttributesForDecorationViewOfKind:(NSString *)decorationViewKind atIndexPath:(NSIndexPath *)indexPath {
+    IGAssertMainThread();
+    IGParameterAssert(indexPath != nil);
+
+    UICollectionViewLayoutAttributes *attributes = _borderAttributesCache[indexPath];
+    if (attributes != nil) {
+        return attributes;
+    }
+    if (CGRectGetWidth(self.collectionView.bounds) < self.maximumContentWidth) {
+        return nil;
+    }
+    UICollectionViewLayoutAttributes *headerAttributes = [self layoutAttributesForSupplementaryViewOfKind:UICollectionElementKindSectionHeader atIndexPath:indexPath];
+    attributes = [self decorationBorderViewOfKind:decorationViewKind atIndexPath:indexPath withSectionHeaderAttributes:headerAttributes];
+    adjustZIndexForAttributes(attributes);
+    _borderAttributesCache[indexPath] = attributes;
+    return attributes;
+}
+
+- (CGSize)collectionViewContentSize {
+    IGAssertMainThread();
+
+    const NSInteger sectionCount = _sectionData.size();
+
+    if (sectionCount == 0) {
+        return CGSizeZero;
+    }
+
+    const IGSectionEntry section = _sectionData[sectionCount - 1];
+    const CGFloat height = CGRectGetMaxY(section.bounds) + section.insets.bottom;
+    return CGSizeMake(MIN(CGRectGetWidth(self.collectionView.bounds), self.maximumContentWidth), height);
+}
+
+- (void)invalidateLayoutWithContext:(IGVerticalCollectionViewLayoutInvalidationContext *)context {
+    BOOL hasInvalidatedItemIndexPaths = NO;
+    if ([context respondsToSelector:@selector(invalidatedItemIndexPaths)]) {
+        hasInvalidatedItemIndexPaths = [context invalidatedItemIndexPaths].count > 0;
+    }
+
+    if (hasInvalidatedItemIndexPaths
+        || [context invalidateEverything]
+        || [context invalidateDataSourceCounts]
+        || context.ig_invalidateAllAttributes) {
+        _cachedLayoutInvalid = YES;
+    }
+
+    if (context.ig_invalidateSupplementaryAttributes) {
+        [_headerAttributesCache removeAllObjects];
+        [_borderAttributesCache removeAllObjects];
+    }
+
+    [super invalidateLayoutWithContext:context];
+}
+
++ (Class)invalidationContextClass {
+    return [IGVerticalCollectionViewLayoutInvalidationContext class];
+}
+
+- (UICollectionViewLayoutInvalidationContext *)invalidationContextForBoundsChange:(CGRect)newBounds {
+    const CGRect oldBounds = self.collectionView.bounds;
+
+    IGVerticalCollectionViewLayoutInvalidationContext *context =
+    (IGVerticalCollectionViewLayoutInvalidationContext *)[super invalidationContextForBoundsChange:newBounds];
+    context.ig_invalidateSupplementaryAttributes = YES;
+    if (!CGSizeEqualToSize(oldBounds.size, newBounds.size)) {
+        context.ig_invalidateAllAttributes = YES;
+    }
+    return context;
+}
+
+- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
+    const CGRect oldBounds = self.collectionView.bounds;
+
+    // if the y origin has changed, only invalidate when using sticky headers
+    if (CGRectGetMinY(newBounds) != CGRectGetMinY(oldBounds)) {
+        return self.stickyHeaders;
+    }
+
+    // always invalidate for size changes
+    return !CGSizeEqualToSize(oldBounds.size, newBounds.size);
+}
+
+- (void)prepareLayout {
+    if (_cachedLayoutInvalid) {
+        [self cacheLayout];
+    }
+}
+
+#pragma mark - Public API
+
+- (void)setStickyHeaderOriginYAdjustment:(CGFloat)stickyHeaderOriginYAdjustment {
+    IGAssertMainThread();
+
+    if (_stickyHeaderOriginYAdjustment != stickyHeaderOriginYAdjustment) {
+        _stickyHeaderOriginYAdjustment = stickyHeaderOriginYAdjustment;
+
+        IGVerticalCollectionViewLayoutInvalidationContext *invalidationContext = [[IGVerticalCollectionViewLayoutInvalidationContext alloc] init];
+        invalidationContext.ig_invalidateSupplementaryAttributes = YES;
+        [self invalidateLayoutWithContext:invalidationContext];
+    }
+}
+
+#pragma mark - Private API
+
+- (void)cacheLayout {
+    _cachedLayoutInvalid = NO;
+
+    // purge attribute caches so they are rebuilt
+    [_attributesCache removeAllObjects];
+    [_headerAttributesCache removeAllObjects];
+    [_borderAttributesCache removeAllObjects];
+
+    UICollectionView *collectionView = self.collectionView;
+    id<UICollectionViewDataSource> dataSource = collectionView.dataSource;
+    id<UICollectionViewDelegateFlowLayout> delegate = (id<UICollectionViewDelegateFlowLayout>)collectionView.delegate;
+
+    const NSInteger sectionCount = [dataSource numberOfSectionsInCollectionView:collectionView];
+    const CGFloat collectionViewWidth = CGRectGetWidth(collectionView.bounds);
+    const CGFloat width = MIN(collectionViewWidth, self.maximumContentWidth);
+    const CGFloat centeringInset = (collectionViewWidth - width) / 2.0f;
+
+    auto sectionData = std::vector<IGSectionEntry>(sectionCount);
+
+    CGFloat itemY = 0.0;
+    CGFloat maxRowHeight = 0.0;
+    CGFloat itemX = 0.0;
+
+    // union item frames and optionally the header to find a bounding box of the entire section
+    CGRect rollingSectionBounds;
+
+    for (NSInteger section = 0; section < sectionCount; section++) {
+        const NSInteger itemCount = [dataSource collectionView:collectionView numberOfItemsInSection:section];
+        sectionData[section].itemBounds = std::vector<CGRect>(itemCount);
+
+        const CGSize headerSize = [delegate collectionView:collectionView layout:self referenceSizeForHeaderInSection:section];
+        const UIEdgeInsets insets = [delegate collectionView:collectionView layout:self insetForSectionAtIndex:section];
+        const CGFloat lineSpacing = [delegate collectionView:collectionView layout:self minimumLineSpacingForSectionAtIndex:section];
+        const CGFloat interitemSpacing = [delegate collectionView:collectionView layout:self minimumInteritemSpacingForSectionAtIndex:section];
+
+        const CGFloat paddedWidth = width - insets.left - insets.right;
+        const BOOL headerExists = headerSize.height > 0;
+
+        // start the section y accounting for the header height
+        // header height is subtracted from the sectionBounds when calculating the header bounds after items are done
+        // this bumps the first row of items down enough to make room for the header
+        itemY += headerSize.height;
+
+        // add the left inset in case the section falls on the same row as the previous
+        // if the section is newlined then the x is reset
+        itemX += insets.left;
+
+        for (NSInteger item = 0; item < itemCount; item++) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
+            const CGSize size = [delegate collectionView:collectionView layout:self sizeForItemAtIndexPath:indexPath];
+
+            IGAssert(size.width <= paddedWidth, @"Width of item %zi in section %zi must be less than container %.0f accounting for section insets %@",
+                     item, section, width, NSStringFromUIEdgeInsets(insets));
+            const CGFloat itemWidth = MIN(size.width, paddedWidth);
+
+            // if the x + width of the item busts the width of the container
+            // or if this is the first item and the header has a non-zero size
+            // newline to the next row and reset
+            if ((itemX + itemWidth > paddedWidth) ||
+                (item == 0 && headerExists)) {
+                itemY += maxRowHeight;
+                itemX = insets.left;
+                maxRowHeight = 0.0;
+
+                // if newlining, always append line spacing unless its the very first item of the section
+                if (item > 0) {
+                    itemY += lineSpacing;
+                }
+            }
+
+            const CGRect frame = CGRectMake(centeringInset + itemX,
+                                            itemY + insets.top,
+                                            itemWidth,
+                                            size.height);
+            sectionData[section].itemBounds[item] = frame;
+
+            // track the max size of the row to find the y of the next row
+            if (size.height > maxRowHeight) {
+                maxRowHeight = size.height;
+            }
+
+            // increase the rolling x by the item width and add item spacing for all items on the same row
+            itemX += itemWidth + interitemSpacing;
+
+            // union the rolling section bounds
+            if (item == 0) {
+                rollingSectionBounds = frame;
+            } else {
+                rollingSectionBounds = CGRectUnion(rollingSectionBounds, frame);
+            }
+        }
+
+        const CGRect headerBounds = CGRectMake(insets.left,
+                                               CGRectGetMinY(rollingSectionBounds) - headerSize.height,
+                                               paddedWidth,
+                                               headerSize.height);
+        sectionData[section].headerBounds = headerBounds;
+
+        // union the header before setting the bounds of the section
+        // only do this when the header has a size, otherwise the union stretches to box empty space
+        if (headerExists) {
+            rollingSectionBounds = CGRectUnion(rollingSectionBounds, headerBounds);
+        }
+
+        sectionData[section].bounds = rollingSectionBounds;
+        sectionData[section].insets = insets;
+
+        // bump the x for the next section with the right insets
+        itemX += insets.right;
+
+        // account for the top/bottom insets of the section since maxRowHeight only uses the item size.height
+        maxRowHeight += insets.top + insets.bottom;
+    }
+
+    _sectionData = sectionData;
+}
+
+- (NSRange)rangeOfSectionsInRect:(CGRect)rect {
+    NSRange result = NSMakeRange(NSNotFound, 0);
+
+    const NSInteger sectionCount = _sectionData.size();
+    for (NSInteger section = 0; section < sectionCount; section++) {
+        IGSectionEntry entry = _sectionData[section];
+        if (entry.isValid() && CGRectIntersectsRect(entry.bounds, rect)) {
+            const NSRange sectionRange = NSMakeRange(section, 1);
+            if (result.location == NSNotFound) {
+                result = sectionRange;
+            } else {
+                result = NSUnionRange(result, sectionRange);
+            }
+        }
+    }
+    
+    return result;
+}
+
+@end

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -109,7 +109,6 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-    IGAssert(NO, @"Layout initialized from storyboards not yet supported");
     return [self initWithStickyHeaders:NO topContentInset:0];
 }
 

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -17,7 +17,7 @@ static NSIndexPath *headerIndexPathForSection(NSInteger section) {
     return [NSIndexPath indexPathForItem:0 inSection:section];
 }
 
-struct IGSectionEntry {
+struct IGListSectionEntry {
     /**
      Represents the minimum-bounding box of every element in the section. This includes all item frames as well as the
      header bounds. It is made simply by unioning all item and header frames. Use this to find section intersections
@@ -79,7 +79,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 @end
 
 @implementation IGListCollectionViewLayout {
-    std::vector<IGSectionEntry> _sectionData;
+    std::vector<IGListSectionEntry> _sectionData;
     NSMutableDictionary<NSIndexPath *, UICollectionViewLayoutAttributes *> *_attributesCache;
     BOOL _cachedLayoutInvalid;
 
@@ -192,7 +192,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
     UICollectionView *collectionView = self.collectionView;
     const NSInteger section = indexPath.section;
-    const IGSectionEntry entry = _sectionData[section];
+    const IGListSectionEntry entry = _sectionData[section];
     const CGFloat minY = CGRectGetMinY(entry.bounds);
 
     CGRect frame = entry.headerBounds;
@@ -224,7 +224,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         return CGSizeZero;
     }
 
-    const IGSectionEntry section = _sectionData[sectionCount - 1];
+    const IGListSectionEntry section = _sectionData[sectionCount - 1];
     const CGFloat height = CGRectGetMaxY(section.bounds) + section.insets.bottom;
 
     UICollectionView *collectionView = self.collectionView;
@@ -317,7 +317,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     const UIEdgeInsets contentInset = collectionView.contentInset;
     const CGFloat width = CGRectGetWidth(collectionView.bounds) - contentInset.left - contentInset.right;
 
-    auto sectionData = std::vector<IGSectionEntry>(sectionCount);
+    auto sectionData = std::vector<IGListSectionEntry>(sectionCount);
 
     CGFloat itemY = 0.0;
     CGFloat maxRowHeight = 0.0;
@@ -422,7 +422,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
     const NSInteger sectionCount = _sectionData.size();
     for (NSInteger section = 0; section < sectionCount; section++) {
-        IGSectionEntry entry = _sectionData[section];
+        IGListSectionEntry entry = _sectionData[section];
         if (entry.isValid() && CGRectIntersectsRect(entry.bounds, rect)) {
             const NSRange sectionRange = NSMakeRange(section, 1);
             if (result.location == NSNotFound) {

--- a/Source/IGListKit.h
+++ b/Source/IGListKit.h
@@ -41,6 +41,7 @@ FOUNDATION_EXPORT const unsigned char IGListKitVersionString[];
 #import <IGListKit/IGListStackedSectionController.h>
 #import <IGListKit/IGListSupplementaryViewSource.h>
 #import <IGListKit/IGListUpdatingDelegate.h>
+#import <IGListKit/IGListCollectionViewLayout.h>
 #import <IGListKit/IGListWorkingRangeDelegate.h>
 
 #endif

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -71,7 +71,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     [self.collectionView layoutIfNeeded];
 }
 
-- (void)test_thatContentSizeZero_withEmptyData {
+- (void)test_whenEmptyData_thatContentSizeZero {
     [self setUpWithStickyHeaders:YES topInset:0];
 
     [self prepareWithData:nil];
@@ -81,7 +81,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, self.collectionView.contentSize));
 }
 
-- (void)test_contentSize_andCellFrame_withItemSizes_andHeaders_andLineSpacing_andSectionInsets {
+- (void)test_whenLayingOutCells_withHeaderHeight_withLineSpacing_withInsets_thatFramesCorrect {
     [self setUpWithStickyHeaders:NO topInset:0];
 
     const CGFloat headerHeight = 10;
@@ -113,7 +113,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 85, 85, 30);
 }
 
-- (void)test_stickyHeaders_afterScrolling {
+- (void)test_whenUsingStickyHeaders_withSimulatedScrolling_thatYPositionsAdjusted {
     [self setUpWithStickyHeaders:YES topInset:10];
 
     [self prepareWithData:@[
@@ -146,6 +146,46 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     self.collectionView.contentOffset = CGPointMake(0, 45);
     [self.collectionView layoutIfNeeded];
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 40, 100, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 55, 100, 10);
+}
+
+- (void)test_whenAdjustingTopYInset_withVaryingHeaderHeights_thatYPositionsUpdated {
+    [self setUpWithStickyHeaders:YES topInset:10];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,10} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,40} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,50} expensive:NO],
+                                                                          ]],
+                            ]];
+
+    // scroll header 0 off and 1 up
+    self.collectionView.contentOffset = CGPointMake(0, 35);
+    [self.collectionView layoutIfNeeded];
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 45, 100, 10);
+
+    self.layout.stickyHeaderOriginYAdjustment = -10;
+    [self.collectionView layoutIfNeeded];
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 40, 100, 10);
+
+    self.layout.stickyHeaderOriginYAdjustment = 10;
+    [self.collectionView layoutIfNeeded];
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 55, 100, 10);
 }
 
@@ -349,7 +389,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 43, 33, 33);
 }
 
-- (void)test_contentSize_andCellFrame_afterBatchUpdates {
+- (void)test_whenBatchItemUpdates_withHeaderHeight_withLineSpacing_withInsets_thatLayoutCorrectAfterUpdates {
     [self setUpWithStickyHeaders:NO topInset:0];
 
     const CGFloat headerHeight = 10;

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -571,4 +571,24 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     IGAssertEqualFrame([self cellForSection:2 item:0].frame, 0, 33, 33, 33);
 }
 
+- (void)test_whenCollectionViewContentInset_withFullWidthItems_thatItemsPinchedIn {
+    [self setUpWithStickyHeaders:NO topInset:0];
+    self.collectionView.contentInset = UIEdgeInsetsMake(0, 30, 0, 30);
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){40,10}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){40,20}],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 40);
+    IGAssertEqualFrame([self headerForSection:0].frame, 30, 0, 40, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 30, 10, 40, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 30, 20, 40, 20);
+}
+
 @end

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -94,15 +94,15 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:headerHeight
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:insets
                                                             lineSpacing:lineSpacing
                                                        interitemSpacing:0
                                                            headerHeight:headerHeight
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 120);
@@ -122,17 +122,17 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:10
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:10
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
                                                                           ]],
                             ]];
 
@@ -158,17 +158,17 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:10
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,10} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,10}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:10
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,40} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,50} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,40}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,50}],
                                                                           ]],
                             ]];
 
@@ -198,16 +198,16 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 66);
@@ -226,9 +226,9 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0.5
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
@@ -246,21 +246,21 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
@@ -269,7 +269,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     IGAssertEqualFrame([self cellForSection:2 item:0].frame, 66, 0, 33, 33);
 }
 
-- (void)test_whenSectionsSmallerThanContainerWidth_withHalfPointSpacing_with0Insets_with0LineSpacing_thatSEctoinsFitSameRow {
+- (void)test_whenSectionsSmallerThanContainerWidth_withHalfPointSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameRow {
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
@@ -278,21 +278,21 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0.5
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0.5
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0.5
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
@@ -310,28 +310,28 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){13,50} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){13,50}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 103);
@@ -350,14 +350,14 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 5, 5)
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,50} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,50}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 98);
@@ -374,14 +374,14 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:0
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
                                                             lineSpacing:0
                                                        interitemSpacing:0
                                                            headerHeight:10
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
                                                                           ]],
                             ]];
     XCTAssertEqual(self.collectionView.contentSize.height, 76);
@@ -405,29 +405,29 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                        interitemSpacing:0
                                                            headerHeight:headerHeight
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:insets
                                                             lineSpacing:lineSpacing
                                                        interitemSpacing:0
                                                            headerHeight:headerHeight
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:insets
                                                             lineSpacing:lineSpacing
                                                        interitemSpacing:0
                                                            headerHeight:headerHeight
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,60} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,60}],
                                                                           ]],
                             [[IGLayoutTestSection alloc] initWithInsets:insets
                                                             lineSpacing:lineSpacing
                                                        interitemSpacing:0
                                                            headerHeight:headerHeight
                                                                   items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40}],
                                                                           ]],
                             ]];
 
@@ -440,7 +440,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                                 interitemSpacing:0
                                                                     headerHeight:headerHeight
                                                                            items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO], // reloaded
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}], // reloaded
                                                                                    // deleted
                                                                                    ]],
                                      // moved from section 3 to 1
@@ -449,7 +449,7 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                                 interitemSpacing:0
                                                                     headerHeight:headerHeight
                                                                            items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40} expensive:NO],
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40}],
                                                                                    ]],
                                      // deleted section 2
                                      [[IGLayoutTestSection alloc] initWithInsets:insets
@@ -457,8 +457,8 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                                 interitemSpacing:0
                                                                     headerHeight:headerHeight
                                                                            items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO],
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO], // inserted
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}],
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}], // inserted
                                                                                    ]],
                                      // inserted
                                      [[IGLayoutTestSection alloc] initWithInsets:insets
@@ -466,8 +466,8 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
                                                                 interitemSpacing:0
                                                                     headerHeight:headerHeight
                                                                            items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO],
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20} expensive:NO],
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}],
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20}],
                                                                                    ]],
                                      ];
 
@@ -501,6 +501,74 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     [self waitForExpectationsWithTimeout:10 handler:^(NSError * _Nullable error) {
         XCTAssertNil(error);
     }];
+}
+
+- (void)test_whenInitializingWithCoder_thatThrows {
+    XCTAssertThrows([[IGListCollectionViewLayout alloc] initWithCoder:[NSCoder new]]);
+}
+
+- (void)test_whenQueryingLayoutAttributes_withLotsOfCells_thatExactFramesFetched {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    NSMutableArray *items = [NSMutableArray new];
+    for (NSInteger i = 0; i < 1000; i++) {
+        [items addObject:[[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}]];
+    }
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:items]
+                            ]];
+
+    XCTAssertEqual([self.layout layoutAttributesForElementsInRect:CGRectMake(0, 500, 100, 100)].count, 5);
+    XCTAssertEqual([self.layout layoutAttributesForElementsInRect:CGRectMake(0, 0, 100, 1000)].count, 50);
+    XCTAssertEqual([self.layout layoutAttributesForElementsInRect:CGRectMake(0, 250, 100, 100)].count, 6);
+    XCTAssertEqual([self.layout layoutAttributesForElementsInRect:CGRectMake(0, 250, 100, 1)].count, 1);
+}
+
+- (void)test_whenChangingBoundsSize_withItemsThatNewlineAfterChange_thatLayoutShiftsItems {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            ]];
+
+    XCTAssertEqual(self.collectionView.contentSize.height, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 33, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:2 item:0].frame, 66, 0, 33, 33);
+
+    // can no longer fit 3 items in one section
+    self.collectionView.frame = CGRectMake(0, 0, 70, 100);
+    [self.collectionView layoutIfNeeded];
+
+    XCTAssertEqual(self.collectionView.contentSize.height, 66);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 33, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:2 item:0].frame, 0, 33, 33, 33);
 }
 
 @end

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -1,0 +1,466 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <IGListKit/IGListCollectionViewLayout.h>
+
+#import "IGLayoutTestDataSource.h"
+#import "IGLayoutTestItem.h"
+#import "IGLayoutTestSection.h"
+
+@interface IGListCollectionViewLayoutTests : XCTestCase
+
+@property (nonatomic, strong) IGListCollectionViewLayout *layout;
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) IGLayoutTestDataSource *dataSource;
+
+@end
+
+static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
+
+static NSIndexPath *quickPath(NSInteger section, NSInteger item) {
+    return [NSIndexPath indexPathForItem:item inSection:section];
+}
+
+#define IGAssertEqualFrame(frame, x, y, w, h, ...) \
+do { \
+CGRect expected = CGRectMake(x, y, w, h); \
+XCTAssertEqual(CGRectGetMinX(expected), CGRectGetMinX(frame)); \
+XCTAssertEqual(CGRectGetMinY(expected), CGRectGetMinY(frame)); \
+XCTAssertEqual(CGRectGetWidth(expected), CGRectGetWidth(frame)); \
+XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
+} while(0)
+
+@implementation IGListCollectionViewLayoutTests
+
+- (UICollectionViewCell *)cellForSection:(NSInteger)section item:(NSInteger)item {
+    return [self.collectionView cellForItemAtIndexPath:quickPath(section, item)];
+}
+
+- (UICollectionReusableView *)headerForSection:(NSInteger)section {
+    return [self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:quickPath(section, 0)];
+}
+
+- (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset {
+    self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky topContentInset:inset];
+    self.dataSource = [IGLayoutTestDataSource new];
+    self.collectionView = [[UICollectionView alloc] initWithFrame:kTestFrame collectionViewLayout:self.layout];
+    self.collectionView.dataSource = self.dataSource;
+    self.collectionView.delegate = self.dataSource;
+    [self.dataSource configCollectionView:self.collectionView];
+}
+
+- (void)tearDown {
+    [super tearDown];
+
+    self.collectionView = nil;
+    self.layout = nil;
+    self.dataSource = nil;
+}
+
+- (void)prepareWithData:(NSArray<IGLayoutTestSection *> *)data {
+    self.dataSource.sections = data;
+    [self.collectionView reloadData];
+    [self.collectionView layoutIfNeeded];
+}
+
+- (void)test_thatContentSizeZero_withEmptyData {
+    [self setUpWithStickyHeaders:YES topInset:0];
+
+    [self prepareWithData:nil];
+
+    // check so that nil messaging doesn't default size to 0
+    XCTAssertEqual(self.layout.collectionView, self.collectionView);
+    XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, self.collectionView.contentSize));
+}
+
+- (void)test_contentSize_andCellFrame_withItemSizes_andHeaders_andLineSpacing_andSectionInsets {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    const CGFloat headerHeight = 10;
+    const CGFloat lineSpacing = 10;
+    const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                            lineSpacing:lineSpacing
+                                                       interitemSpacing:0
+                                                           headerHeight:headerHeight
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                            lineSpacing:lineSpacing
+                                                       interitemSpacing:0
+                                                           headerHeight:headerHeight
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 120);
+    IGAssertEqualFrame([self headerForSection:0].frame, 10, 10, 85, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 10, 20, 85, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 10, 40, 85, 20);
+    IGAssertEqualFrame([self headerForSection:1].frame, 10, 75, 85, 10);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 85, 85, 30);
+}
+
+- (void)test_stickyHeaders_afterScrolling {
+    [self setUpWithStickyHeaders:YES topInset:10];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30} expensive:NO],
+                                                                          ]],
+                            ]];
+
+    // scroll header 0 halfway
+    self.collectionView.contentOffset = CGPointMake(0, 5);
+    [self.collectionView layoutIfNeeded];
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 15, 100, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 50, 100, 10);
+
+    // scroll header 0 off and 1 up
+    self.collectionView.contentOffset = CGPointMake(0, 45);
+    [self.collectionView layoutIfNeeded];
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 40, 100, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 55, 100, 10);
+}
+
+- (void)test_whenItemsSmallerThanContainerWidth_with0Insets_with0LineSpacing_with0Interitem_thatItemsFitSameRow {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 66);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 33, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:2].frame, 66, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 33, 33, 33);
+}
+
+- (void)test_whenItemsSmallerThanContainerWidth_withHalfPointItemSpacing_with0Insets_with0LineSpacing_thatItemsFitSameRow {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0.5
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 33.5, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:2].frame, 67, 0, 33, 33);
+}
+
+- (void)test_whenSectionsSmallerThanContainerWidth_with0ItemSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameRow {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 33, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:2 item:0].frame, 66, 0, 33, 33);
+}
+
+- (void)test_whenSectionsSmallerThanContainerWidth_withHalfPointSpacing_with0Insets_with0LineSpacing_thatSEctoinsFitSameRow {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0.5
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0.5
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0.5
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 33.5, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:2 item:0].frame, 67, 0, 33, 33);
+}
+
+- (void)test_whenSectionsSmallerThanContainerWidth_with0ItemSpacing_withMiddleItemHasInsets_with0LineSpacing_thatNextSectionSnapsBelow {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){13,50} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 103);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 43, 10, 13, 50);
+    IGAssertEqualFrame([self cellForSection:2 item:0].frame, 66, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:3 item:0].frame, 0, 70, 33, 33);
+}
+
+- (void)test_whenSectionBustingRow_thatNewlineAppliesSectionInset {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 5, 5)
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,50} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 98);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 43, 85, 50);
+}
+
+- (void)test_whenSectionsSmallerThanWidth_withSectionHeader_thatHeaderCausesNewline {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33} expensive:NO],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.height, 76);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 43, 33, 33);
+}
+
+- (void)test_contentSize_andCellFrame_afterBatchUpdates {
+    [self setUpWithStickyHeaders:NO topInset:0];
+
+    const CGFloat headerHeight = 10;
+    const CGFloat lineSpacing = 10;
+    const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
+
+    // making the view bigger so that we can check all cell frames
+    self.collectionView.frame = CGRectMake(0, 0, 100, 400);
+
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                            lineSpacing:lineSpacing
+                                                       interitemSpacing:0
+                                                           headerHeight:headerHeight
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                            lineSpacing:lineSpacing
+                                                       interitemSpacing:0
+                                                           headerHeight:headerHeight
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                            lineSpacing:lineSpacing
+                                                       interitemSpacing:0
+                                                           headerHeight:headerHeight
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,60} expensive:NO],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                            lineSpacing:lineSpacing
+                                                       interitemSpacing:0
+                                                           headerHeight:headerHeight
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40} expensive:NO],
+                                                                          ]],
+                            ]];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+
+    [self.collectionView performBatchUpdates:^{
+        self.dataSource.sections = @[
+                                     [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                                     lineSpacing:lineSpacing
+                                                                interitemSpacing:0
+                                                                    headerHeight:headerHeight
+                                                                           items:@[
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO], // reloaded
+                                                                                   // deleted
+                                                                                   ]],
+                                     // moved from section 3 to 1
+                                     [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                                     lineSpacing:lineSpacing
+                                                                interitemSpacing:0
+                                                                    headerHeight:headerHeight
+                                                                           items:@[
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40} expensive:NO],
+                                                                                   ]],
+                                     // deleted section 2
+                                     [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                                     lineSpacing:lineSpacing
+                                                                interitemSpacing:0
+                                                                    headerHeight:headerHeight
+                                                                           items:@[
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30} expensive:NO],
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO], // inserted
+                                                                                   ]],
+                                     // inserted
+                                     [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                                     lineSpacing:lineSpacing
+                                                                interitemSpacing:0
+                                                                    headerHeight:headerHeight
+                                                                           items:@[
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10} expensive:NO],
+                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20} expensive:NO],
+                                                                                   ]],
+                                     ];
+
+        [self.collectionView deleteSections:[NSIndexSet indexSetWithIndex:2]];
+        [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:3]];
+        [self.collectionView moveSection:3 toSection:1];
+        [self.collectionView reloadItemsAtIndexPaths:@[quickPath(0, 0)]];
+        [self.collectionView deleteItemsAtIndexPaths:@[quickPath(0, 1)]];
+        [self.collectionView insertItemsAtIndexPaths:@[quickPath(2, 1)]];
+    } completion:^(BOOL finished) {
+        [self.collectionView layoutIfNeeded];
+        [expectation fulfill];
+
+        XCTAssertEqual(self.collectionView.contentSize.height, 260);
+
+        IGAssertEqualFrame([self headerForSection:0].frame, 10, 10, 85, 10);
+        IGAssertEqualFrame([self cellForSection:0 item:0].frame, 10, 20, 85, 30);
+        
+        IGAssertEqualFrame([self headerForSection:1].frame, 10, 65, 85, 10);
+        IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 75, 85, 40);
+        
+        IGAssertEqualFrame([self headerForSection:2].frame, 10, 130, 85, 10);
+        IGAssertEqualFrame([self cellForSection:2 item:0].frame, 10, 140, 85, 30);
+        IGAssertEqualFrame([self cellForSection:2 item:1].frame, 10, 180, 85, 10);
+        
+        IGAssertEqualFrame([self headerForSection:3].frame, 10, 205, 85, 10);
+        IGAssertEqualFrame([self cellForSection:3 item:0].frame, 10, 215, 85, 10);
+        IGAssertEqualFrame([self cellForSection:3 item:1].frame, 10, 235, 85, 20);
+    }];
+    
+    [self waitForExpectationsWithTimeout:10 handler:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+    }];
+}
+
+@end

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -503,10 +503,6 @@ XCTAssertEqual(CGRectGetHeight(expected), CGRectGetHeight(frame)); \
     }];
 }
 
-- (void)test_whenInitializingWithCoder_thatThrows {
-    XCTAssertThrows([[IGListCollectionViewLayout alloc] initWithCoder:[NSCoder new]]);
-}
-
 - (void)test_whenQueryingLayoutAttributes_withLotsOfCells_thatExactFramesFetched {
     [self setUpWithStickyHeaders:NO topInset:0];
 

--- a/Tests/Objects/IGLayoutTestDataSource.h
+++ b/Tests/Objects/IGLayoutTestDataSource.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+@class IGLayoutTestSection;
+
+@interface IGLayoutTestDataSource : NSObject <UICollectionViewDelegateFlowLayout, UICollectionViewDataSource>
+
+@property (nonatomic, strong) NSArray<IGLayoutTestSection *> *sections;
+
+// call before using as the data source so cells and headers are configured
+- (void)configCollectionView:(UICollectionView *)collectionView;
+
+@end

--- a/Tests/Objects/IGLayoutTestDataSource.m
+++ b/Tests/Objects/IGLayoutTestDataSource.m
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "IGLayoutTestDataSource.h"
+
+#import "IGLayoutTestItem.h"
+#import "IGLayoutTestSection.h"
+
+static NSString * const kCellIdentifier = @"cell";
+static NSString * const kHeaderIdentifier = @"header";
+
+@implementation IGLayoutTestDataSource
+
+- (void)configCollectionView:(UICollectionView *)collectionView {
+    [collectionView registerClass:[UICollectionViewCell class]
+       forCellWithReuseIdentifier:kCellIdentifier];
+    [collectionView registerClass:[UICollectionReusableView class]
+       forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+              withReuseIdentifier:kHeaderIdentifier];
+}
+
+#pragma mark - UICollectionViewDataSource
+
+- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+    return [self.sections count];
+}
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return [self.sections[section].items count];
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    return [collectionView dequeueReusableCellWithReuseIdentifier:kCellIdentifier forIndexPath:indexPath];
+}
+
+- (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath {
+    return [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                              withReuseIdentifier:kHeaderIdentifier
+                                                     forIndexPath:indexPath];
+}
+
+#pragma mark - UICollectionViewDelegateFlowLayout
+
+- (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {
+    return self.sections[section].insets;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
+    return self.sections[indexPath.section].items[indexPath.item].size;
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumLineSpacingForSectionAtIndex:(NSInteger)section {
+    return self.sections[section].lineSpacing;
+}
+
+- (CGFloat)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout minimumInteritemSpacingForSectionAtIndex:(NSInteger)section {
+    return self.sections[section].interitemSpacing;
+}
+
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section {
+    return CGSizeMake(CGRectGetWidth(collectionView.bounds), self.sections[section].headerHeight);
+}
+
+@end

--- a/Tests/Objects/IGLayoutTestItem.h
+++ b/Tests/Objects/IGLayoutTestItem.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface IGLayoutTestItem : NSObject
+
+@property (nonatomic, assign, readonly) CGSize size;
+@property (nonatomic, assign, readonly) BOOL expensive;
+
+- (instancetype)initWithSize:(CGSize)size expensive:(BOOL)expensive;
+
+@end

--- a/Tests/Objects/IGLayoutTestItem.h
+++ b/Tests/Objects/IGLayoutTestItem.h
@@ -12,8 +12,7 @@
 @interface IGLayoutTestItem : NSObject
 
 @property (nonatomic, assign, readonly) CGSize size;
-@property (nonatomic, assign, readonly) BOOL expensive;
 
-- (instancetype)initWithSize:(CGSize)size expensive:(BOOL)expensive;
+- (instancetype)initWithSize:(CGSize)size;
 
 @end

--- a/Tests/Objects/IGLayoutTestItem.m
+++ b/Tests/Objects/IGLayoutTestItem.m
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "IGLayoutTestItem.h"
+
+@implementation IGLayoutTestItem {
+    CGSize _size;
+}
+
+- (instancetype)initWithSize:(CGSize)size expensive:(BOOL)expensive {
+    if (self = [super init]) {
+        _size = size;
+        _expensive = expensive;
+    }
+    return self;
+}
+
+- (CGSize)size {
+    if (self.expensive) {
+        usleep(100); // 0.1 ms
+    }
+    return _size;
+}
+
+@end

--- a/Tests/Objects/IGLayoutTestItem.m
+++ b/Tests/Objects/IGLayoutTestItem.m
@@ -9,23 +9,13 @@
 
 #import "IGLayoutTestItem.h"
 
-@implementation IGLayoutTestItem {
-    CGSize _size;
-}
+@implementation IGLayoutTestItem
 
-- (instancetype)initWithSize:(CGSize)size expensive:(BOOL)expensive {
+- (instancetype)initWithSize:(CGSize)size {
     if (self = [super init]) {
         _size = size;
-        _expensive = expensive;
     }
     return self;
-}
-
-- (CGSize)size {
-    if (self.expensive) {
-        usleep(100); // 0.1 ms
-    }
-    return _size;
 }
 
 @end

--- a/Tests/Objects/IGLayoutTestSection.h
+++ b/Tests/Objects/IGLayoutTestSection.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+@class IGLayoutTestItem;
+
+@interface IGLayoutTestSection : NSObject
+
+@property (nonatomic, assign, readonly) UIEdgeInsets insets;
+@property (nonatomic, assign, readonly) CGFloat lineSpacing;
+@property (nonatomic, assign, readonly) CGFloat interitemSpacing;
+@property (nonatomic, assign, readonly) CGFloat headerHeight;
+@property (nonatomic, strong, readonly) NSArray<IGLayoutTestItem *> *items;
+
+- (instancetype)initWithInsets:(UIEdgeInsets)insets
+                   lineSpacing:(CGFloat)lineSpacing
+              interitemSpacing:(CGFloat)interitemSpacing
+                  headerHeight:(CGFloat)headerHeight
+                         items:(NSArray<IGLayoutTestItem *> *)items;
+
+@end

--- a/Tests/Objects/IGLayoutTestSection.m
+++ b/Tests/Objects/IGLayoutTestSection.m
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "IGLayoutTestSection.h"
+
+@implementation IGLayoutTestSection
+
+- (instancetype)initWithInsets:(UIEdgeInsets)insets
+                   lineSpacing:(CGFloat)lineSpacing
+              interitemSpacing:(CGFloat)interitemSpacing
+                  headerHeight:(CGFloat)headerHeight
+                         items:(NSArray<IGLayoutTestItem *> *)items {
+    if (self = [super init]) {
+        _insets = insets;
+        _lineSpacing = lineSpacing;
+        _interitemSpacing = interitemSpacing;
+        _headerHeight = headerHeight;
+        _items = [items copy];
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
Working on porting our collection view layout to IGListKit. I'm doing this because its a solid layout, and we just finished preparing it to work with inline sections. It is designed to work in tandem with IGListKit, so we're adding it.

This is still a WIP as I add more tests, but I'd love as much feedback as possible.

Aside from the glob of header documentation, this has the following features:

- Infinite sections that each have infinite items. Sections and items can fall inline. When they break the width of their container they will fall on the next row.
- Sections can have their own insets, line spacing, and interitem spacing.
- Sticky header support! When you use headers, it will always newline the section.
- Maximum width with a border decoration view
  - Use this to pinch in your content on larger devices

Followup to #423 

## TODO

- [ ] ~~Move decoration view support to delegate~~ removed
- [x] Unit test changing [top y sticky inset](https://coveralls.io/builds/9977284/source?filename=Source%2FIGListCollectionViewLayout.mm#L362)
- [ ] ~~Update `initWithCoder:` to use sensible defaults~~
- [x] Test `initWithCoder:` throws
- [x] Test when remaining cells [outside of visible bounds](https://coveralls.io/builds/9977284/source?filename=Source%2FIGListCollectionViewLayout.mm#L180)
- [ ] ~~Move `decorationBorderViewOfKind:` internal? C function? (or add unit tests)~~ removed
- [x] Unit test changing [bounds size](https://coveralls.io/builds/9977284/source?filename=Source%2FIGListCollectionViewLayout.mm#L337)

----

Copied from #450