### PR TITLE
Fix unused variable warning when asserts compiled out

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -1054,8 +1054,7 @@
     IGAssertMainThread();
     IGParameterAssert(indexes != nil);
     IGParameterAssert(sectionController != nil);
-    UICollectionView *collectionView = self.collectionView;
-    IGAssert(collectionView != nil, @"Tried to reload the adapter from %@ without a collection view at indexes %@.", sectionController, indexes);
+    IGAssert(self.collectionView != nil, @"Tried to reload the adapter from %@ without a collection view at indexes %@.", sectionController, indexes);
 
     if (indexes.count == 0) {
         return;


### PR DESCRIPTION
## Changes in this pull request

Found this examining Travis output. Warning removed when asserts aren't compiled.

#trivial