### PR TITLE
Fixes sizeForSupplementaryViewOfKind always at index=0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - When setting the collection view on `IGListAdapter`, its layout is now properly invalidated. [Jesse Squires](https://github.com/jessesquires) [(#677)](https://github.com/Instagram/IGListKit/pull/677)
 
+- `IGListSupplementaryViewSource` is now able to receive section indexes different than 0.
+
 2.1.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,7 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - When setting the collection view on `IGListAdapter`, its layout is now properly invalidated. [Jesse Squires](https://github.com/jessesquires) [(#677)](https://github.com/Instagram/IGListKit/pull/677)
 
-- `IGListSupplementaryViewSource` is now able to receive section indexes different than 0.
+- Fixed a bug in `IGListSupplementaryViewSource` where it would always have a section index of 0. [Marcelo Gobetti](https://github.com/gobetti) [(#715)](https://github.com/Instagram/IGListKit/pull/715)
 
 2.1.0
 -----

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -474,7 +474,7 @@
     IGAssertMainThread();
     id <IGListSupplementaryViewSource> supplementaryViewSource = [self supplementaryViewSourceAtIndexPath:indexPath];
     if ([[supplementaryViewSource supportedElementKinds] containsObject:elementKind]) {
-        const CGSize size = [supplementaryViewSource sizeForSupplementaryViewOfKind:elementKind atIndex:indexPath.item];
+        const CGSize size = [supplementaryViewSource sizeForSupplementaryViewOfKind:elementKind atIndex:indexPath.section];
         return CGSizeMake(MAX(size.width, 0.0), MAX(size.height, 0.0));
     }
     return CGSizeZero;

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -1067,6 +1067,24 @@
     XCTAssertEqual(size.height, 0.0);
 }
 
+- (void)test_whenSectionIndexGreaterThanZero_thatAdapterReturnsSizeForSectionIndexesGreaterThanZero {
+  self.dataSource.objects = @[@1];
+  [self.adapter reloadDataWithCompletion:nil];
+  
+  IGTestSupplementarySource *supplementarySource = [IGTestSupplementarySource new];
+  supplementarySource.collectionContext = self.adapter;
+  supplementarySource.supportedElementKinds = @[UICollectionElementKindSectionFooter];
+  
+  IGListSectionController *controller = [self.adapter sectionControllerForObject:@1];
+  controller.supplementaryViewSource = supplementarySource;
+  supplementarySource.sectionController = controller;
+  
+  const CGSize size = [self.adapter sizeForSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                                       atIndexPath:[NSIndexPath indexPathForItem:0 inSection:1]];
+  XCTAssertEqual(size.width, supplementarySource.sizeForSectionIndexesGreaterThanZero.width);
+  XCTAssertEqual(size.height, supplementarySource.sizeForSectionIndexesGreaterThanZero.height);
+}
+
 - (void)test_whenQueryingContainerInset_thatMatchesCollectionView {
     self.dataSource.objects = @[@2];
     [self.adapter reloadDataWithCompletion:nil];

--- a/Tests/Objects/IGTestSupplementarySource.h
+++ b/Tests/Objects/IGTestSupplementarySource.h
@@ -17,6 +17,8 @@
 
 @property (nonatomic, assign) CGSize size;
 
+@property (nonatomic, assign) CGSize sizeForSectionIndexesGreaterThanZero;
+
 @property (nonatomic, strong, readwrite) NSArray<NSString *> *supportedElementKinds;
 
 @property (nonatomic, weak) id<IGListCollectionContext> collectionContext;

--- a/Tests/Objects/IGTestSupplementarySource.m
+++ b/Tests/Objects/IGTestSupplementarySource.m
@@ -16,6 +16,7 @@
 - (instancetype)init {
     if (self = [super init]) {
         _size = CGSizeMake(100, 10);
+        _sizeForSectionIndexesGreaterThanZero = CGSizeMake(100, 20);
     }
     return self;
 }
@@ -41,6 +42,9 @@
 }
 
 - (CGSize)sizeForSupplementaryViewOfKind:(NSString *)elementKind atIndex:(NSInteger)index {
+    if (index > 0) {
+      return self.sizeForSectionIndexesGreaterThanZero;
+    }
     return self.size;
 }
 


### PR DESCRIPTION
An `NSIndexPath` is being built from IGListAdapter+UICollectionView.m
before being passed to
`-[IGListSupplementaryViewSource sizeForSupplementaryViewOfKind:atIndex:]`
however this later is taking the `item` instead of the `section` -
resulting in the index always being equal to 0, even for section
indexes > 0.

## Changes in this pull request

Issue fixed: #714

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
