### PR TITLE
Directly executes the batch update or reload data if the collection view is idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Added `-[IGListSectionController didDeselectItemAtIndex:]` API to support default `UICollectionView` cell deselection. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
 
+- Allow executing a batch update or reloadData immediately if the collection view is idle. [Ethan Jin](https://github.com/ethanjin) [(#869)](https://github.com/Instagram/IGListKit/pull/869)
+
 3.0.0
 -----
 


### PR DESCRIPTION
So the view controller can prepare a default page between viewDidLoad
and viewWillAppear by providing a default data to the collection view
and executing reloadData.