### PR TITLE
Fix reusing collection views among multiple adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - When setting the collection view on `IGListAdapter`, its layout is now properly invalidated. [Jesse Squires](https://github.com/jessesquires) [(#677)](https://github.com/Instagram/IGListKit/pull/677)
 
+- Fixes a bug when reusing `UICollectionView`s with multiple `IGListAdapter`s in an embedded environment that would accidentally `nil` the `collectionView` property of another adapter. [Ryan Nystrom](https://github.com/rnystrom) [(#721)](https://github.com/Instagram/IGListKit/pull/721)
+
 2.1.0
 -----
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -81,6 +81,7 @@
         if (globalCollectionViewAdapterMap == nil) {
             globalCollectionViewAdapterMap = [NSMapTable weakToWeakObjectsMapTable];
         }
+        [globalCollectionViewAdapterMap removeObjectForKey:_collectionView];
         [[globalCollectionViewAdapterMap objectForKey:collectionView] setCollectionView:nil];
         [globalCollectionViewAdapterMap setObject:self forKey:collectionView];
 

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -1214,4 +1214,38 @@
     XCTAssertEqual([wAdapter sectionForSectionController:sc], 0);
 }
 
+- (void)test_whenSwappingCollectionViews_withMultipleAdapters_thatDoesntNilOtherAdaptersCollectionView {
+    IGListTestAdapterDataSource *dataSource1 = [IGListTestAdapterDataSource new];
+    IGListAdapter *adapter1 = [[IGListAdapter alloc] initWithUpdater:[IGListAdapterUpdater new] viewController:nil];
+    adapter1.dataSource = dataSource1;
+
+    IGListTestAdapterDataSource *dataSource2 = [IGListTestAdapterDataSource new];
+    IGListAdapter *adapter2 = [[IGListAdapter alloc] initWithUpdater:[IGListAdapterUpdater new] viewController:nil];
+    adapter2.dataSource = dataSource2;
+
+    UICollectionView *collectionView1 = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:[UICollectionViewFlowLayout new]];
+    UICollectionView *collectionView2 = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:[UICollectionViewFlowLayout new]];
+
+    adapter1.collectionView = collectionView1;
+    adapter2.collectionView = collectionView2;
+
+    XCTAssertEqual(adapter1.collectionView, collectionView1);
+    XCTAssertEqual(collectionView1.dataSource, adapter1);
+    XCTAssertEqual(adapter2.collectionView, collectionView2);
+    XCTAssertEqual(collectionView2.dataSource, adapter2);
+
+    adapter2.collectionView = collectionView1;
+
+    XCTAssertEqual(adapter2.collectionView, collectionView1);
+    XCTAssertEqual(collectionView1.dataSource, adapter2);
+    XCTAssertNil(adapter1.collectionView);
+
+    adapter1.collectionView = collectionView2;
+
+    XCTAssertEqual(adapter1.collectionView, collectionView2);
+    XCTAssertEqual(collectionView2.dataSource, adapter1);
+    XCTAssertEqual(adapter2.collectionView, collectionView1);
+    XCTAssertEqual(collectionView1.dataSource, adapter2);
+}
+
 @end


### PR DESCRIPTION
## Changes in this pull request

When multiple `UICollectionView`s are reused among multiple `IGListAdapter`s (horizontal lists embedded in a bigger, vertical list), the mapping between the old view and adapter is not broken. When a new collection view is attached to the old adapter, an unrelated adapter->collection view reference will be erroneously broken.

The unit test in this diff fails on the second `XCTAssertEqual(adapter2.collectionView, collectionView1);` without this patch.

Issue fixed: #699

t15661237 internally

cc @amonshiz since we were talking about this

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.