### PR TITLE
Fix bug where IGListAdapterProxy cast to UICollectionViewDelegateFlowLayout in Swift always fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Fix a potential crash when a section is moved and deleted at the same time. [Ryan Nystrom](https://github.com/rnystrom) [(#577)](https://github.com/Instagram/IGListKit/pull/577)
 
+- Fix bug where `IGListAdapterProxy` cast to `UICollectionViewDelegateFlowLayout` in Swift always fails. [Anton Romanov](https://github.com/Istered) [(#592)](https://github.com/Instagram/IGListKit/pull/592)
+
 2.1.0
 -----
 
@@ -242,5 +244,3 @@ You can find a [migration guide here](https://instagram.github.io/IGListKit/migr
 -----
 
 Initial release. :tada:
-
-

--- a/Source/Internal/IGListAdapterProxy.m
+++ b/Source/Internal/IGListAdapterProxy.m
@@ -58,6 +58,10 @@ static BOOL isInterceptedSelector(SEL sel) {
     return self;
 }
 
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol {
+    return aProtocol == @protocol(UICollectionViewDelegateFlowLayout);
+}
+
 - (BOOL)respondsToSelector:(SEL)aSelector {
     return isInterceptedSelector(aSelector)
     || [_collectionViewTarget respondsToSelector:aSelector]


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: Added conformsToProtocol implementation to `IGListAdapterProxy` that fixing Swift cast to `UICollectionViewDelegateFlowLayout`.

I noticed that cast to UICollectionViewDelegateFlowLayout always fails when I was trying to implement custom collection layout, so this PR should fix this problem.
But I'm wondering what kind of tests should I add? All the tests are written in Objective C while this problem persists only in Swift code. 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)