### PR TITLE
Demo for dependency injection and announcing changes

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		29D2E4AD1DD69B6000CD255D /* DisplaySectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D2E4AC1DD69B6000CD255D /* DisplaySectionController.swift */; };
 		29D2E4AF1DD69C0E00CD255D /* DisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D2E4AE1DD69C0E00CD255D /* DisplayViewController.swift */; };
 		29D873561E0C539700A6BA95 /* StackedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D873551E0C539700A6BA95 /* StackedViewController.swift */; };
+		29F7E2AA1E9283FF00197586 /* AnnouncingDepsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F7E2A91E9283FF00197586 /* AnnouncingDepsViewController.swift */; };
+		29F7E2AD1E92843A00197586 /* IncrementAnnouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F7E2AC1E92843A00197586 /* IncrementAnnouncer.swift */; };
+		29F7E2AF1E92858500197586 /* ListeningSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29F7E2AE1E92858500197586 /* ListeningSectionController.swift */; };
 		56C05B691E49B2120026DB39 /* ObjcDemoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 56C05B681E49B2120026DB39 /* ObjcDemoViewController.m */; };
 		56C05B6C1E49B2E80026DB39 /* UserInfoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 56C05B6B1E49B2E80026DB39 /* UserInfoCell.m */; };
 		56C05B721E49B32A0026DB39 /* CommentCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 56C05B711E49B32A0026DB39 /* CommentCell.m */; };
@@ -196,6 +199,9 @@
 		29D2E4AC1DD69B6000CD255D /* DisplaySectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplaySectionController.swift; sourceTree = "<group>"; };
 		29D2E4AE1DD69C0E00CD255D /* DisplayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayViewController.swift; sourceTree = "<group>"; };
 		29D873551E0C539700A6BA95 /* StackedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StackedViewController.swift; sourceTree = "<group>"; };
+		29F7E2A91E9283FF00197586 /* AnnouncingDepsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnouncingDepsViewController.swift; sourceTree = "<group>"; };
+		29F7E2AC1E92843A00197586 /* IncrementAnnouncer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncrementAnnouncer.swift; sourceTree = "<group>"; };
+		29F7E2AE1E92858500197586 /* ListeningSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListeningSectionController.swift; sourceTree = "<group>"; };
 		4125DCD99578FDEF3C373BA0 /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitExamples.release.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitExamples/Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
 		45D6CC137030027019AE64D8 /* Pods-IGListKitTodayExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitTodayExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitTodayExample/Pods-IGListKitTodayExample.debug.xcconfig"; sourceTree = "<group>"; };
 		52A8DC2D07A93D7AA55BC993 /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IGListKitExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -325,6 +331,7 @@
 				56C05B851E49B4C40026DB39 /* InteractiveSectionController.h */,
 				56C05B861E49B4C40026DB39 /* InteractiveSectionController.m */,
 				2942FF881D9F39E00015D24B /* LabelSectionController.swift */,
+				29F7E2AE1E92858500197586 /* ListeningSectionController.swift */,
 				292658631E74A2550041B56D /* MonthSectionController.swift */,
 				2942FF891D9F39E00015D24B /* RemoveSectionController.swift */,
 				2942FF8A1D9F39E00015D24B /* SearchSectionController.swift */,
@@ -372,6 +379,7 @@
 				2991F91C1D7BB30300B0C58F /* Models */,
 				2942FF821D9F39E00015D24B /* SectionControllers */,
 				822B29F21DB8AA4700010000 /* Storyboard */,
+				29F7E2AB1E92842D00197586 /* Systems */,
 				2961B3A31D68B0B5001C9451 /* ViewControllers */,
 				2961B3A61D68B0B5001C9451 /* Views */,
 			);
@@ -381,6 +389,7 @@
 		2961B3A31D68B0B5001C9451 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				29F7E2A91E9283FF00197586 /* AnnouncingDepsViewController.swift */,
 				292658561E749EDC0041B56D /* CalendarViewController.swift */,
 				2961B3A41D68B0B5001C9451 /* DemosViewController.swift */,
 				29459BFF1DBE48E200F05375 /* DiffTableViewController.swift */,
