### PR TITLE
Add horizontal scrolling support to IGListCollectionViewLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 ### Breaking Changes
 
-- Added horizontal scrolling direction to `IGListCollectionViewLayout` and added `scrollDirection:` to initializer; renamed some properties to reflect more-generalized behavior. [Peter Edmonston](https://github.com/edmonston) 
+- Added horizontal scrolling direction to `IGListCollectionViewLayout` and added `scrollDirection:` to initializer; renamed some properties to reflect more-generalized behavior. [Peter Edmonston](https://github.com/edmonston)  [(#857)](https://github.com/Instagram/IGListKit/pull/857)
 
 3.1.0 (**upcoming release**)
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,16 @@
 
 The changelog for `IGListKit`. Also see the [releases](https://github.com/instagram/IGListKit/releases) on GitHub.
 
-4.0.0
------
-
-### Breaking Changes
-
-- Added horizontal scrolling direction to `IGListCollectionViewLayout` and added `scrollDirection:` to initializer; renamed some properties to reflect more-generalized behavior. [Peter Edmonston](https://github.com/edmonston)  [(#857)](https://github.com/Instagram/IGListKit/pull/857)
-
 3.1.0 (**upcoming release**)
 -----
 
 ### Fixes
 
 - Prevent a crash when update queued immediately after item batch update. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
+
+### Enhancements
+
+- Added horizontal scrolling support to `IGListCollectionViewLayout`. [Peter Edmonston](https://github.com/edmonston)  [(#857)](https://github.com/Instagram/IGListKit/pull/857)
 
 3.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `IGListKit`. Also see the [releases](https://github.com/instagram/IGListKit/releases) on GitHub.
 
+4.0.0
+-----
+
+### Breaking Changes
+
+- Added horizontal scrolling direction to `IGListCollectionViewLayout` and added `scrollDirection:` to initializer; renamed some properties to reflect more-generalized behavior. [Peter Edmonston](https://github.com/edmonston) 
+
 3.1.0 (**upcoming release**)
 -----
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
@@ -22,7 +22,7 @@ final class CalendarViewController: UIViewController, ListAdapterDataSource {
     }()
     let collectionView = UICollectionView(
         frame: .zero,
-        collectionViewLayout: ListCollectionViewLayout(stickyHeaders: false, scrollDirection: .vertical, initialContentInset: 0, stretchToEdge: false)
+        collectionViewLayout: ListCollectionViewLayout(stickyHeaders: false, topContentInset: 0, stretchToEdge: false)
     )
 
     var months = [Month]()

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/CalendarViewController.swift
@@ -22,7 +22,7 @@ final class CalendarViewController: UIViewController, ListAdapterDataSource {
     }()
     let collectionView = UICollectionView(
         frame: .zero,
-        collectionViewLayout: ListCollectionViewLayout(stickyHeaders: false, topContentInset: 0, stretchToEdge: false)
+        collectionViewLayout: ListCollectionViewLayout(stickyHeaders: false, scrollDirection: .vertical, initialContentInset: 0, stretchToEdge: false)
     )
 
     var months = [Month]()

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -71,25 +71,33 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
 @interface IGListCollectionViewLayout : UICollectionViewLayout
 
 /**
- Set this to adjust the offset of the sticky headers. Can be used to change the sticky header position as UI like the
- navigation bar is scrolled offscreen. Changing this to the height of the navigation bar will give the effect of the
- headers sticking to the nav as it is collapsed.
+ Direction in which layout will be scrollable; items will be flowed in the perpendicular direction, "newlining" when they
+ run out of space along that axis.
+ */
+@property (nonatomic, readonly) UICollectionViewScrollDirection scrollDirection;
+
+/**
+ Set this to adjust the offset of the sticky headers in the scrolling direction. Can be used to change the sticky 
+ header position as UI like the navigation bar is scrolled offscreen. In a vertically scrolling layout, changing 
+ this to the height of the navigation bar will give the effect of the headers sticking to the nav as it is collapsed.
 
  @discussion Changing the value on this method will invalidate the layout every time.
  */
-@property (nonatomic, assign) CGFloat stickyHeaderOriginYAdjustment;
+@property (nonatomic, assign) CGFloat stickyHeaderOriginOffset;
 
 /**
  Create and return a new collection view layout.
 
  @param stickyHeaders Set to `YES` to stick section headers to the top of the bounds while scrolling.
- @param topContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
+ @param scrollDirection Direction along which the collection view will be scrollable (if content size exceeds the frame size)
+ @param initialContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
  @param stretchToEdge Specifies whether to stretch width of last item to right edge when distance from last item to right edge < epsilon(1)
 
  @return A new collection view layout.
  */
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
-                      topContentInset:(CGFloat)topContentInset
+                      scrollDirection:(UICollectionViewScrollDirection)scrollDirection
+                  initialContentInset:(CGFloat)initialContentInset
                         stretchToEdge:(BOOL)stretchToEdge NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -84,9 +84,21 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
  header position as UI like the navigation bar is scrolled offscreen. In a vertically scrolling layout, changing 
  this to the height of the navigation bar will give the effect of the headers sticking to the nav as it is collapsed.
 
- @discussion Changing the value on this method will invalidate the layout every time.
+ @note Changing the value on this method will invalidate the layout every time.
  */
 @property (nonatomic, assign) CGFloat stickyHeaderOriginOffset;
+
+/**
+ 
+ **This property is expected to be removed in IGListKit 4.0. Use `stickyHeaderOriginOffset` instead.** Set this to adjust 
+ the Y offset of the sticky headers. Can be used to change the sticky header position as UI like the navigation bar is scrolled 
+ offscreen. Changing this to the height of the navigation bar will give the effect of the headers sticking to the 
+ nav as it is collapsed.
+ 
+ @note Changing the value on this method will invalidate the layout every time.
+ */
+@property (nonatomic, assign) CGFloat stickyHeaderYOffset;
+
 
 /**
  Create and return a new collection view layout.

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -86,17 +86,6 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
 
  @note Changing the value on this method will invalidate the layout every time.
  */
-@property (nonatomic, assign) CGFloat stickyHeaderOriginOffset;
-
-/**
- 
- **This property is expected to be removed in IGListKit 4.0. Use `stickyHeaderOriginOffset` instead.** Set this to adjust 
- the Y offset of the sticky headers. Can be used to change the sticky header position as UI like the navigation bar is scrolled 
- offscreen. Changing this to the height of the navigation bar will give the effect of the headers sticking to the 
- nav as it is collapsed.
- 
- @note Changing the value on this method will invalidate the layout every time.
- */
 @property (nonatomic, assign) CGFloat stickyHeaderYOffset;
 
 

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -93,15 +93,28 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
 
  @param stickyHeaders Set to `YES` to stick section headers to the top of the bounds while scrolling.
  @param scrollDirection Direction along which the collection view will be scrollable (if content size exceeds the frame size)
- @param initialContentInset The content inset (top or left, depending on scrolling direction) used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
+ @param topContentInset The content inset (top or left, depending on scrolling direction) used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
  @param stretchToEdge Specifies whether to stretch width (in vertically scrolling layout) or height (horizontally scrolling) of last item to right/bottom edge when distance from last item to right/bottom edge < epsilon(1)
 
  @return A new collection view layout.
  */
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
                       scrollDirection:(UICollectionViewScrollDirection)scrollDirection
-                  initialContentInset:(CGFloat)initialContentInset
+                      topContentInset:(CGFloat)topContentInset
                         stretchToEdge:(BOOL)stretchToEdge NS_DESIGNATED_INITIALIZER;
+
+/**
+ Create and return a new vertically scrolling collection view layout.
+ 
+ @param stickyHeaders Set to `YES` to stick section headers to the top of the bounds while scrolling.
+ @param topContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
+ @param stretchToEdge Specifies whether to stretch width of last item to right edge when distance from last item to right edge < epsilon(1)
+ 
+ @return A new collection view layout.
+ */
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                      topContentInset:(CGFloat)topContentInset
+                        stretchToEdge:(BOOL)stretchToEdge;
 
 /**
  :nodoc:

--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -14,8 +14,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- This UICollectionViewLayout subclass is for vertically-scrolling lists of data with variable widths and heights. It
- supports an infinite number of sections and items. All work is done on the main thread, and while extremely efficient,
+ This UICollectionViewLayout subclass is for vertically or horizontally scrolling lists of data with variable widths and
+ heights. It supports an infinite number of sections and items. All work is done on the main thread, and while extremely efficient,
  care must be taken not to stall the main thread in sizing delegate methods.
 
  This layout piggybacks on the mechanics of UICollectionViewFlowLayout in that:
@@ -33,9 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
  - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section;
  ```
 
- Sections and items are put into the same horizontal row until the max-x position of an item extends beyond the width
- of the collection view. When that happens, the item is "newlined" to the next row. The y position of that row is
- determined by the maximum height (including section insets) of the section/item of the previous row.
+ In a vertically scrolling layout, sections and items are put into the same horizontal row until the max-x position
+ of an item extends beyond the width of the collection view. When that happens, the item is "newlined" to the next row.
+ The y position of that row is determined by the maximum height (including section insets) of the section/item of the previous row.
 
  Ex. of a section (2,0) with a large width causing a newline.
  ```
@@ -64,6 +64,9 @@ NS_ASSUME_NONNULL_BEGIN
 
  Interitem spacing applies to items and sections within the same row. Line spacing only applies to items within the same
  section.
+ 
+ In a horizontally scrolling layout, sections and items are flowed vertically until they need to be "newlined" to the 
+ next column. Headers, if used, are stretched to the height of the collection view, minus the section insets.
 
  Please see the unit tests for more configuration examples and expected output.
  */
@@ -72,7 +75,7 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
 
 /**
  Direction in which layout will be scrollable; items will be flowed in the perpendicular direction, "newlining" when they
- run out of space along that axis.
+ run out of space along that axis or when a non-zero header is found.
  */
 @property (nonatomic, readonly) UICollectionViewScrollDirection scrollDirection;
 
@@ -90,8 +93,8 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
 
  @param stickyHeaders Set to `YES` to stick section headers to the top of the bounds while scrolling.
  @param scrollDirection Direction along which the collection view will be scrollable (if content size exceeds the frame size)
- @param initialContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
- @param stretchToEdge Specifies whether to stretch width of last item to right edge when distance from last item to right edge < epsilon(1)
+ @param initialContentInset The content inset (top or left, depending on scrolling direction) used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
+ @param stretchToEdge Specifies whether to stretch width (in vertically scrolling layout) or height (horizontally scrolling) of last item to right/bottom edge when distance from last item to right/bottom edge < epsilon(1)
 
  @return A new collection view layout.
  */

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -14,6 +14,41 @@
 
 #import <IGListKit/IGListAssert.h>
 
+static CGFloat UIEdgeInsetsLeadingInsetInDirection(UIEdgeInsets insets, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? insets.top : insets.left;
+}
+
+static CGFloat UIEdgeInsetsTrailingInsetInDirection(UIEdgeInsets insets, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? insets.bottom : insets.right;
+}
+
+static CGFloat CGPointGetCoordinateInDirection(CGPoint point, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? point.y : point.x;
+}
+
+static CGRect CGRectInset(CGRect rect, UIEdgeInsets insets) {
+    return CGRectMake(rect.origin.x + insets.left,
+                      rect.origin.y + insets.top,
+                      rect.size.width - insets.left - insets.right,
+                      rect.size.height - insets.top - insets.bottom);
+}
+
+static CGFloat CGRectGetLengthInDirection(CGRect rect, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? rect.size.height : rect.size.width;
+}
+
+static CGFloat CGRectGetMaxInDirection(CGRect rect, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? CGRectGetMaxY(rect) : CGRectGetMaxX(rect);
+}
+
+static CGFloat CGRectGetMinInDirection(CGRect rect, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? CGRectGetMinY(rect) : CGRectGetMinX(rect);
+}
+
+static CGFloat CGSizeGetLengthInDirection(CGSize size, UICollectionViewScrollDirection direction) {
+    return direction == UICollectionViewScrollDirectionVertical ? size.height : size.width;
+}
+
 static NSIndexPath *headerIndexPathForSection(NSInteger section) {
     return [NSIndexPath indexPathForItem:0 inSection:section];
 }
@@ -75,7 +110,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 @interface IGListCollectionViewLayout ()
 
 @property (nonatomic, assign, readonly) BOOL stickyHeaders;
-@property (nonatomic, assign, readonly) CGFloat topContentInset;
+@property (nonatomic, assign, readonly) CGFloat initialContentInset;
 @property (nonatomic, assign, readonly) BOOL stretchToEdge;
 
 @end
@@ -99,11 +134,13 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 }
 
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
-                      topContentInset:(CGFloat)topContentInset
+                      scrollDirection:(UICollectionViewScrollDirection)scrollDirection
+                  initialContentInset:(CGFloat)initialContentInset
                         stretchToEdge:(BOOL)stretchToEdge {
     if (self = [super init]) {
+        _scrollDirection = scrollDirection;
         _stickyHeaders = stickyHeaders;
-        _topContentInset = topContentInset;
+        _initialContentInset = initialContentInset;
         _stretchToEdge = stretchToEdge;
         _attributesCache = [NSMutableDictionary new];
         _headerAttributesCache = [NSMutableDictionary new];
@@ -113,7 +150,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-    return [self initWithStickyHeaders:NO topContentInset:0 stretchToEdge:NO];
+    return [self initWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionVertical initialContentInset:0 stretchToEdge:NO];
 }
 
 #pragma mark - UICollectionViewLayout
@@ -139,7 +176,8 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
             // do not add zero height headers or headers that are outside the rect
             const CGRect frame = attributes.frame;
             const CGRect intersection = CGRectIntersection(frame, rect);
-            if (!CGRectIsEmpty(intersection) && CGRectGetHeight(frame) > 0.0) {
+            if (!CGRectIsEmpty(intersection)
+                && CGRectGetLengthInDirection(frame, self.scrollDirection) > 0.0) {
                 [result addObject:attributes];
             }
         }
@@ -199,18 +237,26 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
     UICollectionView *collectionView = self.collectionView;
     const IGListSectionEntry entry = _sectionData[section];
-    const CGFloat minY = CGRectGetMinY(entry.bounds);
+    const CGFloat minOffset = CGRectGetMinInDirection(entry.bounds, self.scrollDirection);
 
     CGRect frame = entry.headerBounds;
 
     if (self.stickyHeaders) {
-        const CGFloat yOffset = collectionView.contentOffset.y + self.topContentInset + self.stickyHeaderOriginYAdjustment;
+        CGFloat offset = CGPointGetCoordinateInDirection(collectionView.contentOffset, self.scrollDirection) + self.initialContentInset + self.stickyHeaderOriginOffset;
 
         if (section + 1 == _sectionData.size()) {
-            frame.origin.y = MAX(minY, yOffset);
+            offset = MAX(minOffset, offset);
         } else {
-            const CGFloat maxY = CGRectGetMinY(_sectionData[section + 1].bounds) - CGRectGetHeight(frame);
-            frame.origin.y = MIN(MAX(minY, yOffset), maxY);
+            const CGFloat maxOffset = CGRectGetMinInDirection(_sectionData[section + 1].bounds, self.scrollDirection) - CGRectGetLengthInDirection(frame, self.scrollDirection);
+            offset = MIN(MAX(minOffset, offset), maxOffset);
+        }
+        switch (self.scrollDirection) {
+            case UICollectionViewScrollDirectionVertical:
+                frame.origin.y = offset;
+                break;
+            case UICollectionViewScrollDirectionHorizontal:
+                frame.origin.x = offset;
+                break;
         }
     }
 
@@ -231,11 +277,20 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     }
 
     const IGListSectionEntry section = _sectionData[sectionCount - 1];
-    const CGFloat height = CGRectGetMaxY(section.bounds) + section.insets.bottom;
-
     UICollectionView *collectionView = self.collectionView;
     const UIEdgeInsets contentInset = collectionView.contentInset;
-    return CGSizeMake(CGRectGetWidth(collectionView.bounds) - contentInset.left - contentInset.right, height);
+    
+    switch (self.scrollDirection) {
+        case UICollectionViewScrollDirectionVertical: {
+            const CGFloat height = CGRectGetMaxY(section.bounds) + section.insets.bottom;
+            return CGSizeMake(CGRectGetWidth(collectionView.bounds) - contentInset.left - contentInset.right, height);
+        }
+        case UICollectionViewScrollDirectionHorizontal: {
+            const CGFloat width = CGRectGetMaxX(section.bounds) + section.insets.right;
+            return CGSizeMake(width, CGRectGetHeight(collectionView.bounds) - contentInset.top - contentInset.bottom);
+        }
+    }
+
 }
 
 - (void)invalidateLayoutWithContext:(IGListCollectionViewLayoutInvalidationContext *)context {
@@ -278,7 +333,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     const CGRect oldBounds = self.collectionView.bounds;
 
     // if the y origin has changed, only invalidate when using sticky headers
-    if (CGRectGetMinY(newBounds) != CGRectGetMinY(oldBounds)) {
+    if (CGRectGetMinInDirection(newBounds, self.scrollDirection) != CGRectGetMinInDirection(oldBounds, self.scrollDirection)) {
         return self.stickyHeaders;
     }
 
@@ -294,11 +349,11 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
 #pragma mark - Public API
 
-- (void)setStickyHeaderOriginYAdjustment:(CGFloat)stickyHeaderOriginYAdjustment {
+- (void)setStickyHeaderOriginOffset:(CGFloat)stickyHeaderOriginOffset {
     IGAssertMainThread();
 
-    if (_stickyHeaderOriginYAdjustment != stickyHeaderOriginYAdjustment) {
-        _stickyHeaderOriginYAdjustment = stickyHeaderOriginYAdjustment;
+    if (_stickyHeaderOriginOffset != stickyHeaderOriginOffset) {
+        _stickyHeaderOriginOffset = stickyHeaderOriginOffset;
 
         IGListCollectionViewLayoutInvalidationContext *invalidationContext = [IGListCollectionViewLayoutInvalidationContext new];
         invalidationContext.ig_invalidateSupplementaryAttributes = YES;
@@ -321,13 +376,13 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
     const NSInteger sectionCount = [dataSource numberOfSectionsInCollectionView:collectionView];
     const UIEdgeInsets contentInset = collectionView.contentInset;
-    const CGFloat width = CGRectGetWidth(collectionView.bounds) - contentInset.left - contentInset.right;
-
+    const CGRect contentInsetAdjustedCollectionViewBounds = CGRectInset(collectionView.bounds, contentInset);
+    
     auto sectionData = std::vector<IGListSectionEntry>(sectionCount);
 
-    CGFloat itemY = 0.0;
-    CGFloat itemX = 0.0;
-    CGFloat nextRowY = 0.0;
+    CGFloat itemCoordInScrollDirection = 0.0;
+    CGFloat itemCoordInFixedDirection = 0.0;
+    CGFloat nextRowCoordInScrollDirection = 0.0;
 
     // union item frames and optionally the header to find a bounding box of the entire section
     CGRect rollingSectionBounds;
@@ -341,63 +396,66 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         const CGFloat lineSpacing = [delegate collectionView:collectionView layout:self minimumLineSpacingForSectionAtIndex:section];
         const CGFloat interitemSpacing = [delegate collectionView:collectionView layout:self minimumInteritemSpacingForSectionAtIndex:section];
 
-        const CGFloat paddedWidth = width - insets.left - insets.right;
-        const BOOL headerExists = headerSize.height > 0;
+        const CGSize paddedCollectionViewSize = CGRectInset(contentInsetAdjustedCollectionViewBounds, insets).size;
+        const UICollectionViewScrollDirection fixedDirection = self.scrollDirection == UICollectionViewScrollDirectionHorizontal ? UICollectionViewScrollDirectionVertical : UICollectionViewScrollDirectionHorizontal;
+        const CGFloat paddedLengthInFixedDirection = CGSizeGetLengthInDirection(paddedCollectionViewSize, fixedDirection);
+        const CGFloat headerLengthInScrollDirection =  CGSizeGetLengthInDirection(headerSize, self.scrollDirection);
+        const BOOL headerExists = headerLengthInScrollDirection > 0;
+        // start the section accounting for the header size
+        // header length in scroll direction is subtracted from the sectionBounds when calculating the header bounds after items are done
+        // this bumps the first row of items over enough to make room for the header
+        itemCoordInScrollDirection += headerLengthInScrollDirection;
+        nextRowCoordInScrollDirection += headerLengthInScrollDirection;
+        
+        // add the leading inset in fixed direction in case the section falls on the same row as the previous
+        // if the section is newlined then the coord in fixed direction is reset
+        itemCoordInFixedDirection += UIEdgeInsetsLeadingInsetInDirection(insets, fixedDirection);
 
-        // start the section y accounting for the header height
-        // header height is subtracted from the sectionBounds when calculating the header bounds after items are done
-        // this bumps the first row of items down enough to make room for the header
-        itemY += headerSize.height;
-        nextRowY += headerSize.height;
-
-        // add the left inset in case the section falls on the same row as the previous
-        // if the section is newlined then the x is reset
-        itemX += insets.left;
-
-        // the farthest right the frame of an item in this section can go
-        const CGFloat maxX = width - insets.right;
+        // the farthest in the fixed direction the frame of an item in this section can go
+        const CGFloat maxCoordinateInFixedDirection = CGRectGetLengthInDirection(contentInsetAdjustedCollectionViewBounds, fixedDirection) - UIEdgeInsetsTrailingInsetInDirection(insets, fixedDirection);
 
         for (NSInteger item = 0; item < itemCount; item++) {
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:item inSection:section];
             const CGSize size = [delegate collectionView:collectionView layout:self sizeForItemAtIndexPath:indexPath];
 
-            IGAssert(size.width <= paddedWidth || fabs(size.width - paddedWidth) < FLT_EPSILON,
-                     @"Width of item %zi in section %zi must be less than container %.0f accounting for section insets %@",
-                     item, section, width, NSStringFromUIEdgeInsets(insets));
-            CGFloat itemWidth = MIN(size.width, paddedWidth);
+            IGAssert(CGSizeGetLengthInDirection(size, fixedDirection) <= paddedLengthInFixedDirection, @"%@ of item %zi in section %zi must be less than container %.0f accounting for section insets %@", self.scrollDirection == UICollectionViewScrollDirectionVertical ? @"Width" : @"Height", item, section, CGRectGetLengthInDirection(contentInsetAdjustedCollectionViewBounds, fixedDirection), NSStringFromUIEdgeInsets(insets));
 
-            // if the x + width of the item busts the width of the container
+            CGFloat itemLengthInFixedDirection = MIN(CGSizeGetLengthInDirection(size, fixedDirection), paddedLengthInFixedDirection);
+
+            // if the origin and length in fixed direction of the item busts the size of the container
             // or if this is the first item and the header has a non-zero size
             // newline to the next row and reset
             // define epsilon to avoid float overflow issue
             const CGFloat epsilon = 1.0;
-            if (itemX + itemWidth > maxX + epsilon
+            if (itemCoordInFixedDirection + itemLengthInFixedDirection > maxCoordinateInFixedDirection + epsilon
                 || (item == 0 && headerExists)) {
-                itemY = nextRowY;
-                itemX = insets.left;
+                itemCoordInScrollDirection = nextRowCoordInScrollDirection;
+                itemCoordInFixedDirection = UIEdgeInsetsLeadingInsetInDirection(insets, fixedDirection);
+
 
                 // if newlining, always append line spacing unless its the very first item of the section
                 if (item > 0) {
-                    itemY += lineSpacing;
+                   itemCoordInScrollDirection += lineSpacing;
                 }
             }
 
-            const CGFloat distanceToRighEdge = paddedWidth - (itemX + itemWidth);
-            if (self.stretchToEdge && distanceToRighEdge > 0 && distanceToRighEdge <= epsilon) {
-                itemWidth = paddedWidth - itemX;
+            const CGFloat distanceToEdge = paddedLengthInFixedDirection - (itemCoordInFixedDirection + itemLengthInFixedDirection);
+            if (self.stretchToEdge && distanceToEdge > 0 && distanceToEdge <= epsilon) {
+                itemLengthInFixedDirection = paddedLengthInFixedDirection - itemCoordInFixedDirection;
             }
 
-            const CGRect frame = IGListRectIntegralScaled(CGRectMake(itemX,
-                                                                     itemY + insets.top,
-                                                                     itemWidth,
-                                                                     size.height));
+            const CGRect rawFrame = (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
+            CGRectMake(itemCoordInFixedDirection, itemCoordInScrollDirection + insets.top, itemLengthInFixedDirection, size.height) :
+            CGRectMake(itemCoordInScrollDirection + insets.left, itemCoordInFixedDirection, size.width, itemLengthInFixedDirection);
+            const CGRect frame = IGListRectIntegralScaled(rawFrame);
+
             sectionData[section].itemBounds[item] = frame;
 
-            // track the max size of the row to find the y of the next row, adjust for top inset while iterating items
-            nextRowY = MAX(CGRectGetMaxY(frame) - insets.top, nextRowY);
+            // track the max size of the row to find the coord of the next row, adjust for leading inset while iterating items
+            nextRowCoordInScrollDirection = MAX(CGRectGetMaxInDirection(frame, self.scrollDirection) - UIEdgeInsetsLeadingInsetInDirection(insets, self.scrollDirection), nextRowCoordInScrollDirection);
 
-            // increase the rolling x by the item width and add item spacing for all items on the same row
-            itemX += itemWidth + interitemSpacing;
+            // increase the rolling coord in fixed direction appropriately and add item spacing for all items on the same row
+            itemCoordInFixedDirection += itemLengthInFixedDirection + interitemSpacing;
 
             // union the rolling section bounds
             if (item == 0) {
@@ -407,10 +465,10 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
             }
         }
 
-        const CGRect headerBounds = CGRectMake(insets.left,
-                                               CGRectGetMinY(rollingSectionBounds) - headerSize.height,
-                                               paddedWidth,
-                                               headerSize.height);
+        const CGRect headerBounds =  (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
+        CGRectMake(insets.left, CGRectGetMinY(rollingSectionBounds) - headerSize.height, paddedLengthInFixedDirection, headerSize.height) :
+        CGRectMake(CGRectGetMinX(rollingSectionBounds) - headerSize.width, insets.top, headerSize.width, paddedLengthInFixedDirection);
+
         sectionData[section].headerBounds = headerBounds;
 
         // union the header before setting the bounds of the section
@@ -422,11 +480,11 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         sectionData[section].bounds = rollingSectionBounds;
         sectionData[section].insets = insets;
 
-        // bump the x for the next section with the right insets
-        itemX += insets.right;
+        // bump the coord for the next section with the right insets
+        itemCoordInFixedDirection += UIEdgeInsetsTrailingInsetInDirection(insets, fixedDirection);
 
-        // find the lowest point in the section and add the bottom inset to find the next row's Y
-        nextRowY = MAX(nextRowY, CGRectGetMaxY(rollingSectionBounds) + insets.bottom);
+        // find the furthest point in the section and add the trailing inset to find the next row's coord
+        nextRowCoordInScrollDirection = MAX(nextRowCoordInScrollDirection, CGRectGetMaxInDirection(rollingSectionBounds, self.scrollDirection) + UIEdgeInsetsTrailingInsetInDirection(insets, self.scrollDirection));
     }
 
     _sectionData = sectionData;

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -265,7 +265,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     CGRect frame = entry.headerBounds;
 
     if (self.stickyHeaders) {
-        CGFloat offset = CGPointGetCoordinateInDirection(collectionView.contentOffset, self.scrollDirection) + self.topContentInset + self.stickyHeaderOriginOffset;
+        CGFloat offset = CGPointGetCoordinateInDirection(collectionView.contentOffset, self.scrollDirection) + self.topContentInset + self.stickyHeaderYOffset;
 
         if (section + 1 == _sectionData.size()) {
             offset = MAX(minOffset, offset);
@@ -372,25 +372,16 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
 #pragma mark - Public API
 
-- (void)setStickyHeaderOriginOffset:(CGFloat)stickyHeaderOriginOffset {
+- (void)setStickyHeaderYOffset:(CGFloat)stickyHeaderYOffset {
     IGAssertMainThread();
 
-    if (_stickyHeaderOriginOffset != stickyHeaderOriginOffset) {
-        _stickyHeaderOriginOffset = stickyHeaderOriginOffset;
+    if (_stickyHeaderYOffset != stickyHeaderYOffset) {
+        _stickyHeaderYOffset = stickyHeaderYOffset;
 
         IGListCollectionViewLayoutInvalidationContext *invalidationContext = [IGListCollectionViewLayoutInvalidationContext new];
         invalidationContext.ig_invalidateSupplementaryAttributes = YES;
         [self invalidateLayoutWithContext:invalidationContext];
     }
-}
-
-// For backwards compatibility
-- (CGFloat)stickyHeaderYOffset {
-    return _stickyHeaderOriginOffset;
-}
-
-- (void)setStickyHeaderYOffset:(CGFloat)stickyHeaderYOffset {
-    [self setStickyHeaderOriginOffset:stickyHeaderYOffset];
 }
 
 #pragma mark - Private API

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -478,8 +478,14 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         }
 
         const CGRect headerBounds =  (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
-        CGRectMake(insets.left, CGRectGetMinY(rollingSectionBounds) - headerSize.height, paddedLengthInFixedDirection, headerSize.height) :
-        CGRectMake(CGRectGetMinX(rollingSectionBounds) - headerSize.width, insets.top, headerSize.width, paddedLengthInFixedDirection);
+            CGRectMake(insets.left,
+                       CGRectGetMinY(rollingSectionBounds) - headerSize.height,
+                       paddedLengthInFixedDirection,
+                       headerSize.height) :
+            CGRectMake(CGRectGetMinX(rollingSectionBounds) - headerSize.width,
+                       insets.top,
+                       headerSize.width,
+                       paddedLengthInFixedDirection);
 
         sectionData[section].headerBounds = headerBounds;
 
@@ -495,7 +501,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         // bump the coord for the next section with the right insets
         itemCoordInFixedDirection += UIEdgeInsetsTrailingInsetInDirection(insets, fixedDirection);
 
-        // find the furthest point in the section and add the trailing inset to find the next row's coord
+        // find the farthest point in the section and add the trailing inset to find the next row's coord
         nextRowCoordInScrollDirection = MAX(nextRowCoordInScrollDirection, CGRectGetMaxInDirection(rollingSectionBounds, self.scrollDirection) + UIEdgeInsetsTrailingInsetInDirection(insets, self.scrollDirection));
     }
 

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -384,6 +384,15 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
     }
 }
 
+// For backwards compatibility
+- (CGFloat)stickyHeaderYOffset {
+    return _stickyHeaderOriginOffset;
+}
+
+- (void)setStickyHeaderYOffset:(CGFloat)stickyHeaderYOffset {
+    [self setStickyHeaderOriginOffset:stickyHeaderYOffset];
+}
+
 #pragma mark - Private API
 
 - (void)cacheLayout {

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -42,7 +42,7 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 - (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
-    self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky topContentInset:inset stretchToEdge:stretchToEdge];
+    self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky scrollDirection: UICollectionViewScrollDirectionVertical initialContentInset:inset stretchToEdge:stretchToEdge];
     self.dataSource = [IGLayoutTestDataSource new];
     self.collectionView = [[UICollectionView alloc] initWithFrame:kTestFrame collectionViewLayout:self.layout];
     self.collectionView.dataSource = self.dataSource;
@@ -171,12 +171,12 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 45, 100, 10);
 
-    self.layout.stickyHeaderOriginYAdjustment = -10;
+    self.layout.stickyHeaderOriginOffset = -10;
     [self.collectionView layoutIfNeeded];
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 40, 100, 10);
 
-    self.layout.stickyHeaderOriginYAdjustment = 10;
+    self.layout.stickyHeaderOriginOffset = 10;
     [self.collectionView layoutIfNeeded];
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 55, 100, 10);

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -919,4 +919,11 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     XCTAssertNil([self.layout layoutAttributesForItemAtIndexPath:genIndexPath(0, 4)]);
 }
 
+- (void)test_whenStickyHeaderYOffsetIsChanged_thatStickyHeaderOriginOffsetIsChangedToo {
+    [self setUpWithStickyHeaders:YES topInset:0 stretchToEdge:YES];
+    self.layout.stickyHeaderYOffset = 44.0;
+    XCTAssertEqual(self.layout.stickyHeaderOriginOffset, 44.0);
+    XCTAssertEqual(self.layout.stickyHeaderYOffset, 44.0);
+}
+
 @end

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -42,11 +42,11 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 - (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
-    [self setUpWithStickyHeaders:sticky scrollDirection:UICollectionViewScrollDirectionVertical initialInset:inset stretchToEdge:stretchToEdge];
+    [self setUpWithStickyHeaders:sticky scrollDirection:UICollectionViewScrollDirectionVertical topInset:inset stretchToEdge:stretchToEdge];
 }
 
-- (void)setUpWithStickyHeaders:(BOOL)sticky scrollDirection:(UICollectionViewScrollDirection)scrollDirection initialInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
-    self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky scrollDirection:scrollDirection initialContentInset:inset stretchToEdge:stretchToEdge];
+- (void)setUpWithStickyHeaders:(BOOL)sticky scrollDirection:(UICollectionViewScrollDirection)scrollDirection topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
+    self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky scrollDirection:scrollDirection topContentInset:inset stretchToEdge:stretchToEdge];
     self.dataSource = [IGLayoutTestDataSource new];
     self.collectionView = [[UICollectionView alloc] initWithFrame:kTestFrame collectionViewLayout:self.layout];
     self.collectionView.dataSource = self.dataSource;
@@ -111,7 +111,7 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 -(void)test_whenLayingOutCellsHorizontally_withHeaderHeight_withLineSpacing_withInsets_thatFramesCorrect {
-    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal initialInset:0 stretchToEdge:NO];
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
     
     const CGFloat headerHeight = 10;
     const CGFloat lineSpacing = 10;
@@ -180,7 +180,7 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 - (void)test_whenUsingStickyHeaders_withSimulatedHorizontalScrolling_thatXPositionsAdjusted {
-    [self setUpWithStickyHeaders:YES scrollDirection:UICollectionViewScrollDirectionHorizontal initialInset:10 stretchToEdge:NO];
+    [self setUpWithStickyHeaders:YES scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:10 stretchToEdge:NO];
     
     [self prepareWithData:@[
                             [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
@@ -304,7 +304,27 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self cellForSection:0 item:2].frame, 67, 0, 33, 33);
 }
 
-- (void)test_whenSectionsSmallerThanContainerWidth_with0ItemSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameRow {
+- (void)test_whenItemsLargerThanContainerHeight_withHorizontalScrolling_with5PointItemSpacing_with0Insets_with10PointLineSpacing_thatItemsBumpToNewColumn {
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
+    
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:10
+                                                       interitemSpacing:5
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.width, 76);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 0, 38, 33, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:2].frame, 43, 0, 33, 33);
+}
+
+- (void)test_whenSectionsSmallerThanContainerWidth_withVerticalScrolling_with0ItemSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameRow {
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
@@ -334,6 +354,38 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 33, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:2 item:0].frame, 66, 0, 33, 33);
+}
+
+- (void)test_whenSectionsSmallerThanContainerHeight_withHorizontalScrolling_with0ItemSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameColumn {
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
+    
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.width, 33);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 33, 33, 33);
+    IGAssertEqualFrame([self cellForSection:2 item:0].frame, 0, 66, 33, 33);
 }
 
 - (void)test_whenSectionsSmallerThanContainerWidth_withHalfPointSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameRow {
@@ -455,6 +507,30 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     XCTAssertEqual(self.collectionView.contentSize.height, 76);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 43, 33, 33);
+}
+
+- (void)test_whenSectionsSmallerThanHeight_withHorizontalScrolling_withSectionHeader_thatHeaderCausesNewline {
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
+    
+    [self prepareWithData:@[
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:0
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                                  items:@[
+                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
+                                                                          ]],
+                            ]];
+    XCTAssertEqual(self.collectionView.contentSize.width, 76);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 43, 0, 33, 33);
 }
 
 - (void)test_whenBatchItemUpdates_withHeaderHeight_withLineSpacing_withInsets_thatLayoutCorrectAfterUpdates {

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -244,12 +244,12 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 45, 100, 10);
 
