### PR TITLE
Remove `@param` alignment from header docs #trivial

### DIFF
--- a/Source/Common/IGListBatchUpdateData.h
+++ b/Source/Common/IGListBatchUpdateData.h
@@ -56,12 +56,12 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Creates a new batch update object with section and item operations.
 
- @param insertSections   Section indexes to insert.
- @param deleteSections   Section indexes to delete.
- @param moveSections     Section moves.
+ @param insertSections Section indexes to insert.
+ @param deleteSections Section indexes to delete.
+ @param moveSections Section moves.
  @param insertIndexPaths Item index paths to insert.
  @param deleteIndexPaths Item index paths to delete.
- @param moveIndexPaths   Item index paths to move.
+ @param moveIndexPaths Item index paths to move.
 
  @return A new batch update object.
  */

--- a/Source/Common/IGListDiff.h
+++ b/Source/Common/IGListDiff.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, IGListDiffOption) {
 
  @param oldArray The old objects to diff against.
  @param newArray The new objects.
- @param option   An option on how to compare objects.
+ @param option An option on how to compare objects.
 
  @return A result object containing affected indexes.
  */
@@ -46,10 +46,10 @@ FOUNDATION_EXTERN IGListIndexSetResult *IGListDiff(NSArray<id<IGListDiffable>> *
  Creates a diff using index paths between two collections.
 
  @param fromSection The old section.
- @param toSection   The new section.
- @param oldArray    The old objects to diff against.
- @param newArray    The new objects.
- @param option      An option on how to compare objects.
+ @param toSection The new section.
+ @param oldArray The old objects to diff against.
+ @param newArray The new objects.
+ @param option An option on how to compare objects.
 
  @return A result object containing affected indexes.
  */

--- a/Source/Common/IGListExperiments.h
+++ b/Source/Common/IGListExperiments.h
@@ -22,7 +22,7 @@ typedef NS_OPTIONS (NSInteger, IGListExperiment) {
 /**
  Check if an experiment is enabled in a bitmask.
 
- @param mask   The bitmask of experiments.
+ @param mask The bitmask of experiments.
  @param option The option to compare with.
 
  @return `YES` if the option is in the bitmask, otherwise `NO`.
@@ -36,9 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Performs an index diff with an experiment bitmask.
 
- @param oldArray    The old array of objects.
- @param newArray    The new array of objects.
- @param option      Option to specify the type of diff.
+ @param oldArray The old array of objects.
+ @param newArray The new array of objects.
+ @param option Option to specify the type of diff.
  @param experiments Optional experiments.
 
  @return An index set result object contained the changed indexes.
@@ -54,10 +54,10 @@ FOUNDATION_EXTERN IGListIndexSetResult *IGListDiffExperiment(NSArray<id<IGListDi
  Performs a index path diff with an experiment bitmask.
 
  @param fromSection The old section.
- @param toSection   The new section.
- @param oldArray    The old array of objects.
- @param newArray    The new array of objects.
- @param option      Option to specify the type of diff.
+ @param toSection The new section.
+ @param oldArray The old array of objects.
+ @param newArray The new array of objects.
+ @param option Option to specify the type of diff.
  @param experiments Optional experiments.
 
  @return An index path result object containing the changed indexPaths.

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -87,7 +87,7 @@ IGLK_SUBCLASSING_RESTRICTED
  Initializes a new `IGListAdapter` object.
 
  @param updater An object that manages updates to the collection view.
- @param viewController   The view controller that will house the adapter.
+ @param viewController The view controller that will house the adapter.
  @param workingRangeSize The number of objects before and after the viewport to consider within the working range.
 
  @return A new list adapter object.
@@ -107,7 +107,7 @@ IGLK_SUBCLASSING_RESTRICTED
  Perform an update from the previous state of the data source. This is analogous to calling
  `-[UICollectionView performBatchUpdates:completion:]`.
 
- @param animated   A flag indicating if the transition should be animated.
+ @param animated A flag indicating if the transition should be animated.
  @param completion The block to execute when the updates complete.
  */
 - (void)performUpdatesAnimated:(BOOL)animated completion:(nullable IGListUpdaterCompletion)completion;
@@ -215,11 +215,11 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Scrolls to the specified object in the list adapter.
 
- @param object             The object to which to scroll.
+ @param object The object to which to scroll.
  @param supplementaryKinds The types of supplementary views in the section.
- @param scrollDirection    An option indicating the direction to scroll.
- @param scrollPosition     An option that specifies where the item should be positioned when scrolling finishes. 
- @param animated           A flag indicating if the scrolling should be animated.
+ @param scrollDirection An option indicating the direction to scroll.
+ @param scrollPosition An option that specifies where the item should be positioned when scrolling finishes.
+ @param animated A flag indicating if the scrolling should be animated.
  */
 - (void)scrollToObject:(id)object
     supplementaryKinds:(nullable NSArray<NSString *> *)supplementaryKinds
@@ -240,7 +240,7 @@ IGLK_SUBCLASSING_RESTRICTED
  Returns the size of a supplementary view in the list at the specified index path.
 
  @param elementKind The kind of supplementary view.
- @param indexPath   The index path of the supplementary view.
+ @param indexPath The index path of the supplementary view.
 
  @return The size of the supplementary view.
  */

--- a/Source/IGListAdapterDataSource.h
+++ b/Source/IGListAdapterDataSource.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  Asks the data source for a section controller for the specified object in the list.
 
  @param listAdapter The list adapter requesting this information.
- @param object      An object in the list.
+ @param object An object in the list.
 
  @return A new section controller instance that can be displayed in the list.
 

--- a/Source/IGListAdapterDelegate.h
+++ b/Source/IGListAdapterDelegate.h
@@ -22,8 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that a list object is about to be displayed.
 
  @param listAdapter The list adapter sending this information.
- @param object      The object that will display.
- @param index       The index of the object in the list.
+ @param object The object that will display.
+ @param index The index of the object in the list.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter willDisplayObject:(id)object atIndex:(NSInteger)index;
 
@@ -31,8 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that a list object is no longer being displayed.
 
  @param listAdapter The list adapter sending this information.
- @param object      The object that ended display.
- @param index       The index of the object in the list.
+ @param object The object that ended display.
+ @param index The index of the object in the list.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter didEndDisplayingObject:(id)object atIndex:(NSInteger)index;
 

--- a/Source/IGListAdapterUpdaterDelegate.h
+++ b/Source/IGListAdapterUpdaterDelegate.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView performBatchUpdates:completion:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param collectionView     The collection view that will perform the batch updates.
+ @param collectionView The collection view that will perform the batch updates.
  */
 - (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater willPerformBatchUpdatesWithCollectionView:(UICollectionView *)collectionView;
 
@@ -32,8 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater successfully finished `-[UICollectionView performBatchUpdates:completion:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param updates            The batch updates that were applied to the collection view.
- @param collectionView     The collection view that performed the batch updates.
+ @param updates The batch updates that were applied to the collection view.
+ @param collectionView The collection view that performed the batch updates.
 
  @note This event is called in the completion block of the batch update.
  */
@@ -45,8 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView insertItemsAtIndexPaths:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param indexPaths         An array of index paths that will be inserted.
- @param collectionView     The collection view that will perform the insert.
+ @param indexPaths An array of index paths that will be inserted.
+ @param collectionView The collection view that will perform the insert.
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
@@ -58,8 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView deleteItemsAtIndexPaths:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param indexPaths         An array of index paths that will be deleted.
- @param collectionView     The collection view that will perform the delete.
+ @param indexPaths An array of index paths that will be deleted.
+ @param collectionView The collection view that will perform the delete.
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
@@ -71,9 +71,9 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView moveItemAtIndexPath:toIndexPath:]`
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param fromIndexPath      The index path of the item that will be moved.
- @param toIndexPath        The index path to move the item to.
- @param collectionView     The collection view that will perform the move.
+ @param fromIndexPath The index path of the item that will be moved.
+ @param toIndexPath The index path to move the item to.
+ @param collectionView The collection view that will perform the move.
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
@@ -86,8 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView reloadItemsAtIndexPaths:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param indexPaths         An array of index paths that will be reloaded.
- @param collectionView     The collection view that will perform the reload.
+ @param indexPaths An array of index paths that will be reloaded.
+ @param collectionView The collection view that will perform the reload.
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
@@ -99,8 +99,8 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView reloadSections:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param sections           The sections that will be reloaded
- @param collectionView     The collection view that will perform the reload.
+ @param sections The sections that will be reloaded
+ @param collectionView The collection view that will perform the reload.
 
  @note This event is only sent when outside of `-[UICollectionView performBatchUpdates:completion:]`.
  */
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater will call `-[UICollectionView reloadData]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param collectionView     The collection view that will be reloaded.
+ @param collectionView The collection view that will be reloaded.
  */
 - (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater willReloadDataWithCollectionView:(UICollectionView *)collectionView;
 
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the updater successfully called `-[UICollectionView reloadData]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param collectionView     The collection view that reloaded.
+ @param collectionView The collection view that reloaded.
  */
 - (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater didReloadDataWithCollectionView:(UICollectionView *)collectionView;
 
@@ -128,10 +128,10 @@ NS_ASSUME_NONNULL_BEGIN
  Notifies the delegate that the collection view threw an exception in `-[UICollectionView performBatchUpdates:completion:]`.
 
  @param listAdapterUpdater The adapter updater owning the transition.
- @param exception          The exception thrown by the collection view.
- @param fromObjects        The items transitioned from in the diff, if any.
- @param toObjects          The items transitioned to in the diff, if any.
- @param updates            The batch updates that were applied to the collection view.
+ @param exception The exception thrown by the collection view.
+ @param fromObjects The items transitioned from in the diff, if any.
+ @param toObjects The items transitioned to in the diff, if any.
+ @param updates The batch updates that were applied to the collection view.
  */
 - (void)listAdapterUpdater:(IGListAdapterUpdater *)listAdapterUpdater
     willCrashWithException:(NSException *)exception

--- a/Source/IGListBatchContext.h
+++ b/Source/IGListBatchContext.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  Reloads cells in the section controller.
  
  @param sectionController  The section controller who's cells need reloading.
- @param indexes            The indexes of items that need reloading.
+ @param indexes The indexes of items that need reloading.
  */
 - (void)reloadInSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                         atIndexes:(NSIndexSet *)indexes;
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  Inserts cells in the list.
  
  @param sectionController The section controller who's cells need inserting.
- @param indexes           The indexes of items that need inserting.
+ @param indexes The indexes of items that need inserting.
  */
 - (void)insertInSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                         atIndexes:(NSIndexSet *)indexes;
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  Deletes cells in the list.
  
  @param sectionController The section controller who's cells need deleted.
- @param indexes           The indexes of items that need deleting.
+ @param indexes The indexes of items that need deleting.
  */
 - (void)deleteInSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                         atIndexes:(NSIndexSet *)indexes;
@@ -52,8 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
  Moves a cell from one index to another within the section controller.
  
  @param sectionController The section controller who's cell needs moved.
- @param fromIndex         The index the cell is currently in.
- @param toIndex           The index the cell should move to.
+ @param fromIndex The index the cell is currently in.
+ @param toIndex The index the cell should move to.
  */
 - (void)moveInSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                       fromIndex:(NSInteger)fromIndex

--- a/Source/IGListBindingSectionControllerDataSource.h
+++ b/Source/IGListBindingSectionControllerDataSource.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @param sectionController The section controller requesting view models.
  @param object The top-level object that powers the section controller.
+ 
  @return A new array of view models.
  */
 - (NSArray<id<IGListDiffable>> *)sectionController:(IGListBindingSectionController *)sectionController
@@ -37,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param sectionController The section controller requesting a cell.
  @param viewModel The view model for the cell.
  @param index The index of the view model.
+ 
  @return A dequeued cell.
  
  @note The section controller will call `-bindViewModel:` with the provided view model after the cell is dequeued. You
@@ -52,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param sectionController The section controller requesting a size.
  @param viewModel The view model for the cell.
  @param index The index of the view model.
+ 
  @return A size for the view model.
  */
 - (CGSize)sectionController:(IGListBindingSectionController *)sectionController

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns the index of the specified cell in the collection relative to the section controller.
 
- @param cell              An existing cell in the collection.
+ @param cell An existing cell in the collection.
  @param sectionController The section controller requesting this information.
 
  @return The index of the cell or `NSNotFound` if it does not exist in the collection.
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Returns the cell in the collection at the specified index for the section controller.
 
- @param index             The index of the desired cell.
+ @param index The index of the desired cell.
  @param sectionController The section controller requesting this information.
 
  @return The collection view cell, or `nil` if not found.
@@ -91,9 +91,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Deselects a cell in the collection.
 
- @param index             The index of the item to deselect.
+ @param index The index of the item to deselect.
  @param sectionController The section controller requesting this information.
- @param animated          Pass `YES` to animate the change, `NO` otherwise.
+ @param animated Pass `YES` to animate the change, `NO` otherwise.
  */
 - (void)deselectItemAtIndex:(NSInteger)index
           sectionController:(IGListSectionController<IGListSectionType> *)sectionController
@@ -111,9 +111,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Dequeues a cell from the collection view reuse pool.
 
- @param cellClass         The class of the cell you want to dequeue.
+ @param cellClass The class of the cell you want to dequeue.
  @param sectionController The section controller requesting this information.
- @param index             The index of the cell.
+ @param index The index of the cell.
 
  @return A cell dequeued from the reuse pool or a newly created one.
 
@@ -126,10 +126,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Dequeues a cell from the collection view reuse pool.
 
- @param nibName           The name of the nib file.
- @param bundle            The bundle in which to search for the nib file. If `nil`, this method searches the main bundle.
+ @param nibName The name of the nib file.
+ @param bundle The bundle in which to search for the nib file. If `nil`, this method searches the main bundle.
  @param sectionController The section controller requesting this information.
- @param index             The index of the cell.
+ @param index The index of the cell.
 
  @return A cell dequeued from the reuse pool or a newly created one.
 
@@ -143,9 +143,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Dequeues a storyboard prototype cell from the collection view reuse pool.
 
- @param identifier        The identifier of the cell prototype in storyboard.
+ @param identifier The identifier of the cell prototype in storyboard.
  @param sectionController The section controller requesting this information.
- @param index             The index of the cell.
+ @param index The index of the cell.
 
  @return A cell dequeued from the reuse pool or a newly created one.
  */
@@ -156,10 +156,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Dequeues a supplementary view from the collection view reuse pool.
 
- @param elementKind       The kind of supplementary view.
+ @param elementKind The kind of supplementary view.
  @param sectionController The section controller requesting this information.
- @param viewClass         The class of the supplementary view.
- @param index             The index of the supplementary view.
+ @param viewClass The class of the supplementary view.
+ @param index The index of the supplementary view.
 
  @return A supplementary view dequeued from the reuse pool or a newly created one.
 
@@ -173,10 +173,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Dequeues a supplementary view from the collection view reuse pool.
 
- @param elementKind       The kind of supplementary view.
- @param identifier        The identifier of the supplementary view in storyboard.
+ @param elementKind The kind of supplementary view.
+ @param identifier The identifier of the supplementary view in storyboard.
  @param sectionController The section controller requesting this information.
- @param index             The index of the supplementary view.
+ @param index The index of the supplementary view.
 
  @return A supplementary view dequeued from the reuse pool or a newly created one.
  */
@@ -187,11 +187,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Dequeues a supplementary view from the collection view reuse pool.
 
- @param elementKind       The kind of supplementary view.
+ @param elementKind The kind of supplementary view.
  @param sectionController The section controller requesting this information.
- @param nibName           The name of the nib file.
- @param bundle            The bundle in which to search for the nib file. If `nil`, this method searches the main bundle.
- @param index             The index of the supplementary view.
+ @param nibName The name of the nib file.
+ @param bundle The bundle in which to search for the nib file. If `nil`, this method searches the main bundle.
+ @param index The index of the supplementary view.
 
  @return A supplementary view dequeued from the reuse pool or a newly created one.
 
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
  Invalidate the backing `UICollectionViewLayout` for all items in the section controller.
 
  @param sectionController The section controller that needs invalidating.
- @param completion        An optional completion block to execute when the updates are finished.
+ @param completion An optional completion block to execute when the updates are finished.
 
  @note This method can be wrapped in `UIView` animation APIs to control the duration or perform without animations. This
  will end up calling `-[UICollectionView performBatchUpdates:completion:]` internally, so invalidated changes may not be
@@ -219,8 +219,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Batches and performs many cell-level updates in a single transaction.
 
- @param animated   A flag indicating if the transition should be animated.
- @param updates    A block with a context parameter to make mutations.
+ @param animated A flag indicating if the transition should be animated.
+ @param updates A block with a context parameter to make mutations.
  @param completion An optional completion block to execute when the updates are finished.
 
  @note You should make state changes that impact the number of items in your section controller within the updates
@@ -255,9 +255,9 @@ NS_ASSUME_NONNULL_BEGIN
  Scrolls to the specified section controller in the list.
 
  @param sectionController The section controller.
- @param index             The index of the item in the section controller to which to scroll.
- @param scrollPosition    An option that specifies where the item should be positioned when scrolling finishes.
- @param animated          A flag indicating if the scrolling should be animated.
+ @param index The index of the item in the section controller to which to scroll.
+ @param scrollPosition An option that specifies where the item should be positioned when scrolling finishes.
+ @param animated A flag indicating if the scrolling should be animated.
  */
 - (void)scrollToSectionController:(IGListSectionController<IGListSectionType> *)sectionController
                           atIndex:(NSInteger)index

--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -84,6 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
  Returns the visible paths for the given section controller.
  
  @param sectionController The section controller requesting this information.
+ 
  @return An array of visible index paths, or an empty array if none are found.
  */
 - (NSArray<NSIndexPath *> *)visibleIndexPathsForSectionController:(IGListSectionController<IGListSectionType> *) sectionController;

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -82,9 +82,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Create and return a new collection view layout.
 
- @param stickyHeaders   Set to `YES` to stick section headers to the top of the bounds while scrolling.
+ @param stickyHeaders Set to `YES` to stick section headers to the top of the bounds while scrolling.
  @param topContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
- @param stretchToEdge   Specifies whether to stretch width of last item to right edge when distance from last item to right edge < epsilon(1)
+ @param stretchToEdge Specifies whether to stretch width of last item to right edge when distance from last item to right edge < epsilon(1)
 
  @return A new collection view layout.
  */

--- a/Source/IGListDisplayDelegate.h
+++ b/Source/IGListDisplayDelegate.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the delegate that the specified section controller is about to be displayed.
 
- @param listAdapter       The list adapter for the section controller.
+ @param listAdapter The list adapter for the section controller.
  @param sectionController The section controller about to be displayed.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter willDisplaySectionController:(IGListSectionController <IGListSectionType> *)sectionController;
@@ -40,10 +40,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the delegate that a cell in the specified list is about to be displayed.
 
- @param listAdapter       The list adapter in which the cell will display.
+ @param listAdapter The list adapter in which the cell will display.
  @param sectionController The section controller that is displaying the cell.
- @param cell              The cell about to be displayed.
- @param index             The index of the cell in the section.
+ @param cell The cell about to be displayed.
+ @param index The index of the cell in the section.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter willDisplaySectionController:(IGListSectionController <IGListSectionType> *)sectionController
                cell:(UICollectionViewCell *)cell
@@ -52,10 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the delegate that a cell in the specified list is no longer being displayed.
 
- @param listAdapter       The list adapter in which the cell was displayed.
+ @param listAdapter The list adapter in which the cell was displayed.
  @param sectionController The section controller that is no longer displaying the cell.
- @param cell              The cell that is no longer displayed.
- @param index             The index of the cell in the section.
+ @param cell The cell that is no longer displayed.
+ @param index The index of the cell in the section.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter didEndDisplayingSectionController:(IGListSectionController <IGListSectionType> *)sectionController
                cell:(UICollectionViewCell *)cell

--- a/Source/IGListScrollDelegate.h
+++ b/Source/IGListScrollDelegate.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the delegate that the section controller was scrolled on screen.
 
- @param listAdapter       The list adapter whose collection view was scrolled.
+ @param listAdapter The list adapter whose collection view was scrolled.
  @param sectionController The visible section controller that was scrolled.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter didScrollSectionController:(IGListSectionController <IGListSectionType> *)sectionController;
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the delegate that the section controller will be dragged on screen.
 
- @param listAdapter       The list adapter whose collection view will drag.
+ @param listAdapter The list adapter whose collection view will drag.
  @param sectionController The visible section controller that will drag.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter willBeginDraggingSectionController:(IGListSectionController <IGListSectionType> *)sectionController;
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Tells the delegate that the section controller did end dragging on screen.
 
- @param listAdapter       The list adapter whose collection view ended dragging.
+ @param listAdapter The list adapter whose collection view ended dragging.
  @param sectionController The visible section controller that ended dragging.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter didEndDraggingSectionController:(IGListSectionController <IGListSectionType> *)sectionController willDecelerate:(BOOL)decelerate;

--- a/Source/IGListSingleSectionController.h
+++ b/Source/IGListSingleSectionController.h
@@ -27,7 +27,7 @@ typedef void (^IGListSingleSectionCellConfigureBlock)(id item, __kindof UICollec
 /**
  A block that returns the size for the cell given the collection context.
 
- @param item              The model for the section.
+ @param item The model for the section.
  @param collectionContext The collection context for the section.
 
  @return The size for the cell.
@@ -45,7 +45,7 @@ typedef CGSize (^IGListSingleSectionCellSizeBlock)(id item, id<IGListCollectionC
  Tells the delegate that the section controller was selected.
 
  @param sectionController The section controller that was selected.
- @param object            The model for the given section.
+ @param object The model for the given section.
  */
 - (void)didSelectSectionController:(IGListSingleSectionController *)sectionController
                         withObject:(id)object;
@@ -63,9 +63,9 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Creates a new section controller for a given cell type that will always have only one cell when present in a list.
  
- @param cellClass      The `UICollectionViewCell` subclass for the single cell.
+ @param cellClass The `UICollectionViewCell` subclass for the single cell.
  @param configureBlock A block that configures the cell with the item given to the section controller.
- @param sizeBlock      A block that returns the size for the cell given the collection context.
+ @param sizeBlock A block that returns the size for the cell given the collection context.
  
  @return A new section controller.
  
@@ -79,10 +79,10 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Creates a new section controller for a given nib name and bundle that will always have only one cell when present in a list.
  
- @param nibName        The name of the nib file for the single cell.
- @param bundle         The bundle in which to search for the nib file. If `nil`, this method looks for the file in the main bundle.
+ @param nibName The name of the nib file for the single cell.
+ @param bundle The bundle in which to search for the nib file. If `nil`, this method looks for the file in the main bundle.
  @param configureBlock A block that configures the cell with the item given to the section controller.
- @param sizeBlock      A block that returns the size for the cell given the collection context.
+ @param sizeBlock A block that returns the size for the cell given the collection context.
  
  @return A new section controller.
 
@@ -97,9 +97,9 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Creates a new section controller for a given storyboard cell identifier that will always have only one cell when present in a list.
  
- @param identifier     The identifier of the cell prototype in storyboard.
+ @param identifier The identifier of the cell prototype in storyboard.
  @param configureBlock A block that configures the cell with the item given to the section controller.
- @param sizeBlock      A block that returns the size for the cell given the collection context.
+ @param sizeBlock A block that returns the size for the cell given the collection context.
  
  @return A new section controller.
 

--- a/Source/IGListSupplementaryViewSource.h
+++ b/Source/IGListSupplementaryViewSource.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  Asks the SupplementaryViewSource for a configured supplementary view for the specified kind and index.
 
  @param elementKind The kind of supplementary view being requested
- @param index       The index for the supplementary veiw being requested.
+ @param index The index for the supplementary veiw being requested.
 
  @note This is your opportunity to do any supplementary view setup and configuration.
 
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  Asks the SupplementaryViewSource for the size of a supplementary view for the given kind and index path.
 
  @param elementKind The kind of supplementary view.
- @param index       The index of the requested view.
+ @param index The index of the requested view.
 
  @return The size for the supplementary view.
  */

--- a/Source/IGListUpdatingDelegate.h
+++ b/Source/IGListUpdatingDelegate.h
@@ -56,12 +56,12 @@ typedef void (^IGListReloadUpdateBlock)();
 /**
  Tells the delegate to perform a section transition from an old array of objects to a new one.
 
- @param collectionView        The collection view to perform the transition on.
- @param fromObjects           The previous objects in the collection view. Objects must conform to `IGListDiffable`.
- @param toObjects             The new objects in collection view. Objects must conform to `IGListDiffable`.
- @param animated              A flag indicating if the transition should be animated.
+ @param collectionView The collection view to perform the transition on.
+ @param fromObjects The previous objects in the collection view. Objects must conform to `IGListDiffable`.
+ @param toObjects The new objects in collection view. Objects must conform to `IGListDiffable`.
+ @param animated A flag indicating if the transition should be animated.
  @param objectTransitionBlock A block that must be called when the adapter applies changes to the collection view.
- @param completion            A completion block to execute when the update is finished.
+ @param completion A completion block to execute when the update is finished.
 
  @note Implementations determine how to transition between objects. You can perform a diff on the objects, reload
  each section, or simply call `-reloadData` on the collection view. In the end, the collection view must be setup with a
@@ -81,7 +81,7 @@ typedef void (^IGListReloadUpdateBlock)();
  Tells the delegate to perform item inserts at the given index paths.
 
  @param collectionView The collection view on which to perform the transition.
- @param indexPaths     The index paths to insert items into.
+ @param indexPaths The index paths to insert items into.
  */
 - (void)insertItemsIntoCollectionView:(UICollectionView *)collectionView indexPaths:(NSArray <NSIndexPath *> *)indexPaths;
 
@@ -89,7 +89,7 @@ typedef void (^IGListReloadUpdateBlock)();
  Tells the delegate to perform item deletes at the given index paths.
 
  @param collectionView The collection view on which to perform the transition.
- @param indexPaths     The index paths to delete items from.
+ @param indexPaths The index paths to delete items from.
  */
 - (void)deleteItemsFromCollectionView:(UICollectionView *)collectionView indexPaths:(NSArray <NSIndexPath *> *)indexPaths;
 
@@ -97,8 +97,8 @@ typedef void (^IGListReloadUpdateBlock)();
  Tells the delegate to move an item from and to given index paths.
 
  @param collectionView The collection view on which to perform the transition.
- @param fromIndexPath  The source index path of the item to move.
- @param toIndexPath    The destination index path of the item to move.
+ @param fromIndexPath The source index path of the item to move.
+ @param toIndexPath The destination index path of the item to move.
  */
 - (void)moveItemInCollectionView:(UICollectionView *)collectionView
                    fromIndexPath:(NSIndexPath *)fromIndexPath
@@ -107,9 +107,9 @@ typedef void (^IGListReloadUpdateBlock)();
 /**
  Completely reload data in the collection.
 
- @param collectionView    The collection view to reload.
+ @param collectionView The collection view to reload.
  @param reloadUpdateBlock A block that must be called when the adapter reloads the collection view.
- @param completion        A completion block to execute when the reload is finished.
+ @param completion A completion block to execute when the reload is finished.
  */
 - (void)reloadDataWithCollectionView:(UICollectionView *)collectionView
                    reloadUpdateBlock:(IGListReloadUpdateBlock)reloadUpdateBlock
@@ -119,7 +119,7 @@ typedef void (^IGListReloadUpdateBlock)();
  Completely reload each section in the collection view.
 
  @param collectionView The collection view to reload.
- @param sections       The sections to reload.
+ @param sections The sections to reload.
  */
 - (void)reloadCollectionView:(UICollectionView *)collectionView sections:(NSIndexSet *)sections;
 
@@ -127,9 +127,9 @@ typedef void (^IGListReloadUpdateBlock)();
  Perform an item update block in the collection view.
 
  @param collectionView The collection view to update.
- @param animated       A flag indicating if the transition should be animated.
- @param itemUpdates    A block containing all of the updates.
- @param completion     A completion block to execute when the update is finished.
+ @param animated A flag indicating if the transition should be animated.
+ @param itemUpdates A block containing all of the updates.
+ @param completion A completion block to execute when the update is finished.
  */
 - (void)performUpdateWithCollectionView:(UICollectionView *)collectionView
                                animated:(BOOL)animated

--- a/Source/IGListWorkingRangeDelegate.h
+++ b/Source/IGListWorkingRangeDelegate.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Notifies the delegate that an section controller will enter the working range.
 
- @param listAdapter       The adapter controlling the list.
+ @param listAdapter The adapter controlling the list.
  @param sectionController The section controller entering the range.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter sectionControllerWillEnterWorkingRange:(IGListSectionController <IGListSectionType> *)sectionController;
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Notifies the delegate that an section controller exited the working range.
 
- @param listAdapter       The adapter controlling the list.
+ @param listAdapter The adapter controlling the list.
  @param sectionController The section controller that exited the range.
  */
 - (void)listAdapter:(IGListAdapter *)listAdapter sectionControllerDidExitWorkingRange:(IGListSectionController <IGListSectionType> *)sectionController;

--- a/Source/Internal/IGListAdapterProxy.h
+++ b/Source/Internal/IGListAdapterProxy.h
@@ -26,8 +26,8 @@ IGLK_SUBCLASSING_RESTRICTED
  Create a new proxy object with targets and interceptor.
 
  @param collectionViewTarget A UICollectionViewDelegate conforming object that receives unintercepted messages.
- @param scrollViewTarget     A UIScrollViewDelegate conforming object that receives unintercepted messages.
- @param interceptor          An IGListAdapter object that intercepts a set of messages.
+ @param scrollViewTarget A UIScrollViewDelegate conforming object that receives unintercepted messages.
+ @param interceptor An IGListAdapter object that intercepts a set of messages.
 
  @return A new IGListAdapterProxy object.
  */

--- a/Source/Internal/IGListDisplayHandler.h
+++ b/Source/Internal/IGListDisplayHandler.h
@@ -24,11 +24,11 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a cell will be displayed in the IGListAdapter.
 
- @param cell              A cell that will be displayed.
- @param listAdapter       The adapter the cell will display in.
+ @param cell A cell that will be displayed.
+ @param listAdapter The adapter the cell will display in.
  @param sectionController The section controller that manages the cell.
- @param object            The object that powers the section controller.
- @param indexPath         The index path of the cell in the UICollectionView.
+ @param object The object that powers the section controller.
+ @param indexPath The index path of the cell in the UICollectionView.
  */
 - (void)willDisplayCell:(UICollectionViewCell *)cell
          forListAdapter:(IGListAdapter *)listAdapter
@@ -39,10 +39,10 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a cell did end display in the IGListAdapter.
 
- @param cell              A cell that will be displayed.
- @param listAdapter       The adapter the cell will display in.
+ @param cell A cell that will be displayed.
+ @param listAdapter The adapter the cell will display in.
  @param sectionController The section controller that manages the cell.
- @param indexPath         The index path of the cell in the UICollectionView.
+ @param indexPath The index path of the cell in the UICollectionView.
  */
 - (void)didEndDisplayingCell:(UICollectionViewCell *)cell
               forListAdapter:(IGListAdapter *)listAdapter
@@ -53,11 +53,11 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a supplementary view will be displayed in the IGListAdapter.
 
- @param view              A supplementary view that will be displayed.
- @param listAdapter       The adapter the supplementary view will display in.
+ @param view A supplementary view that will be displayed.
+ @param listAdapter The adapter the supplementary view will display in.
  @param sectionController The section controller that manages the supplementary view.
- @param object            The object that powers the section controller.
- @param indexPath         The index path of the supplementary view in the UICollectionView.
+ @param object The object that powers the section controller.
+ @param indexPath The index path of the supplementary view in the UICollectionView.
  */
 - (void)willDisplaySupplementaryView:(UICollectionReusableView *)view
                       forListAdapter:(IGListAdapter *)listAdapter
@@ -69,10 +69,10 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Tells the handler that a supplementary view did end display in the IGListAdapter.
 
- @param view              A supplementary view that will be displayed.
- @param listAdapter       The adapter the supplementary view will display in.
+ @param view A supplementary view that will be displayed.
+ @param listAdapter The adapter the supplementary view will display in.
  @param sectionController The section controller that manages the supplementary view.
- @param indexPath         The index path of the supplementary view in the UICollectionView.
+ @param indexPath The index path of the supplementary view in the UICollectionView.
  */
 - (void)didEndDisplayingSupplementaryView:(UICollectionReusableView *)view
                            forListAdapter:(IGListAdapter *)listAdapter

--- a/Source/Internal/IGListSectionMap.h
+++ b/Source/Internal/IGListSectionMap.h
@@ -35,7 +35,7 @@ IGLK_SUBCLASSING_RESTRICTED
 /**
  Update the map with objects and the section controller counterparts.
 
- @param objects            The objects in the collection.
+ @param objects The objects in the collection.
  @param sectionControllers The section controllers that map to each object.
  */
 - (void)updateWithObjects:(NSArray <id <NSObject>> *)objects sectionControllers:(NSArray <id <NSObject>> *)sectionControllers;

--- a/Source/Internal/IGListWorkingRangeHandler.h
+++ b/Source/Internal/IGListWorkingRangeHandler.h
@@ -26,7 +26,7 @@
 /**
  Tells the handler that a cell will be displayed in the IGListKit infra.
 
- @param indexPath   The index path of the cell in the UICollectionView.
+ @param indexPath The index path of the cell in the UICollectionView.
  @param listAdapter The adapter managing the infra.
  */
 - (void)willDisplayItemAtIndexPath:(NSIndexPath *)indexPath
@@ -35,7 +35,7 @@
 /**
  Tells the handler that a cell did end display in the IGListKit infra.
 
- @param indexPath   The index path of the cell in the UICollectionView.
+ @param indexPath The index path of the cell in the UICollectionView.
  @param listAdapter The adapter managing the infra.
  */
 - (void)didEndDisplayingItemAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #655

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)

I've also addressed a few cases where there was no empty line between the `@param`s and `@return`.