@@ -450,6 +459,14 @@
 				2926585C1E74A0360041B56D /* ViewModels */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		29F7E2AB1E92842D00197586 /* Systems */ = {
+			isa = PBXGroup;
+			children = (
+				29F7E2AC1E92843A00197586 /* IncrementAnnouncer.swift */,
+			);
+			path = Systems;
 			sourceTree = "<group>";
 		};
 		586CEEF7A60B53C23ED20E47 /* Pods */ = {
@@ -825,6 +842,7 @@
 				82D91B691DBA0EF300E62758 /* SingleSectionStoryboardViewController.swift in Sources */,
 				29D2E4AF1DD69C0E00CD255D /* DisplayViewController.swift in Sources */,
 				2942FF911D9F39E00015D24B /* LabelSectionController.swift in Sources */,
+				29F7E2AD1E92843A00197586 /* IncrementAnnouncer.swift in Sources */,
 				2981BA391DB874BB00A987F9 /* WorkingRangeViewController.swift in Sources */,
 				56C05B841E49B4B40026DB39 /* CommentSectionController.m in Sources */,
 				29C629831DCFDB57004A5BB1 /* UserHeaderView.swift in Sources */,
@@ -835,6 +853,7 @@
 				56C05B811E49B4AB0026DB39 /* ImageSectionController.m in Sources */,
 				56C05B751E49B33C0026DB39 /* InteractiveCell.m in Sources */,
 				2991F9301D7BC0E400B0C58F /* EmptyViewController.swift in Sources */,
+				29F7E2AF1E92858500197586 /* ListeningSectionController.swift in Sources */,
 				29D2E4AD1DD69B6000CD255D /* DisplaySectionController.swift in Sources */,
 				2991F91E1D7BB30C00B0C58F /* User.swift in Sources */,
 				2991F9241D7BB89F00B0C58F /* NestedAdapterViewController.swift in Sources */,
@@ -867,6 +886,7 @@
 				292658571E749EDC0041B56D /* CalendarViewController.swift in Sources */,
 				29C6297F1DCFD9E9004A5BB1 /* FeedItemSectionController.swift in Sources */,
 				2942FF8E1D9F39E00015D24B /* ExpandableSectionController.swift in Sources */,
+				29F7E2AA1E9283FF00197586 /* AnnouncingDepsViewController.swift in Sources */,
 				56C05B721E49B32A0026DB39 /* CommentCell.m in Sources */,
 				821BC4BA1DB8B61200172ED0 /* StoryboardLabelSectionController.swift in Sources */,
 				56C05B7B1E49B4030026DB39 /* UserInfo.m in Sources */,

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
@@ -1,0 +1,58 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+ The examples provided by Facebook are for non-commercial testing and evaluation
+ purposes only. Facebook reserves all rights not expressly granted.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import IGListKit
+
+class ListeningSectionController: IGListSectionController, IGListSectionType, IncrementListener {
+
+    var value: Int = 0
+
+    init(announcer: IncrementAnnouncer) {
+        super.init()
+        announcer.addListener(listener: self)
+    }
+
+    func configureCell(cell: LabelCell) {
+        let section = collectionContext!.section(for: self)
+        cell.label.text = "Section: \(section), value: \(value)"
+    }
+
+    // MARK: IGListSectionType
+
+    func numberOfItems() -> Int {
+        return 1
+    }
+
+    func sizeForItem(at index: Int) -> CGSize {
+        return CGSize(width: collectionContext!.containerSize.width, height: 55)
+    }
+
+    func cellForItem(at index: Int) -> UICollectionViewCell {
+        let cell = collectionContext!.dequeueReusableCell(of: LabelCell.self, for: self, at: index) as! LabelCell
+        configureCell(cell: cell)
+        return cell
+    }
+
+    func didUpdate(to object: Any) {}
+    func didSelectItem(at index: Int) {}
+
+    // MARK: IncrementListener
+
+    func didIncrement(announcer: IncrementAnnouncer, value: Int) {
+        self.value = value
+        guard let cell = collectionContext?.cellForItem(at: 0, sectionController: self) as? LabelCell else { return }
+        configureCell(cell: cell)
+    }
+
+}

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-class ListeningSectionController: IGListSectionController, IGListSectionType, IncrementListener {
+final class ListeningSectionController: IGListSectionController, IGListSectionType, IncrementListener {
 
     var value: Int = 0
 

--- a/Examples/Examples-iOS/IGListKitExamples/Systems/IncrementAnnouncer.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Systems/IncrementAnnouncer.swift
@@ -1,0 +1,38 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+ The examples provided by Facebook are for non-commercial testing and evaluation
+ purposes only. Facebook reserves all rights not expressly granted.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+
+@objc
+protocol IncrementListener: class {
+    func didIncrement(announcer: IncrementAnnouncer, value: Int)
+}
+
+final class IncrementAnnouncer: NSObject {
+
+    private var value: Int = 0
+    private let map: NSHashTable<IncrementListener> = NSHashTable<IncrementListener>.weakObjects()
+
+    func addListener(listener: IncrementListener) {
+        map.add(listener)
+    }
+
+    func increment() {
+        value += 1
+        for listener in map.allObjects {
+            listener.didIncrement(announcer: self, value: value)
+        }
+    }
+
+}

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/AnnouncingDepsViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/AnnouncingDepsViewController.swift
@@ -1,0 +1,67 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+ The examples provided by Facebook are for non-commercial testing and evaluation
+ purposes only. Facebook reserves all rights not expressly granted.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+import IGListKit
+
+final class AnnouncingDepsViewController: UIViewController, IGListAdapterDataSource {
+
+    lazy var adapter: IGListAdapter = {
+        return IGListAdapter(updater: IGListAdapterUpdater(), viewController: self, workingRangeSize: 1)
+    }()
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+    let data: [NSNumber] = Array(0..<20).map { $0 as NSNumber }
+    let announcer = IncrementAnnouncer()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        collectionView.backgroundColor = UIColor(white: 0.95, alpha: 1)
+        view.addSubview(collectionView)
+        adapter.collectionView = collectionView
+        adapter.dataSource = self
+
+        // disable prefetching so cells are configured as they come on screen
+        if #available(iOS 10.0, *) {
+            collectionView.isPrefetchingEnabled = false
+        }
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
+                                                            target: self,
+                                                            action: #selector(AnnouncingDepsViewController.onAdd))
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        collectionView.frame = view.bounds
+    }
+
+    func onAdd() {
+        announcer.increment()
+    }
+
+    // MARK: IGListAdapterDataSource
+
+    func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
+        return data
+    }
+
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+        return ListeningSectionController(announcer: announcer)
+    }
+
+    func emptyView(for listAdapter: IGListAdapter) -> UIView? {
+        return nil
+    }
+
+}

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -38,7 +38,8 @@ final class DemosViewController: UIViewController, IGListAdapterDataSource {
         DemoItem(name: "Display delegate", controllerClass: DisplayViewController.self),
         DemoItem(name: "Stacked Section Controllers", controllerClass: StackedViewController.self),
         DemoItem(name: "Objc Demo", controllerClass: ObjcDemoViewController.self),
-        DemoItem(name: "Calendar (auto diffing)", controllerClass: CalendarViewController.self)
+        DemoItem(name: "Calendar (auto diffing)", controllerClass: CalendarViewController.self),
+        DemoItem(name: "Dependency Injection", controllerClass: AnnouncingDepsViewController.self)
     ]
 
     override func viewDidLoad() {

--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -156,7 +156,7 @@
 		0B3B93601E08D845008390ED /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0B3B92841E08D7F5008390ED /* IGListDiff.mm */; };
 		0B3B93611E08E38C008390ED /* IGListBatchUpdateDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144EE51D870EDC007C7F66 /* IGListBatchUpdateDataTests.m */; };
 		0B40C5F31E01CB8200378109 /* IGReloadDataUpdaterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2997D4961DF5FC0B005A5DD2 /* IGReloadDataUpdaterTests.m */; };
