### PR TITLE
Fixed the issue with the Search example not working

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
@@ -21,12 +21,13 @@ final class SearchViewController: UIViewController, ListAdapterDataSource, Searc
         return ListAdapter(updater: ListAdapterUpdater(), viewController: self)
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-    lazy var words: [String] = {
+    lazy var words: Set<String> = {
+        // swiftlint:disable:next
         let str = "Humblebrag skateboard tacos viral small batch blue bottle, schlitz fingerstache etsy squid. Listicle tote bag helvetica XOXO literally, meggings cardigan kickstarter roof party deep v selvage scenester venmo truffaut. You probably haven't heard of them fanny pack austin next level 3 wolf moon. Everyday carry offal brunch 8-bit, keytar banjo pinterest leggings hashtag wolf raw denim butcher. Single-origin coffee try-hard echo park neutra, cornhole banh mi meh austin readymade tacos taxidermy pug tattooed. Cold-pressed +1 ethical, four loko cardigan meh forage YOLO health goth sriracha kale chips. Mumblecore cardigan humblebrag, lo-fi typewriter truffaut leggings health goth."
-        var words = [String]()
+        var words = Set<String>()
         let range = str.startIndex ..< str.endIndex
         str.enumerateSubstrings(in: range, options: .byWords) { (substring, _, _, _) in
-            words.append(substring!)
+            words.insert(substring!)
         }
         return words
     }()

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
@@ -22,7 +22,7 @@ final class SearchViewController: UIViewController, ListAdapterDataSource, Searc
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     lazy var words: [String] = {
-        let str = "Humblebrag skateboard tacos viral small batch blue bottle, schlitz fingerstache etsy squid. Listicle tote bag helvetica XOXO literally, meggings cardigan kickstarter roof party deep v selvage scenester venmo truffaut. You probably haven't heard of them fanny pack austin next level 3 wolf moon. Everyday carry offal brunch 8-bit, keytar banjo pinterest leggings hashtag raw denim butcher. Single-origin coffee try-hard echo park neutra, cornhole banh mi meh  readymade taxidermy pug tattooed. Cold-pressed +1 ethical, four loko forage YOLO health goth sriracha kale chips. Mumblecore humblebrag, lo-fi typewriter."
+        let str = "Humblebrag skateboard tacos viral small batch blue bottle, schlitz fingerstache etsy squid. Listicle tote bag helvetica XOXO literally, meggings cardigan kickstarter roof party deep v selvage scenester venmo truffaut. You probably haven't heard of them fanny pack austin next level 3 wolf moon. Everyday carry offal brunch 8-bit, keytar banjo pinterest leggings hashtag wolf raw denim butcher. Single-origin coffee try-hard echo park neutra, cornhole banh mi meh austin readymade tacos taxidermy pug tattooed. Cold-pressed +1 ethical, four loko cardigan meh forage YOLO health goth sriracha kale chips. Mumblecore cardigan humblebrag, lo-fi typewriter truffaut leggings health goth."
         var words = [String]()
         let range = str.startIndex ..< str.endIndex
         str.enumerateSubstrings(in: range, options: .byWords) { (substring, _, _, _) in

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/SearchViewController.swift
@@ -22,7 +22,7 @@ final class SearchViewController: UIViewController, ListAdapterDataSource, Searc
     }()
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     lazy var words: [String] = {
-        let str = "Humblebrag skateboard tacos viral small batch blue bottle, schlitz fingerstache etsy squid. Listicle tote bag helvetica XOXO literally, meggings cardigan kickstarter roof party deep v selvage scenester venmo truffaut. You probably haven't heard of them fanny pack austin next level 3 wolf moon. Everyday carry offal brunch 8-bit, keytar banjo pinterest leggings hashtag wolf raw denim butcher. Single-origin coffee try-hard echo park neutra, cornhole banh mi meh austin readymade tacos taxidermy pug tattooed. Cold-pressed +1 ethical, four loko cardigan meh forage YOLO health goth sriracha kale chips. Mumblecore cardigan humblebrag, lo-fi typewriter truffaut leggings health goth."
+        let str = "Humblebrag skateboard tacos viral small batch blue bottle, schlitz fingerstache etsy squid. Listicle tote bag helvetica XOXO literally, meggings cardigan kickstarter roof party deep v selvage scenester venmo truffaut. You probably haven't heard of them fanny pack austin next level 3 wolf moon. Everyday carry offal brunch 8-bit, keytar banjo pinterest leggings hashtag raw denim butcher. Single-origin coffee try-hard echo park neutra, cornhole banh mi meh  readymade taxidermy pug tattooed. Cold-pressed +1 ethical, four loko forage YOLO health goth sriracha kale chips. Mumblecore humblebrag, lo-fi typewriter."
         var words = [String]()
         let range = str.startIndex ..< str.endIndex
         str.enumerateSubstrings(in: range, options: .byWords) { (substring, _, _, _) in


### PR DESCRIPTION
I have updated the Search Autocomplete example which stopped working as the words don't have unique `diffIdentifier`'s. This caused by the check that good introduced to ensure all objects assigned to a section controller are unique. Fixed this issue by removing all the double words.

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)