### PR TITLE
Add Nullability to a Few Headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Prevent section controllers and supplementary sources from returning negative sizes that crash `UICollectionViewFlowLayout`. [Ryan Nystrom](https://github.com/rnystrom) [(#583)](https://github.com/Instagram/IGListKit/pull/583)
 
+- Add nullability annotations to a few more headers. [Adlai Holler](https://github.com/Adlai-Holler) [(#626)](https://github.com/Instagram/IGListKit/pull/626)
+
 2.1.0
 -----
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/SearchSectionController.swift
@@ -63,7 +63,7 @@ final class SearchSectionController: IGListSectionController, IGListSectionType,
         }
     }
 
-    func listAdapter(_ listAdapter: IGListAdapter!, willBeginDragging sectionController: IGListSectionController!) {}
-    func listAdapter(_ listAdapter: IGListAdapter!, didEndDragging sectionController: IGListSectionController!, willDecelerate decelerate: Bool) {}
+    func listAdapter(_ listAdapter: IGListAdapter, willBeginDragging sectionController: IGListSectionController) {}
+    func listAdapter(_ listAdapter: IGListAdapter, didEndDragging sectionController: IGListSectionController, willDecelerate decelerate: Bool) {}
 
 }

--- a/Source/IGListAdapterDelegate.h
+++ b/Source/IGListAdapterDelegate.h
@@ -11,6 +11,8 @@
 
 @class IGListAdapter;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Conform to `IGListAdapterDelegate` to receive display events for objects in a list.
  */
@@ -35,3 +37,5 @@
 - (void)listAdapter:(IGListAdapter *)listAdapter didEndDisplayingObject:(id)object atIndex:(NSInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListBatchContext.h
+++ b/Source/IGListBatchContext.h
@@ -13,6 +13,8 @@
 
 @protocol IGListSectionType;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Objects conforming to the IGListBatchContext protocol provide a way for section controllers to mutate their cells or
  reload everything within the section.
@@ -65,3 +67,5 @@
 - (void)reloadSectionController:(IGListSectionController<IGListSectionType> *)sectionController;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListReloadDataUpdater.h
+++ b/Source/IGListReloadDataUpdater.h
@@ -12,6 +12,8 @@
 #import <IGListKit/IGListMacros.h>
 #import <IGListKit/IGListUpdatingDelegate.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  An `IGListReloadDataUpdater` is a concrete type that conforms to `IGListUpdatingDelegate`.
  It is an out-of-box updater for `IGListAdapter` objects to use.
@@ -22,3 +24,5 @@ IGLK_SUBCLASSING_RESTRICTED
 @interface IGListReloadDataUpdater : NSObject <IGListUpdatingDelegate>
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListScrollDelegate.h
+++ b/Source/IGListScrollDelegate.h
@@ -14,6 +14,8 @@
 
 @protocol IGListSectionType;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Implement this protocol to receive display events for a section controller when it is on screen.
  */
@@ -44,3 +46,5 @@
 - (void)listAdapter:(IGListAdapter *)listAdapter didEndDraggingSectionController:(IGListSectionController <IGListSectionType> *)sectionController willDecelerate:(BOOL)decelerate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListSectionController.h
+++ b/Source/IGListSectionController.h
@@ -15,10 +15,14 @@
 #import <IGListKit/IGListSupplementaryViewSource.h>
 #import <IGListKit/IGListWorkingRangeDelegate.h>
 
+@protocol IGListDiffable;
+
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  The base class for section controllers used in a list. This class is intended to be subclassed.
  */
-@interface IGListSectionController : NSObject
+@interface IGListSectionController<__covariant ObjectType : id<IGListDiffable>> : NSObject
 
 /**
  The view controller housing the adapter that created this section controller.
@@ -105,3 +109,5 @@
 @property (nonatomic, weak, nullable) id <IGListScrollDelegate> scrollDelegate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListSectionController.h
+++ b/Source/IGListSectionController.h
@@ -15,14 +15,12 @@
 #import <IGListKit/IGListSupplementaryViewSource.h>
 #import <IGListKit/IGListWorkingRangeDelegate.h>
 
-@protocol IGListDiffable;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  The base class for section controllers used in a list. This class is intended to be subclassed.
  */
-@interface IGListSectionController<__covariant ObjectType : id<IGListDiffable>> : NSObject
+@interface IGListSectionController : NSObject
 
 /**
  The view controller housing the adapter that created this section controller.

--- a/Source/IGListStackedSectionController.h
+++ b/Source/IGListStackedSectionController.h
@@ -11,6 +11,8 @@
 #import <IGListKit/IGListSectionType.h>
 #import <IGListKit/IGListMacros.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  An instance of `IGListStackedSectionController` is a clustered section controller, composed of many child section
  controllers. It constructs and routes item-level indexes to the appropriate child section controller with a local
@@ -46,3 +48,5 @@ IGLK_SUBCLASSING_RESTRICTED
 + (instancetype)new NS_UNAVAILABLE;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I saw some `!` in the Swift example that we can remove 🙂 

Same as I mentioned in my last PR, the iOS examples project can't be opened on my machine, but I believe I updated the examples to be compatible.