### PR TITLE
Compare using FLT_EPSILON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 The changelog for `IGListKit`. Also see the [releases](https://github.com/instagram/IGListKit/releases) on GitHub.
 
 3.1.0 (**upcoming release**)
+
+### Fixes
+
+- `IGListCollectionViewLayout` now uses `FLT_EPSILON` for comparison between element width and collection view width. This is to deal with float point precision loss during some calculations. [Andrew Monshizadeh](https://github.com/amonshiz) [(#828)](https://github.com/Instagram/IGListKit/pull/828)
+
 -----
 
 3.0.0

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -361,7 +361,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
             const CGSize size = [delegate collectionView:collectionView layout:self sizeForItemAtIndexPath:indexPath];
 
-            IGAssert(size.width <= paddedWidth, @"Width of item %zi in section %zi must be less than container %.0f accounting for section insets %@",
+            IGAssert(fabs(size.width - paddedWidth) < FLT_EPSILON, @"Width of item %zi in section %zi must be less than container %.0f accounting for section insets %@",
                      item, section, width, NSStringFromUIEdgeInsets(insets));
             CGFloat itemWidth = MIN(size.width, paddedWidth);
 

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -353,15 +353,16 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         // add the left inset in case the section falls on the same row as the previous
         // if the section is newlined then the x is reset
         itemX += insets.left;
-        
+
         // the farthest right the frame of an item in this section can go
         const CGFloat maxX = width - insets.right;
-        
+
         for (NSInteger item = 0; item < itemCount; item++) {
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
             const CGSize size = [delegate collectionView:collectionView layout:self sizeForItemAtIndexPath:indexPath];
 
-            IGAssert(fabs(size.width - paddedWidth) < FLT_EPSILON, @"Width of item %zi in section %zi must be less than container %.0f accounting for section insets %@",
+            IGAssert(size.width <= paddedWidth || fabs(size.width - paddedWidth) < FLT_EPSILON,
+                     @"Width of item %zi in section %zi must be less than container %.0f accounting for section insets %@",
                      item, section, width, NSStringFromUIEdgeInsets(insets));
             CGFloat itemWidth = MIN(size.width, paddedWidth);
 
@@ -380,7 +381,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
                     itemY += lineSpacing;
                 }
             }
-            
+
             const CGFloat distanceToRighEdge = paddedWidth - (itemX + itemWidth);
             if (self.stretchToEdge && distanceToRighEdge > 0 && distanceToRighEdge <= epsilon) {
                 itemWidth = paddedWidth - itemX;
@@ -446,7 +447,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
             }
         }
     }
-    
+
     return result;
 }
 


### PR DESCRIPTION
Floating point math loses precision and so comparing two floats that are likely to only differ in the mantissa, and even then by extremely small amounts, is tricky. Exact equality often fails in these cases and asserting on exact equality is probably not necessary.