### PR TITLE
consistent use of finall class

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-class DemoItem: NSObject {
+final class DemoItem: NSObject {
 
     let name: String
     let controllerClass: UIViewController.Type

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-class DisplaySectionController: IGListSectionController, IGListSectionType, IGListDisplayDelegate {
+final class DisplaySectionController: IGListSectionController, IGListSectionType, IGListDisplayDelegate {
 
     override init() {
         super.init()

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-class GridItem: NSObject {
+final class GridItem: NSObject {
 
     let color: UIColor
     let itemCount: Int

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DisplayViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DisplayViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-class DisplayViewController: UIViewController, IGListAdapterDataSource {
+final class DisplayViewController: UIViewController, IGListAdapterDataSource {
 
     lazy var adapter: IGListAdapter = {
         return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)

--- a/Examples/Examples-iOS/IGListKitExamples/Views/CenterLabelCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/CenterLabelCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class CenterLabelCell: UICollectionViewCell {
+final class CenterLabelCell: UICollectionViewCell {
 
     lazy var label: UILabel = {
         let view = UILabel()

--- a/Examples/Examples-iOS/IGListKitExamples/Views/DetailLabelCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/DetailLabelCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class DetailLabelCell: UICollectionViewCell {
+final class DetailLabelCell: UICollectionViewCell {
 
     fileprivate let padding: CGFloat = 15.0
 

--- a/Examples/Examples-iOS/IGListKitExamples/Views/EmbeddedCollectionViewCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/EmbeddedCollectionViewCell.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-class EmbeddedCollectionViewCell: UICollectionViewCell {
+final class EmbeddedCollectionViewCell: UICollectionViewCell {
 
     lazy var collectionView: IGListCollectionView = {
         let layout = UICollectionViewFlowLayout()

--- a/Examples/Examples-iOS/IGListKitExamples/Views/ImageCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/ImageCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class ImageCell: UICollectionViewCell {
+final class ImageCell: UICollectionViewCell {
 
     fileprivate let imageView: UIImageView = {
         let view = UIImageView()

--- a/Examples/Examples-iOS/IGListKitExamples/Views/LabelCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/LabelCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class LabelCell: UICollectionViewCell {
+final class LabelCell: UICollectionViewCell {
 
     fileprivate static let insets = UIEdgeInsets(top: 8, left: 15, bottom: 8, right: 15)
     fileprivate static let font = UIFont.systemFont(ofSize: 17)

--- a/Examples/Examples-iOS/IGListKitExamples/Views/ManuallySelfSizingCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/ManuallySelfSizingCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class ManuallySelfSizingCell: UICollectionViewCell {
+final class ManuallySelfSizingCell: UICollectionViewCell {
 
     let label: UILabel = {
         let label = UILabel()

--- a/Examples/Examples-iOS/IGListKitExamples/Views/NibSelfSizingCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/NibSelfSizingCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class NibSelfSizingCell: UICollectionViewCell {
+final class NibSelfSizingCell: UICollectionViewCell {
     
     @IBOutlet weak var contentLabel: UILabel!
 

--- a/Examples/Examples-iOS/IGListKitExamples/Views/RemoveCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/RemoveCell.swift
@@ -18,7 +18,7 @@ protocol RemoveCellDelegate: class {
     func removeCellDidTapButton(_ cell: RemoveCell)
 }
 
-class RemoveCell: UICollectionViewCell {
+final class RemoveCell: UICollectionViewCell {
 
     weak var delegate: RemoveCellDelegate?
 

--- a/Examples/Examples-iOS/IGListKitExamples/Views/SearchCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/SearchCell.swift
@@ -14,7 +14,7 @@
 
 import UIKit
 
-class SearchCell: UICollectionViewCell {
+final class SearchCell: UICollectionViewCell {
 
     lazy var searchBar: UISearchBar = {
         let view = UISearchBar()

--- a/Examples/Examples-iOS/IGListKitExamples/Views/SpinnerCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/SpinnerCell.swift
@@ -31,7 +31,7 @@ func spinnerSectionController() -> IGListSingleSectionController {
                                          sizeBlock: sizeBlock)
 }
 
-class SpinnerCell: UICollectionViewCell {
+final class SpinnerCell: UICollectionViewCell {
 
     lazy var activityIndicator: UIActivityIndicatorView = {
         let view = UIActivityIndicatorView(activityIndicatorStyle: .gray)

--- a/Examples/Examples-iOS/IGListKitExamples/Views/StoryboardCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/StoryboardCell.swift
@@ -14,6 +14,6 @@
 
 import UIKit
 
-class StoryboardCell: UICollectionViewCell {
+final class StoryboardCell: UICollectionViewCell {
     @IBOutlet weak var textLabel: UILabel!
 }


### PR DESCRIPTION
You are already using `final class` as the default swift declaration as I guess most people agree this is best practice for classes you are not planning to inherit from :) So I just made the example code more consistent. 

I will not add much more reasoning to why, other than open source projects like this is a _big_ inspirations and starting ground to play with swift for new develoeprs joining the iOS community. Nuding them to ask the right questions (composition vs inheritance) early could only be a good thing (?)

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [X] No new tests. No new classes.
- [X] No breaking changes.
- [X] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