-		1F2984CA1E8039EC005FA211 /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 917E89871E800EE70015F934 /* IGListCollectionViewLayoutInternal.h */; };
+		1F2984CA1E8039EC005FA211 /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 917E89871E800EE70015F934 /* IGListCollectionViewLayoutInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		26271C8A1DAE94E40073E116 /* IGTestSingleNibItemDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C891DAE94E40073E116 /* IGTestSingleNibItemDataSource.m */; };
 		26271C8C1DAE96740073E116 /* IGListSingleNibItemControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 26271C8B1DAE96740073E116 /* IGListSingleNibItemControllerTests.m */; };
 		2914BEE91DCD15F400C96401 /* IGTestNibSupplementaryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2904861C1DCD02140007F41D /* IGTestNibSupplementaryView.xib */; };
@@ -166,7 +166,7 @@
 		2926586D1E75E01A0041B56D /* IGListBindingSectionControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 2926586B1E75E01A0041B56D /* IGListBindingSectionControllerDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2926586F1E75E0830041B56D /* IGListBindingSectionControllerSelectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2926586E1E75E0830041B56D /* IGListBindingSectionControllerSelectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		292658701E75E0830041B56D /* IGListBindingSectionControllerSelectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2926586E1E75E0830041B56D /* IGListBindingSectionControllerSelectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		292658711E75E2440041B56D /* IGListBatchUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = 297278C31E6B59D50099D8EA /* IGListBatchUpdateState.h */; };
