### PR TITLE
RFC: Diff in the background

### DIFF
--- a/Source/Common/IGListExperiments.h
+++ b/Source/Common/IGListExperiments.h
@@ -18,6 +18,8 @@ NS_SWIFT_NAME(ListExperiment)
 typedef NS_OPTIONS (NSInteger, IGListExperiment) {
     /// Specifies no experiments.
     IGListExperimentNone = 1 << 1,
+    /// Test updater diffing performed on a background queue.
+    IGListExperimentBackgroundDiffing = 1 << 2,
 };
 
 /**


### PR DESCRIPTION
Experimenting with a new change. We have observed instances of very large (3k+) lists stalling, even on modern devices. This is especially noticeable if the models being diffed are:

- Immutable
- `performUpdates:` often and models are alloc/init'd each time
- The `isEqualToDiffableObject:` is sort of expensive (many `-[NSString isEqualToString:]` across thousands of models or something)

Instead of just rolling this out, I plan on experimenting with results and seeing how much of a performance and stability boost we gain w/ this. Things to measure:

- Scroll performance
- CPU stalls
- WatchDog kills on older devices