### PR TITLE
Prevent a crash when inserting the same index twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - `IGListCollectionView` has been **completely removed** in favor of using plain old `UICollectionView`. See discussion at [#409](https://github.com/Instagram/IGListKit/issues/409) for details. [Jesse Squires](https://github.com/jessesquires) [(tbd)](https://github.com/Instagram/IGListKit/pull/tbd)
 
+- `IGListBatchUpdateData` replaced its `NSSet` properties with `NSArray` instead. [Ryan Nystrom](https://github.com/rnystrom) [(#616)](https://github.com/Instagram/IGListKit/pull/616)
+
 ### Enhancements
 
 - Added `-[IGListAdapter visibleCellsForObject:]` API. [Sherlouk](https://github.com/Sherlouk) [(#442)](https://github.com/Instagram/IGListKit/pull/442)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Prevent section controllers and supplementary sources from returning negative sizes that crash `UICollectionViewFlowLayout`. [Ryan Nystrom](https://github.com/rnystrom) [(#583)](https://github.com/Instagram/IGListKit/pull/583)
 
+- Fix a crash when inserting or deleting from the same index within the same batch-update application. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
+
 2.1.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Prevent section controllers and supplementary sources from returning negative sizes that crash `UICollectionViewFlowLayout`. [Ryan Nystrom](https://github.com/rnystrom) [(#583)](https://github.com/Instagram/IGListKit/pull/583)
 
-- Fix a crash when inserting or deleting from the same index within the same batch-update application. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
+- Fix a crash when inserting or deleting from the same index within the same batch-update application. [Ryan Nystrom](https://github.com/rnystrom) [(#616)](https://github.com/Instagram/IGListKit/pull/616)
 
 2.1.0
 -----

--- a/Source/Common/IGListBatchUpdateData.h
+++ b/Source/Common/IGListBatchUpdateData.h
@@ -41,17 +41,17 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Item insert index paths.
  */
-@property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *insertIndexPaths;
+@property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *insertIndexPaths;
 
 /**
  Item delete index paths.
  */
-@property (nonatomic, strong, readonly) NSSet<NSIndexPath *> *deleteIndexPaths;
+@property (nonatomic, strong, readonly) NSArray<NSIndexPath *> *deleteIndexPaths;
 
 /**
  Item moves.
  */
-@property (nonatomic, strong, readonly) NSSet<IGListMoveIndexPath *> *moveIndexPaths;
+@property (nonatomic, strong, readonly) NSArray<IGListMoveIndexPath *> *moveIndexPaths;
 
 /**
  Creates a new batch update object with section and item operations.
@@ -68,9 +68,9 @@ IGLK_SUBCLASSING_RESTRICTED
 - (instancetype)initWithInsertSections:(NSIndexSet *)insertSections
                         deleteSections:(NSIndexSet *)deleteSections
                           moveSections:(NSSet<IGListMoveIndex *> *)moveSections
-                      insertIndexPaths:(NSSet<NSIndexPath *> *)insertIndexPaths
-                      deleteIndexPaths:(NSSet<NSIndexPath *> *)deleteIndexPaths
-                        moveIndexPaths:(NSSet<IGListMoveIndexPath *> *)moveIndexPaths NS_DESIGNATED_INITIALIZER;
+                      insertIndexPaths:(NSArray<NSIndexPath *> *)insertIndexPaths
+                      deleteIndexPaths:(NSArray<NSIndexPath *> *)deleteIndexPaths
+                        moveIndexPaths:(NSArray<IGListMoveIndexPath *> *)moveIndexPaths NS_DESIGNATED_INITIALIZER;
 
 /**
  :nodoc:

--- a/Source/Common/IGListBatchUpdateData.mm
+++ b/Source/Common/IGListBatchUpdateData.mm
@@ -51,9 +51,9 @@ static void convertMoveToDeleteAndInsert(NSMutableSet<IGListMoveIndex *> *moves,
 - (instancetype)initWithInsertSections:(NSIndexSet *)insertSections
                         deleteSections:(NSIndexSet *)deleteSections
                           moveSections:(NSSet<IGListMoveIndex *> *)moveSections
-                      insertIndexPaths:(NSSet<NSIndexPath *> *)insertIndexPaths
-                      deleteIndexPaths:(NSSet<NSIndexPath *> *)deleteIndexPaths
-                        moveIndexPaths:(NSSet<IGListMoveIndexPath *> *)moveIndexPaths {
+                      insertIndexPaths:(NSArray<NSIndexPath *> *)insertIndexPaths
+                      deleteIndexPaths:(NSArray<NSIndexPath *> *)deleteIndexPaths
+                        moveIndexPaths:(NSArray<IGListMoveIndexPath *> *)moveIndexPaths {
     IGParameterAssert(insertSections != nil);
     IGParameterAssert(deleteSections != nil);
     IGParameterAssert(moveSections != nil);

--- a/Source/Internal/IGListBatchUpdates.h
+++ b/Source/Internal/IGListBatchUpdates.h
@@ -17,9 +17,9 @@ IGLK_SUBCLASSING_RESTRICTED
 @interface IGListBatchUpdates : NSObject
 
 @property (nonatomic, strong, readonly) NSMutableIndexSet *sectionReloads;
-@property (nonatomic, strong, readonly) NSMutableSet<NSIndexPath *> *itemInserts;
-@property (nonatomic, strong, readonly) NSMutableSet<NSIndexPath *> *itemDeletes;
-@property (nonatomic, strong, readonly) NSMutableSet<IGListMoveIndexPath *> *itemMoves;
+@property (nonatomic, strong, readonly) NSMutableArray<NSIndexPath *> *itemInserts;
+@property (nonatomic, strong, readonly) NSMutableArray<NSIndexPath *> *itemDeletes;
+@property (nonatomic, strong, readonly) NSMutableArray<IGListMoveIndexPath *> *itemMoves;
 
 @property (nonatomic, strong, readonly) NSMutableArray<void (^)()> *itemUpdateBlocks;
 @property (nonatomic, strong, readonly) NSMutableArray<void (^)(BOOL)> *itemCompletionBlocks;

--- a/Source/Internal/IGListBatchUpdates.m
+++ b/Source/Internal/IGListBatchUpdates.m
@@ -14,9 +14,9 @@
 - (instancetype)init {
     if (self = [super init]) {
         _sectionReloads = [NSMutableIndexSet new];
-        _itemInserts = [NSMutableSet new];
-        _itemMoves = [NSMutableSet new];
-        _itemDeletes = [NSMutableSet new];
+        _itemInserts = [NSMutableArray new];
+        _itemMoves = [NSMutableArray new];
+        _itemDeletes = [NSMutableArray new];
         _itemUpdateBlocks = [NSMutableArray new];
         _itemCompletionBlocks = [NSMutableArray new];
     }

--- a/Source/Internal/UICollectionView+IGListBatchUpdateData.m
+++ b/Source/Internal/UICollectionView+IGListBatchUpdateData.m
@@ -14,8 +14,8 @@
 @implementation UICollectionView (IGListBatchUpdateData)
 
 - (void)ig_applyBatchUpdateData:(IGListBatchUpdateData *)updateData {
-    [self deleteItemsAtIndexPaths:[updateData.deleteIndexPaths allObjects]];
-    [self insertItemsAtIndexPaths:[updateData.insertIndexPaths allObjects]];
+    [self deleteItemsAtIndexPaths:updateData.deleteIndexPaths];
+    [self insertItemsAtIndexPaths:updateData.insertIndexPaths];
 
     for (IGListMoveIndexPath *move in updateData.moveIndexPaths) {
         [self moveItemAtIndexPath:move.from toIndexPath:move.to];

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1456,4 +1456,46 @@
     [self waitForExpectationsWithTimeout:15 handler:nil];
 }
 
+- (void)test_whenInsertingItemsTwice_withDataUpdatedTwice_thatAllUpdatesAppliedWithoutException {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @2),
+                             ]];
+
+    IGTestObject *object = self.dataSource.objects[0];
+    IGListSectionController<IGListSectionType> *sectionController = [self.adapter sectionControllerForObject:object];
+
+    XCTestExpectation *expectation = genExpectation;
+    [sectionController.collectionContext performBatchAnimated:YES updates:^(id<IGListBatchContext> batchContext) {
+        object.value = @4;
+        [batchContext insertInSectionController:sectionController atIndexes:[NSIndexSet indexSetWithIndex:0]];
+        [batchContext insertInSectionController:sectionController atIndexes:[NSIndexSet indexSetWithIndex:0]];
+    } completion:^(BOOL finished2) {
+        XCTAssertEqual([self.collectionView numberOfSections], 1);
+        XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 4);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
+- (void)test_whenDeletingItemsTwice_withDataUpdatedTwice_thatAllUpdatesAppliedWithoutException {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @4),
+                             ]];
+
+    IGTestObject *object = self.dataSource.objects[0];
+    IGListSectionController<IGListSectionType> *sectionController = [self.adapter sectionControllerForObject:object];
+
+    XCTestExpectation *expectation = genExpectation;
+    [sectionController.collectionContext performBatchAnimated:YES updates:^(id<IGListBatchContext> batchContext) {
+        object.value = @2;
+        [batchContext deleteInSectionController:sectionController atIndexes:[NSIndexSet indexSetWithIndex:0]];
+        [batchContext deleteInSectionController:sectionController atIndexes:[NSIndexSet indexSetWithIndex:0]];
+    } completion:^(BOOL finished2) {
+        XCTAssertEqual([self.collectionView numberOfSections], 1);
+        XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 2);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:15 handler:nil];
+}
+
 @end

--- a/Tests/IGListBatchUpdateDataTests.m
+++ b/Tests/IGListBatchUpdateDataTests.m
@@ -47,9 +47,9 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[])
                                                                            deleteSections:indexSet(@[])
                                                                              moveSections:[NSSet new]
-                                                                         insertIndexPaths:[NSSet new]
-                                                                         deleteIndexPaths:[NSSet new]
-                                                                           moveIndexPaths:[NSSet new]];
+                                                                         insertIndexPaths:[NSArray new]
+                                                                         deleteIndexPaths:[NSArray new]
+                                                                           moveIndexPaths:[NSArray new]];
     XCTAssertNotNil(result);
 }
 
@@ -57,28 +57,28 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[@0, @1])
                                                                            deleteSections:indexSet(@[@5])
                                                                              moveSections:[NSSet setWithArray:@[newMove(3, 4)]]
-                                                                         insertIndexPaths:[NSSet setWithArray:@[newPath(0, 0)]]
-                                                                         deleteIndexPaths:[NSSet setWithArray:@[newPath(1, 0)]]
-                                                                           moveIndexPaths:[NSSet setWithArray:@[newMovePath(6, 0, 6, 1)]]];
+                                                                         insertIndexPaths:@[newPath(0, 0)]
+                                                                         deleteIndexPaths:@[newPath(1, 0)]
+                                                                           moveIndexPaths:@[newMovePath(6, 0, 6, 1)]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@0, @1]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@5]));
     XCTAssertEqualObjects(result.moveSections, [NSSet setWithArray:@[newMove(3, 4)]]);
-    XCTAssertEqualObjects(result.insertIndexPaths, [NSSet setWithArray:@[newPath(0, 0)]]);
-    XCTAssertEqualObjects(result.deleteIndexPaths, [NSSet setWithArray:@[newPath(1, 0)]]);
+    XCTAssertEqualObjects(result.insertIndexPaths, @[newPath(0, 0)]);
+    XCTAssertEqualObjects(result.deleteIndexPaths, @[newPath(1, 0)]);
     XCTAssertEqual(result.moveIndexPaths.count, 1);
-    XCTAssertEqualObjects(result.moveIndexPaths.anyObject, [[IGListMoveIndexPath alloc] initWithFrom:newPath(6, 0) to:newPath(6, 1)]);
+    XCTAssertEqualObjects(result.moveIndexPaths.firstObject, [[IGListMoveIndexPath alloc] initWithFrom:newPath(6, 0) to:newPath(6, 1)]);
 }
 
 - (void)test_whenMovingSections_withItemDeletes_thatResultConvertsConflicts_toDeletesAndInserts {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[])
                                                                            deleteSections:indexSet(@[])
                                                                              moveSections:[NSSet setWithArray:@[newMove(2, 4)]]
-                                                                         insertIndexPaths:[NSSet new]
-                                                                         deleteIndexPaths:[NSSet setWithArray:@[newPath(2, 0), newPath(3, 4)]]
-                                                                           moveIndexPaths:[NSSet new]];
+                                                                         insertIndexPaths:[NSArray new]
+                                                                         deleteIndexPaths:@[newPath(2, 0), newPath(3, 4)]
+                                                                           moveIndexPaths:[NSArray new]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@4]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@2]));
-    XCTAssertEqualObjects(result.deleteIndexPaths, [NSSet setWithArray:@[newPath(3, 4)]]);
+    XCTAssertEqualObjects(result.deleteIndexPaths, @[newPath(3, 4)]);
     XCTAssertEqual(result.moveSections.count, 0);
 }
 
@@ -86,12 +86,12 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[])
                                                                            deleteSections:indexSet(@[])
                                                                              moveSections:[NSSet setWithArray:@[newMove(2, 4)]]
-                                                                         insertIndexPaths:[NSSet setWithArray:@[newPath(4, 0), newPath(3, 4)]]
-                                                                         deleteIndexPaths:[NSSet new]
-                                                                           moveIndexPaths:[NSSet new]];
+                                                                         insertIndexPaths:@[newPath(4, 0), newPath(3, 4)]
+                                                                         deleteIndexPaths:[NSArray new]
+                                                                           moveIndexPaths:[NSArray new]];
     XCTAssertEqualObjects(result.insertSections, indexSet(@[@4]));
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@2]));
-    XCTAssertEqualObjects(result.insertIndexPaths, [NSSet setWithArray:@[newPath(3, 4)]]);
+    XCTAssertEqualObjects(result.insertIndexPaths, @[newPath(3, 4)]);
     XCTAssertEqual(result.moveSections.count, 0);
 }
 
@@ -99,9 +99,9 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[])
                                                                            deleteSections:indexSet(@[@0])
                                                                              moveSections:[NSSet new]
-                                                                         insertIndexPaths:[NSSet new]
-                                                                         deleteIndexPaths:[NSSet new]
-                                                                           moveIndexPaths:[NSSet setWithArray:@[newMovePath(0, 0, 0, 1)]]];
+                                                                         insertIndexPaths:[NSArray new]
+                                                                         deleteIndexPaths:[NSArray new]
+                                                                           moveIndexPaths:@[newMovePath(0, 0, 0, 1)]];
     XCTAssertEqual(result.moveIndexPaths.count, 0);
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@0]));
 }
@@ -110,9 +110,9 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[])
                                                                            deleteSections:indexSet(@[])
                                                                              moveSections:[NSSet setWithArray:@[newMove(0, 1)]]
-                                                                         insertIndexPaths:[NSSet new]
-                                                                         deleteIndexPaths:[NSSet new]
-                                                                           moveIndexPaths:[NSSet setWithArray:@[newMovePath(0, 0, 0, 1)]]];
+                                                                         insertIndexPaths:[NSArray new]
+                                                                         deleteIndexPaths:[NSArray new]
+                                                                           moveIndexPaths:@[newMovePath(0, 0, 0, 1)]];
     XCTAssertEqual(result.moveIndexPaths.count, 0);
     XCTAssertEqual(result.moveSections.count, 0);
     XCTAssertEqualObjects(result.deleteSections, indexSet(@[@0]));
@@ -123,9 +123,9 @@ static IGListMoveIndex *newMove(NSInteger from, NSInteger to) {
     IGListBatchUpdateData *result = [[IGListBatchUpdateData alloc] initWithInsertSections:indexSet(@[])
                                                                            deleteSections:indexSet(@[@2])
                                                                              moveSections:[NSSet setWithArray:@[newMove(2, 6), newMove(0, 2)]]
-                                                                         insertIndexPaths:[NSSet new]
-                                                                         deleteIndexPaths:[NSSet new]
-                                                                           moveIndexPaths:[NSSet new]];
+                                                                         insertIndexPaths:[NSArray new]
+                                                                         deleteIndexPaths:[NSArray new]
+                                                                           moveIndexPaths:[NSArray new]];
     XCTAssertEqual(result.deleteSections.count, 1);
     XCTAssertEqual(result.moveSections.count, 1);
     XCTAssertEqual(result.insertSections.count, 0);


### PR DESCRIPTION
## Changes in this pull request

If you insert or delete into the same index twice **and** update your data source to reflect those changes, we will squash the insert/delete into a single update because we're using `NSSet` internally.

This becomes very apparent when multiple updates are coalesced.

Issue fixed: #483

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.