### PR TITLE
add Xcode9 fileheader

### DIFF
--- a/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ **/</string>
+</dict>
+</plist>

--- a/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -2,8 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FILEHEADER</key>
-	<string> Copyright (c) 2016-present, Facebook, Inc.
+<key>FILEHEADER</key>
+<string> 
+// Copyright (c) 2016-present, Facebook, Inc.
 // All rights reserved.
 //
 // This source code is licensed under the BSD-style license found in the
@@ -15,6 +16,7 @@
 // 
 // Documentation:
 // https://instagram.github.io/IGListKit/
+//
 </string>
 </dict>
 </plist>

--- a/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -10,7 +10,7 @@
 // This source code is licensed under the BSD-style license found in the
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
-
+//
 // GitHub:
 // https://github.com/Instagram/IGListKit
 // 

--- a/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/IGListKit.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -3,13 +3,18 @@
 <plist version="1.0">
 <dict>
 	<key>FILEHEADER</key>
-	<string>/**
- * Copyright (c) 2016-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- **/</string>
+	<string> Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+// GitHub:
+// https://github.com/Instagram/IGListKit
+// 
+// Documentation:
+// https://instagram.github.io/IGListKit/
+</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Changes in this pull request

This adds the new default header option added in Xcode 9 B3. This works except for `//` being appended at the beginning which is referenced as a radar in the link (rdar://33451838). I used this as the default header. Let me know if you would like something else.

```/**
 * Copyright (c) 2016-present, Facebook, Inc.
 * All rights reserved.
 *
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
 */
```


Issue fixed: #875 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)