### PR TITLE
Fixed typos around 'dequeing'

### DIFF
--- a/Source/IGListCollectionContext.h
+++ b/Source/IGListCollectionContext.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  The collection context provides limited access to the collection-related information that
- section controllers need for operations like sizing, dequeing cells, insterting, deleting, reloading, etc.
+ section controllers need for operations like sizing, dequeuing cells, insterting, deleting, reloading, etc.
  */
 NS_SWIFT_NAME(ListCollectionContext)
 @protocol IGListCollectionContext <NSObject>

--- a/Source/IGListSectionController.h
+++ b/Source/IGListSectionController.h
@@ -94,7 +94,7 @@ NS_SWIFT_NAME(ListSectionController)
 /**
  A context object for interacting with the collection. 
  
- Use this property for accessing the collection size, dequeing cells, reloading, inserting, deleting, etc.
+ Use this property for accessing the collection size, dequeuing cells, reloading, inserting, deleting, etc.
  */
 @property (nonatomic, weak, nullable, readonly) id <IGListCollectionContext> collectionContext;
 


### PR DESCRIPTION
This reverts commit cc039179502b8992da38bfdd984389ace5ebd294.

## Changes in this pull request

Issue fixed: #772 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
