### PR TITLE
Reset all section controllers when a list adapter is deallocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ This release closes the [3.0.0 milestone](https://github.com/Instagram/IGListKit
 
 - Fixes a bug when reusing `UICollectionView`s with multiple `IGListAdapter`s in an embedded environment that would accidentally `nil` the `collectionView` property of another adapter. [Ryan Nystrom](https://github.com/rnystrom) [(#721)](https://github.com/Instagram/IGListKit/pull/721)
 
+- Fixes a bug where maintaining a reference to a section controller but not the list adapter in an async block could lead to calling `-[IGListAdapter sectionForSectionController:]` (or checking `-[IGListSectionController sectionIndex]`) and receiving an incorrect value. With the adapter check the value would be 0 because the adapter was `nil` and for the section controller property the value would be the last set index value. [Andrew Monshizadeh](https://github.com/amonshiz) [(#709)](https://github.com/Instagram/IGListKit/issues/709)
+
 2.1.0
 -----
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -27,6 +27,8 @@
         _collectionView.dataSource = nil;
         _collectionView.delegate = nil;
     }
+
+    [self.sectionMap reset];
 }
 
 

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -1210,7 +1210,8 @@
         XCTAssertEqual(sc.sectionIndex, 1);
     }
 
-    XCTAssertEqual(sc.sectionIndex, 1);
+    XCTAssertEqual(sc.sectionIndex, NSNotFound);
+    // This will be 0 because wAdapter should be nil and so nil messaging will return 0
     XCTAssertEqual([wAdapter sectionForSectionController:sc], 0);
 }
 


### PR DESCRIPTION
This change will ensure that section controllers have the following properties reset to sensible default values when their owning list adapter is deallocated.

```
isFirstSection = NO
isLastSection = NO
sectionIndex = NSNotFound
```

Issue fixed: #709

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested. (Existing test is updated to ensure this doesn't regress)
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
