### PR TITLE
Don't assert indexForCell: API when cell isn't visible

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -726,7 +726,8 @@
     IGParameterAssert(cell != nil);
     IGParameterAssert(sectionController != nil);
     NSIndexPath *indexPath = [self.collectionView indexPathForCell:cell];
-    IGAssert(indexPath.section == [self sectionForSectionController:sectionController],
+    IGAssert(indexPath == nil
+             || indexPath.section == [self sectionForSectionController:sectionController],
              @"Requesting a cell from another section controller is not allowed.");
     return indexPath != nil ? indexPath.item : NSNotFound;
 }


### PR DESCRIPTION
Noticed this randomly debugging. Say you have a completion block that finishes after some async task happens. If you scroll the cell off screen it will return `nil` for `-[UICollectionView indexPathForCell:]`, and the assert will fail (unless the SC is at 0). Quiet some asserts.