### PR TITLE
Fix empty cells on fast scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 ### Fixes
 
+- Added protection from this kind of bug in `UICollectionView` - [Bug description](http://stackoverflow.com/a/13389461/377384). In certain conditions: when section insets, lineSpacing and interItemSpacing are set, when scroll fast blocks of cells are disappearing from collectionView. I added check that exactly two consecutive elements are out of rect - only in this case enumeration of attributes in `layoutAttributesForItemAtIndexPath` will be stopped.
+
 - Gracefully handle a `nil` section controller returned by an `IGListAdapterDataSource`. [Ryan Nystrom](https://github.com/rnystrom) [(#488)](https://github.com/Instagram/IGListKit/pull/488)
 
 - Fix bug where emptyView's hidden status is not updated after the number of items is changed with `insertInSectionController:atIndexes:` or related methods. [Peter Edmonston](https://github.com/edmonston) [(#395)](https://github.com/Instagram/IGListKit/pull/395)


### PR DESCRIPTION
Added protection from this kind of bug in _UICollectionView_ - [Bug description on stackoverflow](http://stackoverflow.com/a/13389461/377384). In certain conditions (when section insets, lineSpacing and interItemSpacing are set) when one scrolls fast then blocks of cells are disappearing from _CollectionView_. In my case almost 40 cells were dissapeared.
It happens because in _layoutAttributesForItemAtIndexPath_ enumeration of cells stops on first cell out that is of _rect_, but on above conditions _CollectionView_ provide us with duplicate cell attribute that is out of _rect_, so at this moment function stops enumerating and returns resulting array with not all cells.
I added check that if exactly two consecutive elements are out of rect - only in this case algorithm stops enumeration. It fixes above bug.

Can't add a test for this changes without huge rewriting of _layoutAttributesForElementsInRect_ because attributes comes from intrinsic function - _layoutAttributesForItemAtIndexPath_ and I can't change them.

## Changes in this pull request

Issue fixed: #

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
