### PR TITLE
Balance reload delete and insert calls

### DIFF
--- a/Source/IGListAdapterUpdater.m
+++ b/Source/IGListAdapterUpdater.m
@@ -286,6 +286,8 @@ void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
             [reloadInsertPaths addObject:reload.toIndexPath];
         }
     }
+    [itemDeletes addObjectsFromArray:[reloadDeletePaths allObjects]];
+    [itemInserts addObjectsFromArray:[reloadInsertPaths allObjects]];
 
     IGListBatchUpdateData *updateData = [[IGListBatchUpdateData alloc] initWithInsertSections:inserts
                                                                                deleteSections:deletes

--- a/Source/IGListAdapterUpdater.m
+++ b/Source/IGListAdapterUpdater.m
@@ -278,10 +278,12 @@ void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
     NSMutableArray<IGListMoveIndexPath *> *itemMoves = batchUpdates.itemMoves;
 
     NSSet<NSIndexPath *> *uniqueDeletes = [NSSet setWithArray:itemDeletes];
+    NSMutableSet<NSIndexPath *> *reloadDeletePaths = [NSMutableSet new];
+    NSMutableSet<NSIndexPath *> *reloadInsertPaths = [NSMutableSet new];
     for (IGListReloadIndexPath *reload in batchUpdates.itemReloads) {
         if (![uniqueDeletes containsObject:reload.fromIndexPath]) {
-            [itemDeletes addObject:reload.fromIndexPath];
-            [itemInserts addObject:reload.toIndexPath];
+            [reloadDeletePaths addObject:reload.fromIndexPath];
+            [reloadInsertPaths addObject:reload.toIndexPath];
         }
     }
 

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1460,5 +1460,24 @@
     [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
+- (void)test_whenReloadingSameItemTwice_thatDeletesAndInsertsAreBalanced {
+    [self setupWithObjects:@[
+                             genTestObject(@1, @4),
+                             ]];
+
+    IGTestObject *object = self.dataSource.objects[0];
+    IGListSectionController *sectionController = [self.adapter sectionControllerForObject:object];
+
+    XCTestExpectation *expectation = genExpectation;
+    [sectionController.collectionContext performBatchAnimated:YES updates:^(id<IGListBatchContext> batchContext) {
+        [batchContext reloadInSectionController:sectionController atIndexes:[NSIndexSet indexSetWithIndex:0]];
+        [batchContext reloadInSectionController:sectionController atIndexes:[NSIndexSet indexSetWithIndex:0]];
+    } completion:^(BOOL finished2) {
+        XCTAssertEqual([self.collectionView numberOfSections], 1);
+        XCTAssertEqual([self.collectionView numberOfItemsInSection:0], 4);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:30 handler:nil];
+}
 
 @end


### PR DESCRIPTION
## Changes in this pull request

In https://github.com/Instagram/IGListKit/commit/073fc073e03c09abfeca022173e9d063d513e137 we deduped delete calls, but since we convert reloads into delete+insert when only deduping deletes, we end up with unbalanced delete+insert calls.

Unit test added reproduced a crash we see internally. Fix passes the test.

Not adding a changelog entry since this is a new regression fixed between releases. #trivial

Issue fixed: t17539856

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.