+		292658711E75E2440041B56D /* IGListBatchUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = 297278C31E6B59D50099D8EA /* IGListBatchUpdateState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		292807391E82CE240077A81C /* IGListBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 292807381E82CE240077A81C /* IGListBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2928073A1E82CE2E0077A81C /* IGListBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 292807381E82CE240077A81C /* IGListBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		294AC6321DDE4C19002FCE5D /* IGListDiffResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */; };
@@ -293,7 +293,7 @@
 		88DF89881E010F5C00B1B9B4 /* IGListDiffResultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 294AC6311DDE4C19002FCE5D /* IGListDiffResultTests.m */; };
 		88DF89891E010F6500B1B9B4 /* IGListDiffSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88144EE61D870EDC007C7F66 /* IGListDiffSwiftTests.swift */; };
 		88DF898A1E010F7000B1B9B4 /* IGListDiffTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88144EE81D870EDC007C7F66 /* IGListDiffTests.m */; };
-		917E89881E800EE70015F934 /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 917E89871E800EE70015F934 /* IGListCollectionViewLayoutInternal.h */; };
+		917E89881E800EE70015F934 /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 917E89871E800EE70015F934 /* IGListCollectionViewLayoutInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		989317631E0ED45900DB93B3 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 989317621E0ED45900DB93B3 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		989317641E0ED45900DB93B3 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 989317621E0ED45900DB93B3 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		989317651E0ED45900DB93B3 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 989317621E0ED45900DB93B3 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -829,7 +829,6 @@
 				2926586D1E75E01A0041B56D /* IGListBindingSectionControllerDataSource.h in Headers */,
 				0B3B92C71E08D7F5008390ED /* IGListBatchUpdateData.h in Headers */,
 				0B3B92ED1E08D7F5008390ED /* IGListMoveIndexPathInternal.h in Headers */,
-				1F2984CA1E8039EC005FA211 /* IGListCollectionViewLayoutInternal.h in Headers */,
 				0B3B93351E08D7F5008390ED /* IGListDisplayHandler.h in Headers */,
 				0B3B92D31E08D7F5008390ED /* IGListIndexPathResult.h in Headers */,
 				0B3B93251E08D7F5008390ED /* IGListSupplementaryViewSource.h in Headers */,
@@ -864,6 +863,7 @@
 				292658711E75E2440041B56D /* IGListBatchUpdateState.h in Headers */,
 				0B3B92E31E08D7F5008390ED /* IGListMoveIndexPath.h in Headers */,
 				0B3B93111E08D7F5008390ED /* IGListReloadDataUpdater.h in Headers */,
+				1F2984CA1E8039EC005FA211 /* IGListCollectionViewLayoutInternal.h in Headers */,
 				298DDA201E3B0DC800F76F50 /* IGListCollectionViewLayout.h in Headers */,
 				297278BE1E6B58560099D8EA /* IGListBatchUpdates.h in Headers */,
 				0B3B92FF1E08D7F5008390ED /* IGListAdapterUpdater.h in Headers */,
@@ -888,7 +888,6 @@
 				0B3B92C61E08D7F5008390ED /* IGListBatchUpdateData.h in Headers */,
 				0B3B92EC1E08D7F5008390ED /* IGListMoveIndexPathInternal.h in Headers */,
 				0B3B93341E08D7F5008390ED /* IGListDisplayHandler.h in Headers */,
-				917E89881E800EE70015F934 /* IGListCollectionViewLayoutInternal.h in Headers */,
 				0B3B92D21E08D7F5008390ED /* IGListIndexPathResult.h in Headers */,
 				2926586C1E75E01A0041B56D /* IGListBindingSectionControllerDataSource.h in Headers */,
 				0B3B93241E08D7F5008390ED /* IGListSupplementaryViewSource.h in Headers */,
@@ -923,6 +922,7 @@
 				0B3B92E21E08D7F5008390ED /* IGListMoveIndexPath.h in Headers */,
 				297278C41E6B59D50099D8EA /* IGListBatchUpdateState.h in Headers */,
 				0B3B93101E08D7F5008390ED /* IGListReloadDataUpdater.h in Headers */,
+				917E89881E800EE70015F934 /* IGListCollectionViewLayoutInternal.h in Headers */,
 				298DDA1F1E3B0DC800F76F50 /* IGListCollectionViewLayout.h in Headers */,
 				297278BD1E6B58560099D8EA /* IGListBatchUpdates.h in Headers */,
 				0B3B92FE1E08D7F5008390ED /* IGListAdapterUpdater.h in Headers */,


### PR DESCRIPTION
Created a new demo that shows off how to:

- Inject dependencies to section controllers
  - Objects shared between section controllers
  - Things that aren't the core "object"
- Announce changes from the VC that make their way to the section controllers
  - Without calling updates