### PR TITLE
Amend swiftlint to work with older installations

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -797,7 +797,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint lint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		DEB8B682C7C0C2DA4D507589 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Examples/Examples-macOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-macOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -269,7 +269,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint lint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Examples/Examples-tvOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-tvOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -275,7 +275,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint lint --config ../.swiftlint.yml\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/15193942/26492070/41f53338-420a-11e7-8ed6-f5d9872338c4.png)

Noticed an issue when trying to build the examples project that I couldn't because of the Swiftlint build phase (see the image above)

As it turns out in between the version I have installed (0.16.1) and the latest (0.19.0) they've made it so you can drop `lint` from the command (which is the default task).

I see two options really:
1. We add `lint` to the command which at least lets older versions of Swiftlint compile the project without making changes to run phases. It's worth noting that this means that certain (newer) rules won't be detected.
2. We add a way of detecting if they have an older version (likely by comparing the output of `$(swiftlint version)` to the version we know it works on. And display a more appropriate message and not fail the build.

Happy to discuss this

@heshamsalman @jessesquires @rnystrom 