### PR TITLE
Added two useful UIScrollViewDelegate methods to IGListAdapterProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Renamed `IGListAdapterUpdaterDelegate` method to `listAdapterUpdater:didPerformBatchUpdates:collectionView:`. [Vincent Peng](https://github.com/vincent-peng) [(#491)](https://github.com/Instagram/IGListKit/pull/491)
 
+- Added `scrollViewDidEndScrollingAnimation:` and `scrollViewDidEndDecelerating:` UIScrollViewDelegate methods to IGListAdapterProxy. [Antoine Lamy](https://github.com/antoinelamy) [(#570)](https://github.com/Instagram/IGListKit/pull/570)
+
 
 ### Enhancements
 

--- a/Source/Internal/IGListAdapterProxy.m
+++ b/Source/Internal/IGListAdapterProxy.m
@@ -31,7 +31,9 @@ static BOOL isInterceptedSelector(SEL sel) {
             // UIScrollViewDelegate
             sel == @selector(scrollViewDidScroll:) ||
             sel == @selector(scrollViewWillBeginDragging:) ||
-            sel == @selector(scrollViewDidEndDragging:willDecelerate:)
+            sel == @selector(scrollViewDidEndDragging:willDecelerate:) ||
+            sel == @selector(scrollViewDidEndScrollingAnimation:) ||
+            sel == @selector(scrollViewDidEndDecelerating:)
             );
 }
 


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: Added two useful UIScrollViewDelegate methods to IGListAdapterProxy. `IGListAdapterProxyTests` already cover the changes.

### Checklist

- [ X ] All tests pass. Demo project builds and runs.
- [ X ] I added tests, an experiment, or detailed why my change isn't tested.
- [ X ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ X ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)