-    self.layout.stickyHeaderOriginOffset = -10;
+    self.layout.stickyHeaderYOffset = -10;
     [self.collectionView layoutIfNeeded];
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 40, 100, 10);
 
-    self.layout.stickyHeaderOriginOffset = 10;
+    self.layout.stickyHeaderYOffset = 10;
     [self.collectionView layoutIfNeeded];
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 30, 100, 10);
     IGAssertEqualFrame([self headerForSection:1].frame, 0, 55, 100, 10);
@@ -917,13 +917,6 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
                                                                           ]],
                             ]];
     XCTAssertNil([self.layout layoutAttributesForItemAtIndexPath:genIndexPath(0, 4)]);
-}
-
-- (void)test_whenStickyHeaderYOffsetIsChanged_thatStickyHeaderOriginOffsetIsChangedToo {
-    [self setUpWithStickyHeaders:YES topInset:0 stretchToEdge:YES];
-    self.layout.stickyHeaderYOffset = 44.0;
-    XCTAssertEqual(self.layout.stickyHeaderOriginOffset, 44.0);
-    XCTAssertEqual(self.layout.stickyHeaderYOffset, 44.0);
 }
 
 @end

--- a/Tests/Objects/IGLayoutTestDataSource.m
+++ b/Tests/Objects/IGLayoutTestDataSource.m
@@ -64,7 +64,7 @@ static NSString * const kHeaderIdentifier = @"header";
 }
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForHeaderInSection:(NSInteger)section {
-    return CGSizeMake(CGRectGetWidth(collectionView.bounds), self.sections[section].headerHeight);
+    return CGSizeMake(self.sections[section].headerHeight, self.sections[section].headerHeight); // Only the dimension along scrolling direction is used
 }
 
 @end


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #752

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)

This PR generalizes the layout logic in `IGListCollectionViewLayout.mm` to handle horizontally scrolling layouts, mainly by generalizing references to `width`, `height`, `x` and `y` to take scrolling direction into account. This changes the signature of `IGListCollectionViewLayout.init` as well as the names of a few properties, so it would be a breaking change. 

I added a couple of unit tests specifically for horizontal layouts -- but held off from adding a horizontal version of *every* unit test for this class, as it would basically double the number of tests. But if you want that, just let me know and I'm happy to do it.

Also let me know if you want me to add a demo VC to the Examples project that uses this new horizontal flow layout -- I have some demo code handy (I used it for testing), but didn't want to clutter up the PR if you didn't want/need it.
