### PR TITLE
Make explicit `IGListDiffable` protocol requirement

### DIFF
--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -79,6 +79,7 @@ The data should be immutable. If you return mutable objects that you will be edi
 `IGListKit` uses an algorithm adapted from a paper titled [A technique for isolating differences between files](http://dl.acm.org/citation.cfm?id=359467&dl=ACM&coll=DL) by Paul Heckel. This algorithm uses a technique known as the *longest common subsequence* to find a minimal diff between collections in linear time `O(n)`. It finds all **inserts**, **deletes**, **updates**, and **moves** between arrays of data.
 
 To add custom, diffable models, you need to conform to the `IGListDiffable` protocol and implement `diffIdentifier()` and `isEqual(toDiffableObject:)`.
+> **Note:** an object's `diffIdentifier()` should never change. If an object mutates it's `diffIdentifer()` the behavior of IGListKit is undefined (and almost assuredly undesirable).
 
 For an example, consider the following model:
 

--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -80,7 +80,7 @@ The data should be immutable. If you return mutable objects that you will be edi
 
 To add custom, diffable models, you need to conform to the `IGListDiffable` protocol and implement `diffIdentifier()` and `isEqual(toDiffableObject:)`.
 
-> **Note:** an object's `diffIdentifier()` should never change. If an object mutates it's `diffIdentifer()` the behavior of IGListKit is undefined (and almost assuredly undesirable).
+> **Warning:** an object's `diffIdentifier()` should never change. If an object mutates its `diffIdentifer()` the behavior of IGListKit is undefined (and almost assuredly undesirable).
 
 For an example, consider the following model:
 

--- a/Guides/Getting Started.md
+++ b/Guides/Getting Started.md
@@ -79,6 +79,7 @@ The data should be immutable. If you return mutable objects that you will be edi
 `IGListKit` uses an algorithm adapted from a paper titled [A technique for isolating differences between files](http://dl.acm.org/citation.cfm?id=359467&dl=ACM&coll=DL) by Paul Heckel. This algorithm uses a technique known as the *longest common subsequence* to find a minimal diff between collections in linear time `O(n)`. It finds all **inserts**, **deletes**, **updates**, and **moves** between arrays of data.
 
 To add custom, diffable models, you need to conform to the `IGListDiffable` protocol and implement `diffIdentifier()` and `isEqual(toDiffableObject:)`.
+
 > **Note:** an object's `diffIdentifier()` should never change. If an object mutates it's `diffIdentifer()` the behavior of IGListKit is undefined (and almost assuredly undesirable).
 
 For an example, consider the following model:


### PR DESCRIPTION
While the CocoaDocs for the [IGListDiffable](https://instagram.github.io/IGListKit/Protocols/IGListDiffable.html) state that IGListDiffable objects should not mutate their `diffIdentifier` that requirement is not clear in this guide. 

This is a documentation only PR.

## Changes in this pull request

Issue fixed: #880

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
