### PR TITLE
Swift name annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 ### Breaking Changes
 
+- Added Swift annotation names which remove `IG` prefixes from class names, C functions, and other APIs. Note, this only affects Swift clients. [Robert Payne](https://github.com/robertjpayne) [(#593)](https://github.com/Instagram/IGListKit/pull/593)
+
+Example:
+
+```swift
+// OLD
+class MySectionController : IGListSectionController { ... }
+
+// NEW
+class MySectionController : ListSectionController { ... }
+
+// OLD
+IGListDiff([], [], .equality)
+
+// NEW
+ListDiff(oldArray: [], newArray: [], .equality)
+
+```
+
 - Updated `didSelect` delegate call in `IGListSingleSectionControllerDelegate` to include object. [Sherlouk](https://github.com/Sherlouk) [(#397)](https://github.com/Instagram/IGListKit/pull/397)
 
 ```objc

--- a/Examples/Examples-iOS/IGListKitExamples/Models/FeedItem.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/FeedItem.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-final class FeedItem: IGListDiffable {
+final class FeedItem: ListDiffable {
 
     let pk: Int
     let user: User
@@ -26,13 +26,13 @@ final class FeedItem: IGListDiffable {
         self.comments = comments
     }
 
-    //MARK: IGListDiffable
+    //MARK: ListDiffable
 
     func diffIdentifier() -> NSObjectProtocol {
         return pk as NSObjectProtocol
     }
 
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         guard self !== object else { return true }
         guard let object = object as? FeedItem else { return false }
         return user.isEqual(toDiffableObject: object.user) && comments == object.comments

--- a/Examples/Examples-iOS/IGListKitExamples/Models/Month.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/Month.swift
@@ -31,13 +31,13 @@ final class Month {
     
 }
 
-extension Month: IGListDiffable {
+extension Month: ListDiffable {
     
     func diffIdentifier() -> NSObjectProtocol {
         return name as NSObjectProtocol
     }
     
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         return true
     }
     

--- a/Examples/Examples-iOS/IGListKitExamples/Models/SelectionModel.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/SelectionModel.swift
@@ -30,13 +30,13 @@ final class SelectionModel: NSObject {
 
 }
 
-extension SelectionModel: IGListDiffable {
+extension SelectionModel: ListDiffable {
 
     func diffIdentifier() -> NSObjectProtocol {
         return self
     }
 
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         return isEqual(object)
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/Models/User.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/User.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-final class User: IGListDiffable {
+final class User: ListDiffable {
 
     let pk: Int
     let name: String
@@ -26,13 +26,13 @@ final class User: IGListDiffable {
         self.handle = handle
     }
 
-    //MARK: IGListDiffable
+    //MARK: ListDiffable
 
     func diffIdentifier() -> NSObjectProtocol {
         return pk as NSObjectProtocol
     }
 
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         guard self !== object else { return true }
         guard let object = object as? User else { return false }
         return name == object.name && handle == object.handle

--- a/Examples/Examples-iOS/IGListKitExamples/Models/ViewModels/DayViewModel.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/ViewModels/DayViewModel.swift
@@ -31,13 +31,13 @@ final class DayViewModel {
     
 }
 
-extension DayViewModel: IGListDiffable {
+extension DayViewModel: ListDiffable {
     
     func diffIdentifier() -> NSObjectProtocol {
         return day as NSObjectProtocol
     }
     
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         if self === object { return true }
         guard let object = object as? DayViewModel else { return false }
         return today == object.today && selected == object.selected && appointments == object.appointments

--- a/Examples/Examples-iOS/IGListKitExamples/Models/ViewModels/MonthTitleViewModel.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/ViewModels/MonthTitleViewModel.swift
@@ -25,13 +25,13 @@ final class MonthTitleViewModel {
     
 }
 
-extension MonthTitleViewModel: IGListDiffable {
+extension MonthTitleViewModel: ListDiffable {
     
     func diffIdentifier() -> NSObjectProtocol {
         return name as NSObjectProtocol
     }
     
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         if self === object { return true }
         guard object is MonthTitleViewModel else { return false }
         // name is checked in the diffidentifier, so we can assume its equal

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -33,13 +33,13 @@ final class DemoItem: NSObject {
 
 }
 
-extension DemoItem: IGListDiffable {
+extension DemoItem: ListDiffable {
 
     func diffIdentifier() -> NSObjectProtocol {
         return name as NSObjectProtocol
     }
 
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         if self === object { return true }
         guard let object = object as? DemoItem else { return false }
         return controllerClass == object.controllerClass && controllerIdentifier == object.controllerIdentifier
@@ -47,7 +47,7 @@ extension DemoItem: IGListDiffable {
 
 }
 
-final class DemoSectionController: IGListSectionController, IGListSectionType {
+final class DemoSectionController: ListSectionController, ListSectionType {
 
     var object: DemoItem?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class DisplaySectionController: IGListSectionController, IGListSectionType, IGListDisplayDelegate {
+final class DisplaySectionController: ListSectionController, ListSectionType, ListDisplayDelegate {
 
     override init() {
         super.init()
@@ -42,24 +42,24 @@ final class DisplaySectionController: IGListSectionController, IGListSectionType
 
     func didSelectItem(at index: Int) {}
 
-    // MARK: IGListDisplayDelegate
+    // MARK: ListDisplayDelegate
 
-    func listAdapter(_ listAdapter: IGListAdapter, willDisplay sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: ListAdapter, willDisplay sectionController: ListSectionController) {
         let section = collectionContext!.section(for: self)
         print("Will display section \(section)")
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, willDisplay sectionController: IGListSectionController, cell: UICollectionViewCell, at index: Int) {
+    func listAdapter(_ listAdapter: ListAdapter, willDisplay sectionController: ListSectionController, cell: UICollectionViewCell, at index: Int) {
         let section = collectionContext!.section(for: self)
         print("Did will display cell \(index) in section \(section)")
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, didEndDisplaying sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: ListAdapter, didEndDisplaying sectionController: ListSectionController) {
         let section = collectionContext!.section(for: self)
         print("Did end displaying section \(section)")
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, didEndDisplaying sectionController: IGListSectionController, cell: UICollectionViewCell, at index: Int) {
+    func listAdapter(_ listAdapter: ListAdapter, didEndDisplaying sectionController: ListSectionController, cell: UICollectionViewCell, at index: Int) {
         let section = collectionContext!.section(for: self)
         print("Did end displaying cell \(index) in section \(section)")
     }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/EmbeddedSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/EmbeddedSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class EmbeddedSectionController: IGListSectionController, IGListSectionType {
+final class EmbeddedSectionController: ListSectionController, ListSectionType {
 
     var number: Int?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class ExpandableSectionController: IGListSectionController, IGListSectionType {
+final class ExpandableSectionController: ListSectionController, ListSectionType {
 
     var expanded = false
     var object: String?

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-final class FeedItemSectionController: IGListSectionController, IGListSectionType, IGListSupplementaryViewSource {
+final class FeedItemSectionController: ListSectionController, ListSectionType, ListSupplementaryViewSource {
 
     var feedItem: FeedItem!
 
@@ -45,7 +45,7 @@ final class FeedItemSectionController: IGListSectionController, IGListSectionTyp
 
     func didSelectItem(at index: Int) {}
 
-    // MARK: IGListSupplementaryViewSource
+    // MARK: ListSupplementaryViewSource
 
     func supportedElementKinds() -> [String] {
         return [UICollectionElementKindSectionHeader]

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
@@ -27,19 +27,19 @@ final class GridItem: NSObject {
 
 }
 
-extension GridItem: IGListDiffable {
+extension GridItem: ListDiffable {
     
     func diffIdentifier() -> NSObjectProtocol {
         return self
     }
     
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         return self === object ? true : self.isEqual(object)
     }
     
 }
 
-final class GridSectionController: IGListSectionController, IGListSectionType {
+final class GridSectionController: ListSectionController, ListSectionType {
 
     var object: GridItem?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
@@ -15,12 +15,12 @@
 import UIKit
 import IGListKit
 
-final class HorizontalSectionController: IGListSectionController, IGListSectionType, IGListAdapterDataSource {
+final class HorizontalSectionController: ListSectionController, ListSectionType, ListAdapterDataSource {
 
     var number: Int?
 
-    lazy var adapter: IGListAdapter = {
-        let adapter = IGListAdapter(updater: IGListAdapterUpdater(),
+    lazy var adapter: ListAdapter = {
+        let adapter = ListAdapter(updater: ListAdapterUpdater(),
                                     viewController: self.viewController,
                                     workingRangeSize: 0)
         adapter.dataSource = self
@@ -47,18 +47,18 @@ final class HorizontalSectionController: IGListSectionController, IGListSectionT
 
     func didSelectItem(at index: Int) {}
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         guard let number = number else { return [] }
-        return (0..<number).map { $0 as IGListDiffable }
+        return (0..<number).map { $0 as ListDiffable }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return EmbeddedSectionController()
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class LabelSectionController: IGListSectionController, IGListSectionType {
+final class LabelSectionController: ListSectionController, ListSectionType {
 
     var object: String?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-final class ListeningSectionController: IGListSectionController, IGListSectionType, IncrementListener {
+final class ListeningSectionController: ListSectionController, ListSectionType, IncrementListener {
 
     var value: Int = 0
 
@@ -28,7 +28,7 @@ final class ListeningSectionController: IGListSectionController, IGListSectionTy
         cell.label.text = "Section: \(section), value: \(value)"
     }
 
-    // MARK: IGListSectionType
+    // MARK: ListSectionType
 
     func numberOfItems() -> Int {
         return 1

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/MonthSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/MonthSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class MonthSectionController: IGListBindingSectionController<IGListDiffable>, IGListBindingSectionControllerDataSource, IGListBindingSectionControllerSelectionDelegate {
+final class MonthSectionController: ListBindingSectionController<ListDiffable>, ListBindingSectionControllerDataSource, ListBindingSectionControllerSelectionDelegate {
     
     var selectedDay: Int = -1
     
@@ -25,15 +25,15 @@ final class MonthSectionController: IGListBindingSectionController<IGListDiffabl
         selectionDelegate = self
     }
     
-    // MARK: IGListBindingSectionControllerDataSource
+    // MARK: ListBindingSectionControllerDataSource
     
-    func sectionController(_ sectionController: IGListBindingSectionController<IGListDiffable>, viewModelsFor object: Any) -> [IGListDiffable] {
+    func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, viewModelsFor object: Any) -> [ListDiffable] {
         guard let month = object as? Month else { return [] }
         
         let date = Date()
         let today = Calendar.current.component(.day, from: date)
         
-        var viewModels = [IGListDiffable]()
+        var viewModels = [ListDiffable]()
         
         viewModels.append(MonthTitleViewModel(name: month.name))
         
@@ -54,7 +54,7 @@ final class MonthSectionController: IGListBindingSectionController<IGListDiffabl
         return viewModels
     }
     
-    func sectionController(_ sectionController: IGListBindingSectionController<IGListDiffable>, cellForViewModel viewModel: Any, at index: Int) -> UICollectionViewCell {
+    func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, cellForViewModel viewModel: Any, at index: Int) -> UICollectionViewCell {
         let cellClass: AnyClass
         if viewModel is DayViewModel {
             cellClass = CalendarDayCell.self
@@ -66,7 +66,7 @@ final class MonthSectionController: IGListBindingSectionController<IGListDiffabl
         return collectionContext?.dequeueReusableCell(of: cellClass, for: self, at: index) ?? UICollectionViewCell()
     }
     
-    func sectionController(_ sectionController: IGListBindingSectionController<IGListDiffable>, sizeForViewModel viewModel: Any, at index: Int) -> CGSize {
+    func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, sizeForViewModel viewModel: Any, at index: Int) -> CGSize {
         guard let width = collectionContext?.containerSize.width else { return .zero }
         if viewModel is DayViewModel {
             let square = width / 7.0
@@ -78,9 +78,9 @@ final class MonthSectionController: IGListBindingSectionController<IGListDiffabl
         }
     }
     
-    // MARK: IGListBindingSectionControllerSelectionDelegate
+    // MARK: ListBindingSectionControllerSelectionDelegate
     
-    func sectionController(_ sectionController: IGListBindingSectionController<IGListDiffable>, didSelectItemAt index: Int, viewModel: Any) {
+    func sectionController(_ sectionController: ListBindingSectionController<ListDiffable>, didSelectItemAt index: Int, viewModel: Any) {
         guard let dayViewModel = viewModel as? DayViewModel else { return }
         if dayViewModel.day == selectedDay {
             selectedDay = -1

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/RemoveSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/RemoveSectionController.swift
@@ -18,7 +18,7 @@ protocol RemoveSectionControllerDelegate: class {
     func removeSectionControllerWantsRemoved(_ sectionController: RemoveSectionController)
 }
 
-final class RemoveSectionController: IGListSectionController, IGListSectionType, RemoveCellDelegate {
+final class RemoveSectionController: ListSectionController, ListSectionType, RemoveCellDelegate {
 
     weak var delegate: RemoveSectionControllerDelegate?
     var number: Int?

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
@@ -18,7 +18,7 @@ protocol SearchSectionControllerDelegate: class {
     func searchSectionController(_ sectionController: SearchSectionController, didChangeText text: String)
 }
 
-final class SearchSectionController: IGListSectionController, IGListSectionType, UISearchBarDelegate, IGListScrollDelegate {
+final class SearchSectionController: ListSectionController, ListSectionType, UISearchBarDelegate, ListScrollDelegate {
 
     weak var delegate: SearchSectionControllerDelegate?
 
@@ -54,16 +54,16 @@ final class SearchSectionController: IGListSectionController, IGListSectionType,
         delegate?.searchSectionController(self, didChangeText: "")
     }
 
-    //MARK: IGListScrollDelegate
+    //MARK: ListScrollDelegate
 
-    func listAdapter(_ listAdapter: IGListAdapter, didScroll sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: ListAdapter, didScroll sectionController: ListSectionController) {
         if let searchBar = (collectionContext?.cellForItem(at: 0, sectionController: self) as? SearchCell)?.searchBar {
             searchBar.text = ""
             searchBar.resignFirstResponder()
         }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter!, willBeginDragging sectionController: IGListSectionController!) {}
-    func listAdapter(_ listAdapter: IGListAdapter!, didEndDragging sectionController: IGListSectionController!, willDecelerate decelerate: Bool) {}
+    func listAdapter(_ listAdapter: ListAdapter!, willBeginDragging sectionController: ListSectionController!) {}
+    func listAdapter(_ listAdapter: ListAdapter!, didEndDragging sectionController: ListSectionController!, willDecelerate decelerate: Bool) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SelfSizingSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SelfSizingSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class SelfSizingSectionController: IGListSectionController, IGListSectionType {
+final class SelfSizingSectionController: ListSectionController, ListSectionType {
 
     var model: SelectionModel!
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/StoryboardLabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/StoryboardLabelSectionController.swift
@@ -19,7 +19,7 @@ protocol StoryboardLabelSectionControllerDelegate: class {
     func removeSectionControllerWantsRemoved(_ sectionController: StoryboardLabelSectionController)
 }
 
-final class StoryboardLabelSectionController: IGListSectionController, IGListSectionType {
+final class StoryboardLabelSectionController: ListSectionController, ListSectionType {
     
     var object: Person?
     weak var delegate: StoryboardLabelSectionControllerDelegate?

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/UserSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/UserSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class UserSectionController: IGListSectionController, IGListSectionType {
+final class UserSectionController: ListSectionController, ListSectionType {
 
     var user: User?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class WorkingRangeSectionController: IGListSectionController, IGListSectionType, IGListWorkingRangeDelegate {
+final class WorkingRangeSectionController: ListSectionController, ListSectionType, ListWorkingRangeDelegate {
 
     var height: Int?
     var downloadedImage: UIImage?
@@ -64,9 +64,9 @@ final class WorkingRangeSectionController: IGListSectionController, IGListSectio
 
     func didSelectItem(at index: Int) {}
 
-    //MARK: IGListWorkingRangeDelegate
+    //MARK: ListWorkingRangeDelegate
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerWillEnterWorkingRange sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerWillEnterWorkingRange sectionController: ListSectionController) {
         guard downloadedImage == nil,
             task == nil,
             let urlString = urlString,
@@ -90,6 +90,6 @@ final class WorkingRangeSectionController: IGListSectionController, IGListSectio
         task?.resume()
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerDidExitWorkingRange sectionController: IGListSectionController) {}
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerDidExitWorkingRange sectionController: ListSectionController) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/AnnouncingDepsViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/AnnouncingDepsViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class AnnouncingDepsViewController: UIViewController, IGListAdapterDataSource {
+final class AnnouncingDepsViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 1)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 1)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     let data: [NSNumber] = Array(0..<20).map { $0 as NSNumber }
@@ -50,17 +50,17 @@ final class AnnouncingDepsViewController: UIViewController, IGListAdapterDataSou
         announcer.increment()
     }
 
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return data
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return ListeningSectionController(announcer: announcer)
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
@@ -15,14 +15,14 @@
 import UIKit
 import IGListKit
 
-final class CalendarViewController: UIViewController, IGListAdapterDataSource {
+final class CalendarViewController: UIViewController, ListAdapterDataSource {
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(
         frame: .zero,
-        collectionViewLayout: IGListCollectionViewLayout(stickyHeaders: false, topContentInset: 0, stretchToEdge: false)
+        collectionViewLayout: ListCollectionViewLayout(stickyHeaders: false, topContentInset: 0, stretchToEdge: false)
     )
     
     var months = [Month]()
@@ -61,16 +61,16 @@ final class CalendarViewController: UIViewController, IGListAdapterDataSource {
         collectionView.frame = view.bounds
     }
     
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return months
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return MonthSectionController()
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class DemosViewController: UIViewController, IGListAdapterDataSource {
+final class DemosViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
@@ -55,17 +55,17 @@ final class DemosViewController: UIViewController, IGListAdapterDataSource {
         collectionView.frame = view.bounds
     }
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return demos
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return DemoSectionController()
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DiffTableViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DiffTableViewController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class Person: IGListDiffable {
+final class Person: ListDiffable {
 
     let pk: Int
     let name: String
@@ -29,7 +29,7 @@ final class Person: IGListDiffable {
         return pk as NSNumber
     }
 
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         guard let object = object as? Person else { return false }
         return self.name == object.name
     }
@@ -79,7 +79,7 @@ final class DiffTableViewController: UITableViewController {
         usingOldPeople = !usingOldPeople
         people = to
 
-        let result = IGListDiffPaths(0, 0, from, to, .equality).forBatchUpdates()
+        let result = ListDiffPaths(fromSection: 0, toSection: 0, oldArray: from, newArray: to, option: .equality).forBatchUpdates()
 
         tableView.beginUpdates()
         tableView.deleteRows(at: result.deletes, with: .fade)

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DisplayViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DisplayViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class DisplayViewController: UIViewController, IGListAdapterDataSource {
+final class DisplayViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
@@ -34,16 +34,16 @@ final class DisplayViewController: UIViewController, IGListAdapterDataSource {
         collectionView.frame = view.bounds
     }
 
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return [1, 2, 3, 4, 5, 6] as [NSNumber]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return DisplaySectionController()
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/EmptyViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/EmptyViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class EmptyViewController: UIViewController, IGListAdapterDataSource, RemoveSectionControllerDelegate {
+final class EmptyViewController: UIViewController, ListAdapterDataSource, RemoveSectionControllerDelegate {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -60,19 +60,19 @@ final class EmptyViewController: UIViewController, IGListAdapterDataSource, Remo
         adapter.performUpdates(animated: true, completion: nil)
     }
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         let sectionController = RemoveSectionController()
         sectionController.delegate = self
         return sectionController
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return emptyLabel
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/LoadMoreViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/LoadMoreViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class LoadMoreViewController: UIViewController, IGListAdapterDataSource, UIScrollViewDelegate {
+final class LoadMoreViewController: UIViewController, ListAdapterDataSource, UIScrollViewDelegate {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
@@ -39,19 +39,19 @@ final class LoadMoreViewController: UIViewController, IGListAdapterDataSource, U
         collectionView.frame = view.bounds
     }
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        var objects = items as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        var objects = items as [ListDiffable]
         
         if loading {
-            objects.append(spinToken as IGListDiffable)
+            objects.append(spinToken as ListDiffable)
         }
         
         return objects
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         if let obj = object as? String, obj == spinToken {
             return spinnerSectionController()
         } else {
@@ -59,7 +59,7 @@ final class LoadMoreViewController: UIViewController, IGListAdapterDataSource, U
         }
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
     //MARK: UIScrollViewDelegate
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/MixedDataViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/MixedDataViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class MixedDataViewController: UIViewController, IGListAdapterDataSource {
+final class MixedDataViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
@@ -69,17 +69,17 @@ final class MixedDataViewController: UIViewController, IGListAdapterDataSource {
         adapter.performUpdates(animated: true, completion: nil)
     }
 
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         guard selectedClass != nil else {
-            return data.map { $0 as! IGListDiffable }
+            return data.map { $0 as! ListDiffable }
         }
         return data.filter { type(of: $0) == selectedClass! }
-            .map { $0 as! IGListDiffable }
+            .map { $0 as! ListDiffable }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         switch object {
         case is String:   return ExpandableSectionController()
         case is GridItem: return GridSectionController()
@@ -87,5 +87,5 @@ final class MixedDataViewController: UIViewController, IGListAdapterDataSource {
         }
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class NestedAdapterViewController: UIViewController, IGListAdapterDataSource {
+final class NestedAdapterViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
@@ -45,13 +45,13 @@ final class NestedAdapterViewController: UIViewController, IGListAdapterDataSour
         collectionView.frame = view.bounds
     }
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as! [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as! [ListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         if object is Int {
             return HorizontalSectionController()
         } else {
@@ -59,7 +59,7 @@ final class NestedAdapterViewController: UIViewController, IGListAdapterDataSour
         }
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class SearchViewController: UIViewController, IGListAdapterDataSource, SearchSectionControllerDelegate {
+final class SearchViewController: UIViewController, ListAdapterDataSource, SearchSectionControllerDelegate {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     lazy var words: [String] = {
@@ -45,14 +45,14 @@ final class SearchViewController: UIViewController, IGListAdapterDataSource, Sea
         collectionView.frame = view.bounds
     }
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        guard filterString != "" else { return [searchToken] + words.map { $0 as IGListDiffable } }
-        return [searchToken] + words.filter { $0.lowercased().contains(filterString.lowercased()) }.map { $0 as IGListDiffable }
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        guard filterString != "" else { return [searchToken] + words.map { $0 as ListDiffable } }
+        return [searchToken] + words.filter { $0.lowercased().contains(filterString.lowercased()) }.map { $0 as ListDiffable }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         if let obj = object as? NSNumber, obj == searchToken {
             let sectionController = SearchSectionController()
             sectionController.delegate = self
@@ -62,7 +62,7 @@ final class SearchViewController: UIViewController, IGListAdapterDataSource, Sea
         }
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SelfSizingCellsViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SelfSizingCellsViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class SelfSizingCellsViewController: UIViewController, IGListAdapterDataSource {
+final class SelfSizingCellsViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -54,16 +54,16 @@ final class SelfSizingCellsViewController: UIViewController, IGListAdapterDataSo
         collectionView.frame = view.bounds
     }
 
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return SelfSizingSectionController()
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionStoryboardViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionStoryboardViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class SingleSectionStoryboardViewController: UIViewController, IGListAdapterDataSource, IGListSingleSectionControllerDelegate {
+final class SingleSectionStoryboardViewController: UIViewController, ListAdapterDataSource, ListSingleSectionControllerDelegate {
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     
     @IBOutlet weak var collectionView: UICollectionView!
@@ -33,33 +33,33 @@ final class SingleSectionStoryboardViewController: UIViewController, IGListAdapt
         adapter.dataSource = self
     }
 
-    //MARK: - IGListAdapterDataSource
+    //MARK: - ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         let configureBlock = { (item: Any, cell: UICollectionViewCell) in
             guard let cell = cell as? StoryboardCell, let number = item as? Int else { return }
             cell.textLabel.text = "Cell: \(number + 1)"
         }
-        let sizeBlock = { (item: Any, context: IGListCollectionContext?) -> CGSize in
+        let sizeBlock = { (item: Any, context: ListCollectionContext?) -> CGSize in
             guard let context = context else { return .zero }
             return CGSize(width: context.containerSize.width, height: 44)
         }
-        let sectionController = IGListSingleSectionController(storyboardCellIdentifier: "cell",
+        let sectionController = ListSingleSectionController(storyboardCellIdentifier: "cell",
                                                               configureBlock: configureBlock,
                                                               sizeBlock: sizeBlock)
         sectionController.selectionDelegate = self
         return sectionController
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
     
-    // MARK: - IGListSingleSectionControllerDelegate
+    // MARK: - ListSingleSectionControllerDelegate
     
-    func didSelect(_ sectionController: IGListSingleSectionController, with object: Any) {
+    func didSelect(_ sectionController: ListSingleSectionController, with object: Any) {
         let section = adapter.section(for: sectionController) + 1
         let alert = UIAlertController(title: "Section \(section) was selected \u{1F389}", message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: nil))

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class SingleSectionViewController: UIViewController, IGListAdapterDataSource, IGListSingleSectionControllerDelegate {
+final class SingleSectionViewController: UIViewController, ListAdapterDataSource, ListSingleSectionControllerDelegate {
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -40,23 +40,23 @@ final class SingleSectionViewController: UIViewController, IGListAdapterDataSour
         collectionView.frame = view.bounds
     }
     
-    //MARK: - IGListAdapterDataSource
+    //MARK: - ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         let configureBlock = { (item: Any, cell: UICollectionViewCell) in
             guard let cell = cell as? NibCell, let number = item as? Int else { return }
             cell.textLabel.text = "Cell: \(number + 1)"
         }
         
-        let sizeBlock = { (item: Any, context: IGListCollectionContext?) -> CGSize in
+        let sizeBlock = { (item: Any, context: ListCollectionContext?) -> CGSize in
             guard let context = context else { return CGSize() }
             return CGSize(width: context.containerSize.width, height: 44)
         }
-        let sectionController = IGListSingleSectionController(nibName: NibCell.nibName,
+        let sectionController = ListSingleSectionController(nibName: NibCell.nibName,
                                                               bundle: nil,
                                                               configureBlock: configureBlock,
                                                               sizeBlock: sizeBlock)
@@ -65,11 +65,11 @@ final class SingleSectionViewController: UIViewController, IGListAdapterDataSour
         return sectionController
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
     
-    // MARK: - IGListSingleSectionControllerDelegate
+    // MARK: - ListSingleSectionControllerDelegate
     
-    func didSelect(_ sectionController: IGListSingleSectionController, with object: Any) {
+    func didSelect(_ sectionController: ListSingleSectionController, with object: Any) {
         let section = adapter.section(for: sectionController) + 1
         let alert = UIAlertController(title: "Section \(section) was selected \u{1F389}",
                                       message: "Cell Object: " + String(describing: object),

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class StackedViewController: UIViewController, IGListAdapterDataSource {
+final class StackedViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 1)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 1)
     }()
 
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -38,15 +38,15 @@ final class StackedViewController: UIViewController, IGListAdapterDataSource {
         collectionView.frame = view.bounds
     }
 
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         // note that each child section controller is designed to handle an Int (or no data)
-        let sectionController = IGListStackedSectionController(sectionControllers: [
+        let sectionController = ListStackedSectionController(sectionControllers: [
             WorkingRangeSectionController(),
             DisplaySectionController(),
             HorizontalSectionController(),
@@ -55,5 +55,5 @@ final class StackedViewController: UIViewController, IGListAdapterDataSource {
         return sectionController
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StoryboardViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StoryboardViewController.swift
@@ -15,12 +15,12 @@
 import UIKit
 import IGListKit
 
-final class StoryboardViewController: UIViewController, IGListAdapterDataSource, StoryboardLabelSectionControllerDelegate {
+final class StoryboardViewController: UIViewController, ListAdapterDataSource, StoryboardLabelSectionControllerDelegate {
     
     @IBOutlet weak var collectionView: UICollectionView!
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     
     lazy var people = [
@@ -64,19 +64,19 @@ final class StoryboardViewController: UIViewController, IGListAdapterDataSource,
         adapter.dataSource = self
     }
     
-    //MARK: IGListAdapterDataSource
+    //MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return people
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         let sectionController = StoryboardLabelSectionController()
         sectionController.delegate = self
         return sectionController
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
     
     func removeSectionControllerWantsRemoved(_ sectionController: StoryboardLabelSectionController) {
         let section = adapter.section(for: sectionController)

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SupplementaryViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SupplementaryViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class SupplementaryViewController: UIViewController, IGListAdapterDataSource {
+final class SupplementaryViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
@@ -41,16 +41,16 @@ final class SupplementaryViewController: UIViewController, IGListAdapterDataSour
         collectionView.frame = view.bounds
     }
 
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return feedItems
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return FeedItemSectionController()
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/WorkingRangeViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/WorkingRangeViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class WorkingRangeViewController: UIViewController, IGListAdapterDataSource {
+final class WorkingRangeViewController: UIViewController, ListAdapterDataSource {
 
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 2)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 2)
     }()
 
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -44,17 +44,17 @@ final class WorkingRangeViewController: UIViewController, IGListAdapterDataSourc
         collectionView.frame = view.bounds
     }
 
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
 
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return WorkingRangeSectionController()
     }
 
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/Views/CalendarDayCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/CalendarDayCell.swift
@@ -50,7 +50,7 @@ final class CalendarDayCell: UICollectionViewCell {
     
 }
 
-extension CalendarDayCell: IGListBindable {
+extension CalendarDayCell: ListBindable {
     
     func bindViewModel(_ viewModel: Any) {
         guard let viewModel = viewModel as? DayViewModel else { return }

--- a/Examples/Examples-iOS/IGListKitExamples/Views/LabelCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/LabelCell.swift
@@ -74,7 +74,7 @@ final class LabelCell: UICollectionViewCell {
     
 }
 
-extension LabelCell: IGListBindable {
+extension LabelCell: ListBindable {
     
     func bindViewModel(_ viewModel: Any) {
         guard let viewModel = viewModel as? String else { return }

--- a/Examples/Examples-iOS/IGListKitExamples/Views/MonthTitleCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/MonthTitleCell.swift
@@ -34,7 +34,7 @@ final class MonthTitleCell: UICollectionViewCell {
     
 }
 
-extension MonthTitleCell: IGListBindable {
+extension MonthTitleCell: ListBindable {
     
     func bindViewModel(_ viewModel: Any) {
         guard let viewModel = viewModel as? MonthTitleViewModel else { return }

--- a/Examples/Examples-iOS/IGListKitExamples/Views/SpinnerCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/SpinnerCell.swift
@@ -15,18 +15,18 @@
 import UIKit
 import IGListKit
 
-func spinnerSectionController() -> IGListSingleSectionController {
+func spinnerSectionController() -> ListSingleSectionController {
     let configureBlock = { (item: Any, cell: UICollectionViewCell) in
         guard let cell = cell as? SpinnerCell else { return }
         cell.activityIndicator.startAnimating()
     }
     
-    let sizeBlock = { (item: Any, context: IGListCollectionContext?) -> CGSize in
+    let sizeBlock = { (item: Any, context: ListCollectionContext?) -> CGSize in
         guard let context = context else { return .zero }
         return CGSize(width: context.containerSize.width, height: 100)
     }
     
-    return IGListSingleSectionController(cellClass: SpinnerCell.self,
+    return ListSingleSectionController(cellClass: SpinnerCell.self,
                                          configureBlock: configureBlock,
                                          sizeBlock: sizeBlock)
 }

--- a/Examples/Examples-iOS/IGListKitMessageExample/MessagesViewController.swift
+++ b/Examples/Examples-iOS/IGListKitMessageExample/MessagesViewController.swift
@@ -16,10 +16,10 @@ import UIKit
 import Messages
 import IGListKit
 
-final class MessagesViewController: MSMessagesAppViewController, IGListAdapterDataSource {
+final class MessagesViewController: MSMessagesAppViewController, ListAdapterDataSource {
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
     
@@ -43,17 +43,17 @@ final class MessagesViewController: MSMessagesAppViewController, IGListAdapterDa
         collectionView.frame = view.bounds
     }
     
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return LabelSectionController()
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 }

--- a/Examples/Examples-iOS/IGListKitTodayExample/TodayViewController.swift
+++ b/Examples/Examples-iOS/IGListKitTodayExample/TodayViewController.swift
@@ -17,10 +17,10 @@ import NotificationCenter
 import IGListKit
 
 @available(iOSApplicationExtension 10.0, *)
-final class TodayViewController: UIViewController, NCWidgetProviding, IGListAdapterDataSource {
+final class TodayViewController: UIViewController, NCWidgetProviding, ListAdapterDataSource {
         
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
     
@@ -54,17 +54,17 @@ final class TodayViewController: UIViewController, NCWidgetProviding, IGListAdap
         preferredContentSize = maxSize
     }
     
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as [ListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return LabelSectionController()
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
     }
 }

--- a/Examples/Examples-macOS/IGListKitExamples/Models/User.swift
+++ b/Examples/Examples-macOS/IGListKitExamples/Models/User.swift
@@ -15,7 +15,7 @@
 import Foundation
 import IGListKit
 
-final class User: IGListDiffable {
+final class User: ListDiffable {
     
     let pk: Int
     let name: String
@@ -25,13 +25,13 @@ final class User: IGListDiffable {
         self.name = name
     }
     
-    //MARK: IGListDiffable
+    //MARK: ListDiffable
     
     func diffIdentifier() -> NSObjectProtocol {
         return pk as NSObjectProtocol
     }
     
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         guard self !== object else { return true }
         guard let object = object as? User else { return false }
         return name == object.name

--- a/Examples/Examples-macOS/IGListKitExamples/ViewControllers/UsersViewController.swift
+++ b/Examples/Examples-macOS/IGListKitExamples/ViewControllers/UsersViewController.swift
@@ -54,7 +54,7 @@ final class UsersViewController: NSViewController {
     var filteredUsers = [User]() {
         didSet {
             // get the difference between the old array of Users and the new array of Users
-            let diff = IGListDiff(oldValue, filteredUsers, .equality)
+            let diff = ListDiff(oldArray: oldValue, newArray: filteredUsers, option: .equality)
             
             // this difference is used here to update the table view, but it can be used
             // to update collection views and other similar interface elements

--- a/Examples/Examples-tvOS/IGListKitExamples/Models/NSObject+IGListDiffable.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/Models/NSObject+IGListDiffable.swift
@@ -15,13 +15,13 @@
 import Foundation
 import IGListKit
 
-extension NSObject: IGListDiffable {
+extension NSObject: ListDiffable {
 
     public func diffIdentifier() -> NSObjectProtocol {
         return self
     }
 
-    public func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    public func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         return isEqual(object);
     }
 

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/CarouselSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/CarouselSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class CarouselSectionController: IGListSectionController, IGListSectionType {
+final class CarouselSectionController: ListSectionController, ListSectionType {
 
     var number: Int?
     

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -31,7 +31,7 @@ final class DemoItem: NSObject {
     
 }
 
-final class DemoSectionController: IGListSectionController, IGListSectionType {
+final class DemoSectionController: ListSectionController, ListSectionType {
 
     var object: DemoItem?
     

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
@@ -15,12 +15,12 @@
 import UIKit
 import IGListKit
 
-final class HorizontalSectionController: IGListSectionController, IGListSectionType, IGListAdapterDataSource {
+final class HorizontalSectionController: ListSectionController, ListSectionType, ListAdapterDataSource {
     
     var number: Int?
     
-    lazy var adapter: IGListAdapter = {
-        let adapter = IGListAdapter(updater: IGListAdapterUpdater(),
+    lazy var adapter: ListAdapter = {
+        let adapter = ListAdapter(updater: ListAdapterUpdater(),
                                     viewController: self.viewController,
                                     workingRangeSize: 0)
         adapter.dataSource = self
@@ -52,17 +52,17 @@ final class HorizontalSectionController: IGListSectionController, IGListSectionT
     
     func didSelectItem(at index: Int) {}
     
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         guard let number = number else { return [] }
-        return (0..<number).map { $0 as IGListDiffable }
+        return (0..<number).map { $0 as ListDiffable }
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return CarouselSectionController()
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
     
 }

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class LabelSectionController: IGListSectionController, IGListSectionType {
+final class LabelSectionController: ListSectionController, ListSectionType {
     
     var object: String?
     

--- a/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class DemosViewController: UIViewController, IGListAdapterDataSource {
+final class DemosViewController: UIViewController, ListAdapterDataSource {
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
@@ -40,17 +40,17 @@ final class DemosViewController: UIViewController, IGListAdapterDataSource {
         collectionView.frame = view.bounds
     }
     
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         return demos
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         return DemoSectionController()
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
 }
 

--- a/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
@@ -15,10 +15,10 @@
 import UIKit
 import IGListKit
 
-final class NestedAdapterViewController: UIViewController, IGListAdapterDataSource {
+final class NestedAdapterViewController: UIViewController, ListAdapterDataSource {
     
-    lazy var adapter: IGListAdapter = {
-        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 0)
+    lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self, workingRangeSize: 0)
     }()
 
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
@@ -46,13 +46,13 @@ final class NestedAdapterViewController: UIViewController, IGListAdapterDataSour
         collectionView.frame = view.bounds
     }
     
-    // MARK: IGListAdapterDataSource
+    // MARK: ListAdapterDataSource
     
-    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
-        return data as! [IGListDiffable]
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        return data as! [ListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
         if object is Int {
             return HorizontalSectionController()
         }
@@ -60,6 +60,6 @@ final class NestedAdapterViewController: UIViewController, IGListAdapterDataSour
         return LabelSectionController()
     }
     
-    func emptyView(for listAdapter: IGListAdapter) -> UIView? { return nil }
+    func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
     
 }

--- a/Source/Common/IGListBatchUpdateData.h
+++ b/Source/Common/IGListBatchUpdateData.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  update via `-[UICollectionView performBatchUpdates:completion:]`.
  */
 IGLK_SUBCLASSING_RESTRICTED
+NS_SWIFT_NAME(ListBatchUpdateData)
 @interface IGListBatchUpdateData : NSObject
 
 /**

--- a/Source/Common/IGListDiff.h
+++ b/Source/Common/IGListDiff.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  An option for how to do comparisons between similar objects.
  */
+NS_SWIFT_NAME(ListDiffOption)
 typedef NS_ENUM(NSInteger, IGListDiffOption) {
     /**
      Compare objects using pointer personality.
@@ -38,7 +39,8 @@ typedef NS_ENUM(NSInteger, IGListDiffOption) {
 
  @return A result object containing affected indexes.
  */
-FOUNDATION_EXTERN IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable>> *_Nullable oldArray,
+NS_SWIFT_NAME(ListDiff(oldArray:newArray:option:))
+FOUNDATION_EXTERN  IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable>> *_Nullable oldArray,
                                                    NSArray<id<IGListDiffable>> *_Nullable newArray,
                                                    IGListDiffOption option);
 
@@ -53,6 +55,7 @@ FOUNDATION_EXTERN IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable>> *
 
  @return A result object containing affected indexes.
  */
+NS_SWIFT_NAME(ListDiffPaths(fromSection:toSection:oldArray:newArray:option:))
 FOUNDATION_EXTERN IGListIndexPathResult *IGListDiffPaths(NSInteger fromSection,
                                                          NSInteger toSection,
                                                          NSArray<id<IGListDiffable>> *_Nullable oldArray,

--- a/Source/Common/IGListDiffable.h
+++ b/Source/Common/IGListDiffable.h
@@ -12,6 +12,7 @@
 /**
  The `IGListDiffable` protocol provides methods needed to compare the identity and equality of two objects.
  */
+NS_SWIFT_NAME(ListDiffable)
 @protocol IGListDiffable
 
 /**

--- a/Source/Common/IGListExperiments.h
+++ b/Source/Common/IGListExperiments.h
@@ -14,6 +14,7 @@
 /**
  Bitmask-able options used for pre-release feature testing.
  */
+NS_SWIFT_NAME(ListExperiment)
 typedef NS_OPTIONS (NSInteger, IGListExperiment) {
     /// Specifies no experiements.
     IGListExperimentNone = 1 << 1,
@@ -27,6 +28,7 @@ typedef NS_OPTIONS (NSInteger, IGListExperiment) {
 
  @return `YES` if the option is in the bitmask, otherwise `NO`.
  */
+NS_SWIFT_NAME(ListExperimentEnabled(mask:option:))
 static inline BOOL IGListExperimentEnabled(IGListExperiment mask, IGListExperiment option) {
     return (mask & option) != 0;
 }
@@ -45,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @see `IGListDiff()`.
  */
+NS_SWIFT_NAME(ListDiffExperiment(oldArray:newArray:option:experiments:))
 FOUNDATION_EXTERN IGListIndexSetResult *IGListDiffExperiment(NSArray<id<IGListDiffable>> *_Nullable oldArray,
                                                              NSArray<id<IGListDiffable>> *_Nullable newArray,
                                                              IGListDiffOption option,
@@ -64,6 +67,7 @@ FOUNDATION_EXTERN IGListIndexSetResult *IGListDiffExperiment(NSArray<id<IGListDi
 
  @see `IGListDiffPaths()`.
  */
+NS_SWIFT_NAME(ListDiffPathsExperiment(fromSection:toSection:oldArray:newArray:option:experiments:))
 FOUNDATION_EXTERN IGListIndexPathResult *IGListDiffPathsExperiment(NSInteger fromSection,
                                                                    NSInteger toSection,
                                                                    NSArray<id<IGListDiffable>> *_Nullable oldArray,

--- a/Source/Common/IGListIndexPathResult.h
+++ b/Source/Common/IGListIndexPathResult.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A result object returned when diffing with sections.
  */
+NS_SWIFT_NAME(ListIndexPathResult)
 @interface IGListIndexPathResult : NSObject
 
 /**

--- a/Source/Common/IGListIndexSetResult.h
+++ b/Source/Common/IGListIndexSetResult.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A result object returned when diffing with indexes.
  */
+NS_SWIFT_NAME(ListIndexSetResult)
 @interface IGListIndexSetResult : NSObject
 
 /**

--- a/Source/Common/IGListMoveIndex.h
+++ b/Source/Common/IGListMoveIndex.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  An object representing a move between indexes.
  */
+NS_SWIFT_NAME(ListMoveIndex)
 @interface IGListMoveIndex : NSObject
 
 /**

--- a/Source/Common/IGListMoveIndexPath.h
+++ b/Source/Common/IGListMoveIndexPath.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  An object representing a move between indexes.
  */
+NS_SWIFT_NAME(ListMoveIndexPath)
 @interface IGListMoveIndexPath : NSObject
 
 /**

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param finished Specifies whether or not the update animations completed successfully.
  */
+NS_SWIFT_NAME(ListUpdaterCompletion)
 typedef void (^IGListUpdaterCompletion)(BOOL finished);
 
 /**
@@ -39,6 +40,7 @@ typedef void (^IGListUpdaterCompletion)(BOOL finished);
  controllers in a collection view.
  */
 IGLK_SUBCLASSING_RESTRICTED
+NS_SWIFT_NAME(ListAdapter)
 @interface IGListAdapter : NSObject
 
 /**

--- a/Source/IGListAdapterDataSource.h
+++ b/Source/IGListAdapterDataSource.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Implement this protocol to provide data to an `IGListAdapter`.
  */
+NS_SWIFT_NAME(ListAdapterDataSource)
 @protocol IGListAdapterDataSource <NSObject>
 
 /**

--- a/Source/IGListAdapterUpdater.h
+++ b/Source/IGListAdapterUpdater.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  `-performUpdateWithCollectionView:fromObjects:toObjects:completion:`.
  */
 IGLK_SUBCLASSING_RESTRICTED
+NS_SWIFT_NAME(ListAdapterUpdater)
 @interface IGListAdapterUpdater : NSObject <IGListUpdatingDelegate>
 
 /**

--- a/Source/IGListAdapterUpdaterDelegate.h
+++ b/Source/IGListAdapterUpdaterDelegate.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A protocol that receives events about `IGListAdapterUpdater` operations.
  */
+NS_SWIFT_NAME(ListAdapterUpdaterDelegate)
 @protocol IGListAdapterUpdaterDelegate <NSObject>
 
 /**

--- a/Source/IGListBatchContext.h
+++ b/Source/IGListBatchContext.h
@@ -17,6 +17,7 @@
  Objects conforming to the IGListBatchContext protocol provide a way for section controllers to mutate their cells or
  reload everything within the section.
  */
+NS_SWIFT_NAME(ListBatchContext)
 @protocol IGListBatchContext <NSObject>
 
 /**

--- a/Source/IGListBindable.h
+++ b/Source/IGListBindable.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A protocol for cells that configure themselves given a view model.
  */
+NS_SWIFT_NAME(ListBindable)
 @protocol IGListBindable <NSObject>
 
 /**

--- a/Source/IGListBindingSectionController.h
+++ b/Source/IGListBindingSectionController.h
@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  Only when `-diffIdentifier`s match is object equality compared, so you can assume the class is the same, and the
  instance has already been checked.
  */
+NS_SWIFT_NAME(ListBindingSectionController)
 @interface IGListBindingSectionController<__covariant ObjectType : id<IGListDiffable>> : IGListSectionController<IGListSectionType>
 
 /**

--- a/Source/IGListBindingSectionControllerDataSource.h
+++ b/Source/IGListBindingSectionControllerDataSource.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A protocol that returns data to power cells in an `IGListBindingSectionController`.
  */
+NS_SWIFT_NAME(ListBindingSectionControllerDataSource)
 @protocol IGListBindingSectionControllerDataSource <NSObject>
 
 /**

--- a/Source/IGListBindingSectionControllerSelectionDelegate.h
+++ b/Source/IGListBindingSectionControllerSelectionDelegate.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A protocol that handles cell selection events in an `IGListBindingSectionController`.
  */
+NS_SWIFT_NAME(ListBindingSectionControllerSelectionDelegate)
 @protocol IGListBindingSectionControllerSelectionDelegate <NSObject>
 
 /**

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  The collection context provides limited access to the collection-related information that
  section controllers need for operations like sizing, dequeing cells, insterting, deleting, reloading, etc.
  */
+NS_SWIFT_NAME(ListCollectionContext)
 @protocol IGListCollectionContext <NSObject>
 
 /**

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  Please see the unit tests for more configuration examples and expected output.
  */
-
+NS_SWIFT_NAME(ListCollectionViewLayout)
 @interface IGListCollectionViewLayout : UICollectionViewLayout
 
 /**

--- a/Source/IGListDisplayDelegate.h
+++ b/Source/IGListDisplayDelegate.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Implement this protocol to receive display events for a section controller when it is on screen.
  */
+NS_SWIFT_NAME(ListDisplayDelegate)
 @protocol IGListDisplayDelegate <NSObject>
 
 /**

--- a/Source/IGListReloadDataUpdater.h
+++ b/Source/IGListReloadDataUpdater.h
@@ -19,6 +19,7 @@
  @note This updater performs simple, synchronous updates using `-[UICollectionView reloadData]`.
  */
 IGLK_SUBCLASSING_RESTRICTED
+NS_SWIFT_NAME(ListReloadDataUpdater)
 @interface IGListReloadDataUpdater : NSObject <IGListUpdatingDelegate>
 
 @end

--- a/Source/IGListScrollDelegate.h
+++ b/Source/IGListScrollDelegate.h
@@ -17,6 +17,7 @@
 /**
  Implement this protocol to receive display events for a section controller when it is on screen.
  */
+NS_SWIFT_NAME(ListScrollDelegate)
 @protocol IGListScrollDelegate <NSObject>
 
 /**

--- a/Source/IGListSectionController.h
+++ b/Source/IGListSectionController.h
@@ -18,6 +18,7 @@
 /**
  The base class for section controllers used in a list. This class is intended to be subclassed.
  */
+NS_SWIFT_NAME(ListSectionController)
 @interface IGListSectionController : NSObject
 
 /**

--- a/Source/IGListSectionType.h
+++ b/Source/IGListSectionType.h
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  section to mutate its own position within a list. The row of an index path can be directly mapped to a cell within
  an `IGListSectionType` conforming object.
  */
+NS_SWIFT_NAME(ListSectionType)
 @protocol IGListSectionType <NSObject>
 
 /**

--- a/Source/IGListSingleSectionController.h
+++ b/Source/IGListSingleSectionController.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param item The model with which to configure the cell.
  @param cell The cell to configure.
  */
+NS_SWIFT_NAME(ListSingleSectionCellConfigureBlock)
 typedef void (^IGListSingleSectionCellConfigureBlock)(id item, __kindof UICollectionViewCell *cell);
 
 /**
@@ -32,6 +33,7 @@ typedef void (^IGListSingleSectionCellConfigureBlock)(id item, __kindof UICollec
 
  @return The size for the cell.
  */
+NS_SWIFT_NAME(ListSingleSectionCellSizeBlock)
 typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionContext> _Nullable collectionContext);
 
 @class IGListSingleSectionController;
@@ -39,6 +41,7 @@ typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionC
 /**
  A delegate that can receive selection events on an `IGListSingleSectionController`.
  */
+NS_SWIFT_NAME(ListSingleSectionControllerDelegate)
 @protocol IGListSingleSectionControllerDelegate <NSObject>
 
 /**
@@ -58,6 +61,7 @@ typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionC
  simpler architecture.
  */
 IGLK_SUBCLASSING_RESTRICTED
+NS_SWIFT_NAME(ListSingleSectionController)
 @interface IGListSingleSectionController : IGListSectionController <IGListSectionType>
 
 /**

--- a/Source/IGListStackedSectionController.h
+++ b/Source/IGListStackedSectionController.h
@@ -22,6 +22,7 @@
  huge class.
  */
 IGLK_SUBCLASSING_RESTRICTED
+NS_SWIFT_NAME(ListStackedSectionController)
 @interface IGListStackedSectionController : IGListSectionController <IGListSectionType>
 
 /**

--- a/Source/IGListSupplementaryViewSource.h
+++ b/Source/IGListSupplementaryViewSource.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  `IGListAdapter` which then configures and maintains a `UICollectionView`. The supplementary API reflects that in
  `UICollectionView`, `UICollectionViewLayout`, and `UICollectionViewDataSource`.
  */
+NS_SWIFT_NAME(ListSupplementaryViewSource)
 @protocol IGListSupplementaryViewSource <NSObject>
 
 /**

--- a/Source/IGListUpdatingDelegate.h
+++ b/Source/IGListUpdatingDelegate.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param finished Specifies whether or not the update finished.
  */
+NS_SWIFT_NAME(ListUpdatingCompletion)
 typedef void (^IGListUpdatingCompletion)(BOOL finished);
 
 /**
@@ -25,18 +26,22 @@ typedef void (^IGListUpdatingCompletion)(BOOL finished);
 
  @param toObjects The new objects in the collection.
  */
+NS_SWIFT_NAME(ListObjectTransitionBlock)
 typedef void (^IGListObjectTransitionBlock)(NSArray *toObjects);
 
 /// A block that contains all of the updates.
+NS_SWIFT_NAME(ListItemUpdateBlock)
 typedef void (^IGListItemUpdateBlock)();
 
 /// A block to be called when an adapter reloads the collection view.
+NS_SWIFT_NAME(ListReloadUpdateBlock)
 typedef void (^IGListReloadUpdateBlock)();
 
 /**
  Implement this protocol in order to handle both section and row based update events. Implementation should forward or
  coalesce these events to a backing store or collection.
  */
+NS_SWIFT_NAME(ListUpdatingDelegate)
 @protocol IGListUpdatingDelegate <NSObject>
 
 /**

--- a/Source/IGListWorkingRangeDelegate.h
+++ b/Source/IGListWorkingRangeDelegate.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  The working range is a range *near* the viewport in which you can begin preparing content for display. For example,
  you could begin decoding images, or warming text caches.
  */
+NS_SWIFT_NAME(ListWorkingRangeDelegate)
 @protocol IGListWorkingRangeDelegate <NSObject>
 
 /**

--- a/Tests/IGListDiffSwiftTests.swift
+++ b/Tests/IGListDiffSwiftTests.swift
@@ -10,7 +10,7 @@
 import XCTest
 import IGListKit
 
-class SwiftClass: IGListDiffable {
+class SwiftClass: ListDiffable {
 
     let id: Int
     let value: String
@@ -24,7 +24,7 @@ class SwiftClass: IGListDiffable {
         return NSNumber(value: id)
     }
 
-    func isEqual(toDiffableObject object: IGListDiffable?) -> Bool {
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
         guard let object = object as? SwiftClass else { return false }
         return id == object.id && value == object.value
     }
@@ -36,7 +36,7 @@ class IGDiffingSwiftTests: XCTestCase {
     func testDiffingStrings() {
         let o: [NSString] = ["a", "b", "c"]
         let n: [NSString] = ["a", "c", "d"]
-        let result = IGListDiff(o, n, .equality)
+        let result = ListDiff(oldArray: o, newArray: n, option: .equality)
         XCTAssertEqual(result.deletes, IndexSet(integer: 1))
         XCTAssertEqual(result.inserts, IndexSet(integer: 2))
         XCTAssertEqual(result.moves.count, 0)
@@ -46,7 +46,7 @@ class IGDiffingSwiftTests: XCTestCase {
     func testDiffingNumbers() {
         let o: [NSNumber] = [0, 1, 2]
         let n: [NSNumber] = [0, 2, 4]
-        let result = IGListDiff(o, n, .equality)
+        let result = ListDiff(oldArray: o, newArray: n, option: .equality)
         XCTAssertEqual(result.deletes, IndexSet(integer: 1))
         XCTAssertEqual(result.inserts, IndexSet(integer: 2))
         XCTAssertEqual(result.moves.count, 0)
@@ -56,7 +56,7 @@ class IGDiffingSwiftTests: XCTestCase {
     func testDiffingSwiftClass() {
         let o = [SwiftClass(id: 0, value: "a"), SwiftClass(id: 1, value: "b"), SwiftClass(id: 2, value: "c")]
         let n = [SwiftClass(id: 0, value: "a"), SwiftClass(id: 2, value: "c"), SwiftClass(id: 4, value: "d")]
-        let result = IGListDiff(o, n, .equality)
+        let result = ListDiff(oldArray: o, newArray: n, option: .equality)
         XCTAssertEqual(result.deletes, IndexSet(integer: 1))
         XCTAssertEqual(result.inserts, IndexSet(integer: 2))
         XCTAssertEqual(result.moves.count, 0)
@@ -66,7 +66,7 @@ class IGDiffingSwiftTests: XCTestCase {
     func testDiffingSwiftClassPointerComparison() {
         let o = [SwiftClass(id: 0, value: "a"), SwiftClass(id: 1, value: "b"), SwiftClass(id: 2, value: "c")]
         let n = [SwiftClass(id: 0, value: "a"), SwiftClass(id: 2, value: "c"), SwiftClass(id: 4, value: "d")]
-        let result = IGListDiff(o, n, .pointerPersonality)
+        let result = ListDiff(oldArray: o, newArray: n, option: .pointerPersonality)
         XCTAssertEqual(result.deletes, IndexSet(integer: 1))
         XCTAssertEqual(result.inserts, IndexSet(integer: 2))
         XCTAssertEqual(result.moves.count, 0)
@@ -76,7 +76,7 @@ class IGDiffingSwiftTests: XCTestCase {
     func testDiffingSwiftClassWithUpdates() {
         let o = [SwiftClass(id: 0, value: "a"), SwiftClass(id: 1, value: "b"), SwiftClass(id: 2, value: "c")]
         let n = [SwiftClass(id: 0, value: "b"), SwiftClass(id: 1, value: "b"), SwiftClass(id: 2, value: "b")]
-        let result = IGListDiff(o, n, .equality)
+        let result = ListDiff(oldArray: o, newArray: n, option: .equality)
         XCTAssertEqual(result.deletes.count, 0)
         XCTAssertEqual(result.inserts.count, 0)
         XCTAssertEqual(result.moves.count, 0)


### PR DESCRIPTION
## Changes in this pull request

This adds `NS_SWIFT_NAME` annotations to all public API's to provide cleaner integration into Swift:

- Removes the need to prefix classes in Swift code, instead rely on Swift module name spacing
- Adds more argument labels to C function API's like `IGListDiff([], [], .equality)` => `ListDiff(oldArray: [], newArray: [], option: .equality)`

While this is a large API change it should be as easy as:

- Find and replace `(IGList)([^K])` to `List$2` in Xcode with a scope set to Swift
- Build and follow compiler's auto fix corrections for C API's or any missed renames

I have not updated the documentation to reflect this yet, I am totally willing to do so but before I sink that amount of time into it I wanted to see if the Instagram team is even open to this change!

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
- [ ] I have updated the documentation