### PR TITLE
fix NSProxy init

### DIFF
--- a/Source/Internal/IGListAdapterProxy.h
+++ b/Source/Internal/IGListAdapterProxy.h
@@ -33,7 +33,7 @@ IGLK_SUBCLASSING_RESTRICTED
  */
 - (instancetype)initWithCollectionViewTarget:(nullable id<UICollectionViewDelegate>)collectionViewTarget
                             scrollViewTarget:(nullable id<UIScrollViewDelegate>)scrollViewTarget
-                                 interceptor:(IGListAdapter *)interceptor NS_DESIGNATED_INITIALIZER;
+                                 interceptor:(IGListAdapter *)interceptor;
 
 /**
  :nodoc:


### PR DESCRIPTION
`NSProxy` doesn't define `init` because it's abstract.

designated init requires a call to super designated init (which doesn't exist for NSProxy)

sweet

broken in #662 

lol