### PR TITLE
Invalidate layout when collection view reused between IGListAdapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - `IGListSectionType` protocol was removed and its methods were absorted into the `IGListSectionController` base class with default implementations. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
 
+- When setting the collection view on `IGListAdapter`, its layout is now properly invalidated. [Jesse Squires](https://github.com/jessesquires) [(#677)](https://github.com/Instagram/IGListKit/pull/677)
+
 2.1.0
 -----
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -83,6 +83,7 @@
 
         _collectionView = collectionView;
         _collectionView.dataSource = self;
+        [_collectionView.collectionViewLayout invalidateLayout];
 
         [self updateCollectionViewDelegate];
         [self updateAfterPublicSettingsChange];


### PR DESCRIPTION
Closes #659 