### PR TITLE
Make Section Controllers Generic on ObjectType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - `IGListCollectionView` has been **completely removed** in favor of using plain old `UICollectionView`. See discussion at [#409](https://github.com/Instagram/IGListKit/issues/409) for details. [Jesse Squires](https://github.com/jessesquires) [(tbd)](https://github.com/Instagram/IGListKit/pull/tbd)
 
+- Section controllers are now generic on ObjectType. [Adlai-Holler](https://github.com/Adlai-Holler) [#625](https://github.com/Instagram/IGListKit/pull/625)
+
 ### Enhancements
 
 - Added `-[IGListAdapter visibleCellsForObject:]` API. [Sherlouk](https://github.com/Sherlouk) [(#442)](https://github.com/Instagram/IGListKit/pull/442)

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -47,7 +47,7 @@ extension DemoItem: IGListDiffable {
 
 }
 
-final class DemoSectionController: IGListSectionController, IGListSectionType {
+final class DemoSectionController: IGListSectionController<DemoItem>, IGListSectionType {
 
     var object: DemoItem?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/DisplaySectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class DisplaySectionController: IGListSectionController, IGListSectionType, IGListDisplayDelegate {
+final class DisplaySectionController: IGListSectionController<IGListDiffable>, IGListSectionType, IGListDisplayDelegate {
 
     override init() {
         super.init()
@@ -44,22 +44,22 @@ final class DisplaySectionController: IGListSectionController, IGListSectionType
 
     // MARK: IGListDisplayDelegate
 
-    func listAdapter(_ listAdapter: IGListAdapter, willDisplay sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: IGListAdapter, willDisplay sectionController: IGListSectionController<IGListDiffable>) {
         let section = collectionContext!.section(for: self)
         print("Will display section \(section)")
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, willDisplay sectionController: IGListSectionController, cell: UICollectionViewCell, at index: Int) {
+    func listAdapter(_ listAdapter: IGListAdapter, willDisplay sectionController: IGListSectionController<IGListDiffable>, cell: UICollectionViewCell, at index: Int) {
         let section = collectionContext!.section(for: self)
         print("Did will display cell \(index) in section \(section)")
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, didEndDisplaying sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: IGListAdapter, didEndDisplaying sectionController: IGListSectionController<IGListDiffable>) {
         let section = collectionContext!.section(for: self)
         print("Did end displaying section \(section)")
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, didEndDisplaying sectionController: IGListSectionController, cell: UICollectionViewCell, at index: Int) {
+    func listAdapter(_ listAdapter: IGListAdapter, didEndDisplaying sectionController: IGListSectionController<IGListDiffable>, cell: UICollectionViewCell, at index: Int) {
         let section = collectionContext!.section(for: self)
         print("Did end displaying cell \(index) in section \(section)")
     }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/EmbeddedSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/EmbeddedSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class EmbeddedSectionController: IGListSectionController, IGListSectionType {
+final class EmbeddedSectionController: IGListSectionController<Int>, IGListSectionType {
 
     var number: Int?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ExpandableSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class ExpandableSectionController: IGListSectionController, IGListSectionType {
+final class ExpandableSectionController: IGListSectionController<String>, IGListSectionType {
 
     var expanded = false
     var object: String?

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-final class FeedItemSectionController: IGListSectionController, IGListSectionType, IGListSupplementaryViewSource {
+final class FeedItemSectionController: IGListSectionController<FeedItem>, IGListSectionType, IGListSupplementaryViewSource {
 
     var feedItem: FeedItem!
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/GridSectionController.swift
@@ -39,7 +39,7 @@ extension GridItem: IGListDiffable {
     
 }
 
-final class GridSectionController: IGListSectionController, IGListSectionType {
+final class GridSectionController: IGListSectionController<GridItem>, IGListSectionType {
 
     var object: GridItem?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class HorizontalSectionController: IGListSectionController, IGListSectionType, IGListAdapterDataSource {
+final class HorizontalSectionController: IGListSectionController<Int>, IGListSectionType, IGListAdapterDataSource {
 
     var number: Int?
 
@@ -54,7 +54,7 @@ final class HorizontalSectionController: IGListSectionController, IGListSectionT
         return (0..<number).map { $0 as IGListDiffable }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return EmbeddedSectionController()
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class LabelSectionController: IGListSectionController, IGListSectionType {
+final class LabelSectionController: IGListSectionController<IGListDiffable>, IGListSectionType {
 
     var object: String?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ListeningSectionController.swift
@@ -14,7 +14,7 @@
 
 import IGListKit
 
-final class ListeningSectionController: IGListSectionController, IGListSectionType, IncrementListener {
+final class ListeningSectionController: IGListSectionController<IGListDiffable>, IGListSectionType, IncrementListener {
 
     var value: Int = 0
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/MonthSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/MonthSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class MonthSectionController: IGListBindingSectionController<IGListDiffable>, IGListBindingSectionControllerDataSource, IGListBindingSectionControllerSelectionDelegate {
+final class MonthSectionController: IGListBindingSectionController<Month>, IGListBindingSectionControllerDataSource, IGListBindingSectionControllerSelectionDelegate {
     
     var selectedDay: Int = -1
     

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/PostSectionController.h
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/PostSectionController.h
@@ -13,7 +13,8 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import "Post.h"
 
-@interface PostSectionController : IGListSectionController <IGListSectionType>
+@interface PostSectionController : IGListSectionController<Post *> <IGListSectionType>
 
 @end

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/RemoveSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/RemoveSectionController.swift
@@ -18,7 +18,7 @@ protocol RemoveSectionControllerDelegate: class {
     func removeSectionControllerWantsRemoved(_ sectionController: RemoveSectionController)
 }
 
-final class RemoveSectionController: IGListSectionController, IGListSectionType, RemoveCellDelegate {
+final class RemoveSectionController: IGListSectionController<Int>, IGListSectionType, RemoveCellDelegate {
 
     weak var delegate: RemoveSectionControllerDelegate?
     var number: Int?

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
@@ -18,7 +18,7 @@ protocol SearchSectionControllerDelegate: class {
     func searchSectionController(_ sectionController: SearchSectionController, didChangeText text: String)
 }
 
-final class SearchSectionController: IGListSectionController, IGListSectionType, UISearchBarDelegate, IGListScrollDelegate {
+final class SearchSectionController: IGListSectionController<IGListDiffable>, IGListSectionType, UISearchBarDelegate, IGListScrollDelegate {
 
     weak var delegate: SearchSectionControllerDelegate?
 
@@ -56,14 +56,14 @@ final class SearchSectionController: IGListSectionController, IGListSectionType,
 
     //MARK: IGListScrollDelegate
 
-    func listAdapter(_ listAdapter: IGListAdapter, didScroll sectionController: IGListSectionController) {
+    func listAdapter(_ listAdapter: IGListAdapter, didScroll sectionController: IGListSectionController<IGListDiffable>) {
         if let searchBar = (collectionContext?.cellForItem(at: 0, sectionController: self) as? SearchCell)?.searchBar {
             searchBar.text = ""
             searchBar.resignFirstResponder()
         }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter!, willBeginDragging sectionController: IGListSectionController!) {}
-    func listAdapter(_ listAdapter: IGListAdapter!, didEndDragging sectionController: IGListSectionController!, willDecelerate decelerate: Bool) {}
+    func listAdapter(_ listAdapter: IGListAdapter!, willBeginDragging sectionController: IGListSectionController<IGListDiffable>!) {}
+    func listAdapter(_ listAdapter: IGListAdapter!, didEndDragging sectionController: IGListSectionController<IGListDiffable>!, willDecelerate decelerate: Bool) {}
 
 }

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SelfSizingSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SelfSizingSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class SelfSizingSectionController: IGListSectionController, IGListSectionType {
+final class SelfSizingSectionController: IGListSectionController<SelectionModel>, IGListSectionType {
 
     var model: SelectionModel!
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/StoryboardLabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/StoryboardLabelSectionController.swift
@@ -19,7 +19,7 @@ protocol StoryboardLabelSectionControllerDelegate: class {
     func removeSectionControllerWantsRemoved(_ sectionController: StoryboardLabelSectionController)
 }
 
-final class StoryboardLabelSectionController: IGListSectionController, IGListSectionType {
+final class StoryboardLabelSectionController: IGListSectionController<Person>, IGListSectionType {
     
     var object: Person?
     weak var delegate: StoryboardLabelSectionControllerDelegate?

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/UserSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/UserSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class UserSectionController: IGListSectionController, IGListSectionType {
+final class UserSectionController: IGListSectionController<User>, IGListSectionType {
 
     var user: User?
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/WorkingRangeSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class WorkingRangeSectionController: IGListSectionController, IGListSectionType, IGListWorkingRangeDelegate {
+final class WorkingRangeSectionController: IGListSectionController<Int>, IGListSectionType, IGListWorkingRangeDelegate {
 
     var height: Int?
     var downloadedImage: UIImage?

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/AnnouncingDepsViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/AnnouncingDepsViewController.swift
@@ -56,7 +56,7 @@ final class AnnouncingDepsViewController: UIViewController, IGListAdapterDataSou
         return data
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return ListeningSectionController(announcer: announcer)
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
@@ -67,7 +67,7 @@ final class CalendarViewController: UIViewController, IGListAdapterDataSource {
         return months
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return MonthSectionController()
     }
     

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -61,7 +61,7 @@ final class DemosViewController: UIViewController, IGListAdapterDataSource {
         return demos
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return DemoSectionController()
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DisplayViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DisplayViewController.swift
@@ -40,7 +40,7 @@ final class DisplayViewController: UIViewController, IGListAdapterDataSource {
         return [1, 2, 3, 4, 5, 6] as [NSNumber]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return DisplaySectionController()
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/EmptyViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/EmptyViewController.swift
@@ -66,7 +66,7 @@ final class EmptyViewController: UIViewController, IGListAdapterDataSource, Remo
         return data as [IGListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         let sectionController = RemoveSectionController()
         sectionController.delegate = self
         return sectionController

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/LoadMoreViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/LoadMoreViewController.swift
@@ -51,7 +51,7 @@ final class LoadMoreViewController: UIViewController, IGListAdapterDataSource, U
         return objects
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         if let obj = object as? String, obj == spinToken {
             return spinnerSectionController()
         } else {

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/MixedDataViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/MixedDataViewController.swift
@@ -79,7 +79,7 @@ final class MixedDataViewController: UIViewController, IGListAdapterDataSource {
             .map { $0 as! IGListDiffable }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         switch object {
         case is String:   return ExpandableSectionController()
         case is GridItem: return GridSectionController()

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
@@ -51,7 +51,7 @@ final class NestedAdapterViewController: UIViewController, IGListAdapterDataSour
         return data as! [IGListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         if object is Int {
             return HorizontalSectionController()
         } else {

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
@@ -52,7 +52,7 @@ final class SearchViewController: UIViewController, IGListAdapterDataSource, Sea
         return [searchToken] + words.filter { $0.lowercased().contains(filterString.lowercased()) }.map { $0 as IGListDiffable }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         if let obj = object as? NSNumber, obj == searchToken {
             let sectionController = SearchSectionController()
             sectionController.delegate = self

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SelfSizingCellsViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SelfSizingCellsViewController.swift
@@ -60,7 +60,7 @@ final class SelfSizingCellsViewController: UIViewController, IGListAdapterDataSo
         return data as [IGListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return SelfSizingSectionController()
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionStoryboardViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionStoryboardViewController.swift
@@ -39,7 +39,7 @@ final class SingleSectionStoryboardViewController: UIViewController, IGListAdapt
         return data as [IGListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         let configureBlock = { (item: Any, cell: UICollectionViewCell) in
             guard let cell = cell as? StoryboardCell, let number = item as? Int else { return }
             cell.textLabel.text = "Cell: \(number + 1)"

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SingleSectionViewController.swift
@@ -46,20 +46,20 @@ final class SingleSectionViewController: UIViewController, IGListAdapterDataSour
         return data as [IGListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
-        let configureBlock = { (item: Any, cell: UICollectionViewCell) in
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
+        let configureBlock = { (item: Int, cell: UICollectionViewCell) in
             guard let cell = cell as? NibCell, let number = item as? Int else { return }
             cell.textLabel.text = "Cell: \(number + 1)"
         }
         
-        let sizeBlock = { (item: Any, context: IGListCollectionContext?) -> CGSize in
+        let sizeBlock = { (item: Int, context: IGListCollectionContext?) -> CGSize in
             guard let context = context else { return CGSize() }
             return CGSize(width: context.containerSize.width, height: 44)
         }
-        let sectionController = IGListSingleSectionController(nibName: NibCell.nibName,
-                                                              bundle: nil,
-                                                              configureBlock: configureBlock,
-                                                              sizeBlock: sizeBlock)
+        let sectionController = IGListSingleSectionController<Int>(nibName: NibCell.nibName,
+                                                                   bundle: nil,
+                                                                   configureBlock: configureBlock,
+                                                                   sizeBlock: sizeBlock)
         sectionController.selectionDelegate = self
         
         return sectionController
@@ -69,7 +69,7 @@ final class SingleSectionViewController: UIViewController, IGListAdapterDataSour
     
     // MARK: - IGListSingleSectionControllerDelegate
     
-    func didSelect(_ sectionController: IGListSingleSectionController, with object: Any) {
+    func didSelect(_ sectionController: IGListSingleSectionController<IGListDiffable>, with object: Any) {
         let section = adapter.section(for: sectionController) + 1
         let alert = UIAlertController(title: "Section \(section) was selected \u{1F389}",
                                       message: "Cell Object: " + String(describing: object),

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StackedViewController.swift
@@ -44,7 +44,7 @@ final class StackedViewController: UIViewController, IGListAdapterDataSource {
         return data as [IGListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         // note that each child section controller is designed to handle an Int (or no data)
         let sectionController = IGListStackedSectionController(sectionControllers: [
             WorkingRangeSectionController(),

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StoryboardViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/StoryboardViewController.swift
@@ -70,7 +70,7 @@ final class StoryboardViewController: UIViewController, IGListAdapterDataSource,
         return people
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         let sectionController = StoryboardLabelSectionController()
         sectionController.delegate = self
         return sectionController

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SupplementaryViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SupplementaryViewController.swift
@@ -47,7 +47,7 @@ final class SupplementaryViewController: UIViewController, IGListAdapterDataSour
         return feedItems
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return FeedItemSectionController()
     }
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/WorkingRangeViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/WorkingRangeViewController.swift
@@ -50,7 +50,7 @@ final class WorkingRangeViewController: UIViewController, IGListAdapterDataSourc
         return data as [IGListDiffable]
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return WorkingRangeSectionController()
     }
 

--- a/Examples/Examples-iOS/IGListKitMessageExample/MessagesViewController.swift
+++ b/Examples/Examples-iOS/IGListKitMessageExample/MessagesViewController.swift
@@ -49,7 +49,7 @@ final class MessagesViewController: MSMessagesAppViewController, IGListAdapterDa
         return data as [IGListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return LabelSectionController()
     }
     

--- a/Examples/Examples-iOS/IGListKitTodayExample/TodayViewController.swift
+++ b/Examples/Examples-iOS/IGListKitTodayExample/TodayViewController.swift
@@ -60,7 +60,7 @@ final class TodayViewController: UIViewController, NCWidgetProviding, IGListAdap
         return data as [IGListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return LabelSectionController()
     }
     

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/CarouselSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/CarouselSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class CarouselSectionController: IGListSectionController, IGListSectionType {
+final class CarouselSectionController: IGListSectionController<Int>, IGListSectionType {
 
     var number: Int?
     

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/DemoSectionController.swift
@@ -31,7 +31,7 @@ final class DemoItem: NSObject {
     
 }
 
-final class DemoSectionController: IGListSectionController, IGListSectionType {
+final class DemoSectionController: IGListSectionController<DemoItem>, IGListSectionType {
 
     var object: DemoItem?
     

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/HorizontalSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class HorizontalSectionController: IGListSectionController, IGListSectionType, IGListAdapterDataSource {
+final class HorizontalSectionController: IGListSectionController<Int>, IGListSectionType, IGListAdapterDataSource {
     
     var number: Int?
     
@@ -59,7 +59,7 @@ final class HorizontalSectionController: IGListSectionController, IGListSectionT
         return (0..<number).map { $0 as IGListDiffable }
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return CarouselSectionController()
     }
     

--- a/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/SectionControllers/LabelSectionController.swift
@@ -15,7 +15,7 @@
 import UIKit
 import IGListKit
 
-final class LabelSectionController: IGListSectionController, IGListSectionType {
+final class LabelSectionController: IGListSectionController<IGListDiffable>, IGListSectionType {
     
     var object: String?
     

--- a/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -46,7 +46,7 @@ final class DemosViewController: UIViewController, IGListAdapterDataSource {
         return demos
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         return DemoSectionController()
     }
     

--- a/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
+++ b/Examples/Examples-tvOS/IGListKitExamples/ViewControllers/NestedAdapterViewController.swift
@@ -52,7 +52,7 @@ final class NestedAdapterViewController: UIViewController, IGListAdapterDataSour
         return data as! [IGListDiffable]
     }
     
-    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+    func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
         if object is Int {
             return HorizontalSectionController()
         }

--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -43,7 +43,7 @@ func objects(for listAdapter: IGListAdapter) -> [IGListDiffable] {
   return [ "Foo", "Bar", 42, "Biz" ]
 }
 
-func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController {
+func listAdapter(_ listAdapter: IGListAdapter, sectionControllerFor object: Any) -> IGListSectionController<IGListDiffable> {
   if object is String {
     return LabelSectionController()
   } else {

--- a/Source/IGListBindingSectionController.h
+++ b/Source/IGListBindingSectionController.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  Only when `-diffIdentifier`s match is object equality compared, so you can assume the class is the same, and the
  instance has already been checked.
  */
-@interface IGListBindingSectionController<__covariant ObjectType : id<IGListDiffable>> : IGListSectionController<IGListSectionType>
+@interface IGListBindingSectionController<__covariant ObjectType : id<IGListDiffable>, __covariant ViewModelType : id<IGListDiffable>> : IGListSectionController<ObjectType> <IGListSectionType>
 
 /**
  A data source that transforms a top-level object into view models, and returns cells and sizes for given view models.
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
  The array of view models created from the data source. Values are changed when the top-level object changes or by
  calling `-updateAnimated:completion:` manually.
  */
-@property (nonatomic, strong, readonly) NSArray<id<IGListDiffable>> *viewModels;
+@property (nonatomic, strong, readonly) NSArray<ViewModelType> *viewModels;
 
 /**
  Tells the section controller to query for new view models, diff the changes, and update its cells.

--- a/Source/IGListSectionController.h
+++ b/Source/IGListSectionController.h
@@ -14,11 +14,12 @@
 #import <IGListKit/IGListScrollDelegate.h>
 #import <IGListKit/IGListSupplementaryViewSource.h>
 #import <IGListKit/IGListWorkingRangeDelegate.h>
+#import <IGListKit/IGListDiffable.h>
 
 /**
  The base class for section controllers used in a list. This class is intended to be subclassed.
  */
-@interface IGListSectionController : NSObject
+@interface IGListSectionController<__covariant ObjectType : id<IGListDiffable>> : NSObject
 
 /**
  The view controller housing the adapter that created this section controller.

--- a/Source/IGListSingleSectionController.h
+++ b/Source/IGListSingleSectionController.h
@@ -12,6 +12,7 @@
 #import <IGListKit/IGListSectionController.h>
 #import <IGListKit/IGListSectionType.h>
 #import <IGListKit/IGListMacros.h>
+#import <IGListKit/IGListDiffable.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -22,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param item The model with which to configure the cell.
  @param cell The cell to configure.
  */
-typedef void (^IGListSingleSectionCellConfigureBlock)(id item, __kindof UICollectionViewCell *cell);
+#define IGListSingleSectionCellConfigureBlock void (^)(ObjectType item, __kindof UICollectionViewCell *cell)
 
 /**
  A block that returns the size for the cell given the collection context.
@@ -32,7 +33,7 @@ typedef void (^IGListSingleSectionCellConfigureBlock)(id item, __kindof UICollec
 
  @return The size for the cell.
  */
-typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionContext> _Nullable collectionContext);
+#define IGListSingleSectionCellSizeBlock CGSize (^)(ObjectType item, id<IGListCollectionContext> _Nullable collectionContext)
 
 @class IGListSingleSectionController;
 
@@ -58,7 +59,7 @@ typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionC
  simpler architecture.
  */
 IGLK_SUBCLASSING_RESTRICTED
-@interface IGListSingleSectionController : IGListSectionController <IGListSectionType>
+@interface IGListSingleSectionController<__covariant ObjectType : id<IGListDiffable>> : IGListSectionController<ObjectType> <IGListSectionType>
 
 /**
  Creates a new section controller for a given cell type that will always have only one cell when present in a list.

--- a/Source/IGListStackedSectionController.h
+++ b/Source/IGListStackedSectionController.h
@@ -10,6 +10,7 @@
 #import <IGListKit/IGListSectionController.h>
 #import <IGListKit/IGListSectionType.h>
 #import <IGListKit/IGListMacros.h>
+#import <IGListKit/IGListDiffable.h>
 
 /**
  An instance of `IGListStackedSectionController` is a clustered section controller, composed of many child section
@@ -22,7 +23,7 @@
  huge class.
  */
 IGLK_SUBCLASSING_RESTRICTED
-@interface IGListStackedSectionController : IGListSectionController <IGListSectionType>
+@interface IGListStackedSectionController<__covariant ObjectType : id<IGListDiffable>> : IGListSectionController<ObjectType> <IGListSectionType>
 
 /**
  Creates a new stacked section controller.


### PR DESCRIPTION
## Changes in this pull request

- IGListSectionController is now generic on ObjectType.
- IGListBindingSectionController is now generic also on ViewModelType.

Issue fixed: #622 

@jessesquires I can't open the iOS examples project on my machine. Xcode 8.3 complains that the project is unreadable. So I believe I updated the example projects to be compatible but I'm not 100% sure.