### PR TITLE
fix #460 by making a copy of the section map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Gracefully handle a `nil` section controller returned by an `IGListAdapterDataSource`. [Ryan Nystrom](https://github.com/rnystrom) [(tbd)](https://github.com/Instagram/IGListKit/pull/tbd)
 
+- Fixes `-[IGListAdapter performUpdatesAnimated: completion:]`, not triggering the NSCopying copy() method for all objects inside the adapter array, this enables peformUpdates to correctly show in the collectionView edits to model objects that are implementing NSCopying. [Marco Pappalardo](https://github.com/racer1988) [(#510)](https://github.com/Instagram/IGListKit/pull/510)
+
 2.2.0
 -----
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -259,7 +259,7 @@
         return;
     }
 
-    NSArray *fromObjects = self.sectionMap.objects;
+    NSArray *fromObjects = [[NSArray alloc] initWithArray:self.sectionMap.objects copyItems:YES];
     NSArray *newObjects = [dataSource objectsForListAdapter:self];
 
     __weak __typeof__(self) weakSelf = self;


### PR DESCRIPTION
performUpdates was not making any copy of the old map
or the new objects

Due to this, no objects inside the array were getting their
copy() (NSCopying) method called.

This prevented updates to objects in the collectionView.
By making a shallow copy of the map, we trigger the copy()
method of every objects, permitting the comparison of
copied object provided by the user implementation of NSCopying
and the new objects provided by IGListKit Adapter Data Source

## Changes in this pull request

Issue fixed: #460 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
