### PR TITLE
Disable prefetching when setting the collection view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,20 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 ### Fixes
 
 - Prevent a crash when update queued immediately after item batch update. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
+
 - Return correct `-[IGListAdapter visibleSectionControllers]` when section has no items, but has supplementary views. [Mani Ghasemlou](https://github.com/manicakes) [(#643)](https://github.com/Instagram/IGListKit/issues/643)
+
 - Call `[CATransaction commit]` before calling completion block in IGListAdapterUpdater to prevent animation issues. [Maxime Ollivier](https://github.com/maxoll) (tbd)
 
 ### Enhancements
 
 - Added `-[IGListSectionController didDeselectItemAtIndex:]` API to support default `UICollectionView` cell deselection. [Ryan Nystrom](https://github.com/rnystrom) (tbd)
+
 - Added `-[IGListCollectionContext selectItemAtIndex:]` Select an item through IGListCollectionContext like `-[IGListCollectionContext deselectItemAtIndex:]`. [Marvin Nazari](https://github.com/MarvinNazari) (tbd)
 
 - Added horizontal scrolling support to `IGListCollectionViewLayout`. [Peter Edmonston](https://github.com/edmonston)  [(#857)](https://github.com/Instagram/IGListKit/pull/857)
+
+- Automatically disable `[UICollectionView isPrefetchingEnabled]` when setting a collection view on an adapter. [Ryan Nystrom](https://github.com/rnystrom) [(#889)](https://github.com/Instagram/IGListKit/pull/889)
 
 3.0.0
 -----

--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -49,6 +49,8 @@ NS_SWIFT_NAME(ListAdapter)
 
 /**
  The collection view used with the adapter.
+
+ @note Setting this property will automatically set isPrefetchingEnabled to `NO` for performance reasons.
  */
 @property (nonatomic, nullable, weak) UICollectionView *collectionView;
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -96,6 +96,11 @@
 
         _collectionView = collectionView;
         _collectionView.dataSource = self;
+
+        if ([_collectionView respondsToSelector:@selector(setPrefetchingEnabled:)]) {
+            _collectionView.prefetchingEnabled = NO;
+        }
+
         [_collectionView.collectionViewLayout invalidateLayout];
 
         [self updateCollectionViewDelegate];

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -1319,4 +1319,14 @@
     XCTAssertThrows([self.adapter reloadDataWithCompletion:nil]);
 }
 
+- (void)test_whenPrefetchingEnabled_thatSetterDisables {
+    UICollectionView *collectionView = [[UICollectionView alloc] initWithFrame:CGRectZero collectionViewLayout:[UICollectionViewFlowLayout new]];
+    collectionView.prefetchingEnabled = YES;
+
+    IGListAdapter *adapter = [[IGListAdapter alloc] initWithUpdater:[IGListAdapterUpdater new] viewController:nil];
+    adapter.collectionView = collectionView;
+
+    XCTAssertFalse(collectionView.prefetchingEnabled);
+}
+
 @end


### PR DESCRIPTION
Followup from #852 since `UIAppearance` doesn't have any effect. Automatically disable prefetching.

Issue fixed: #846 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
