### PR TITLE
Disabled force_unwrapping, trailing comma, line_length rules

### DIFF
--- a/Examples/.swiftlint.yml
+++ b/Examples/.swiftlint.yml
@@ -1,5 +1,9 @@
 opt_in_rules: # some rules are only opt-in
   - empty_count
+disabled_rules:
+  - force_unwrapping
+  - comma
+  - line_length
 included:
   - IGListKitExamples
   - IGListKitMessageExample
@@ -9,7 +13,6 @@ excluded:
 force_cast: warning
 force_try: warning
 weak_delegate: error
-line_length: 140
 type_body_length:
   warning: 300
   error: 400


### PR DESCRIPTION
References #894 

Disabled force unwrapping, but force try and force cast rules are still in effect:
```swift
let k = object.things! // no longer causes a warning
let r = object.fidget as! Spinnable // causes warning 
let s = try! object.doDangerousTask() // causes warning 
```