### PR TITLE
Defer invalidatation until all batch updates are finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Weakly reference the `UICollectionView` in coalescence so that it can be released if the rest of system is destroyed. [Ryan Nystrom](https://github.com/rnystrom) [(#tbd)](https://github.com/Instagram/IGListKit/pull/tbd)
 
+- Avoid crash when invalidating the layout while inside `-[UICollectionView performBatchUpdates:completion:]. [Ryan Nystrom](https://github.com/rnystrom) [(#tbd)](https://github.com/Instagram/IGListKit/pull/tbd)
+
 
 3.1.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The changelog for `IGListKit`. Also see the [releases](https://github.com/instagram/IGListKit/releases) on GitHub.
 
+3.2.0 (upcoming release)
+-----
+
+### Fixes
+
+- Weakly reference the `UICollectionView` in coalescence so that it can be released if the rest of system is destroyed. [Ryan Nystrom](https://github.com/rnystrom) [(#tbd)](https://github.com/Instagram/IGListKit/pull/tbd)
+
+
 3.1.1
 -----
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -319,6 +319,8 @@
     NSArray *fromObjects = self.sectionMap.objects;
     NSArray *newObjects = [dataSource objectsForListAdapter:self];
 
+    [self enterBatchUpdates];
+
     __weak __typeof__(self) weakSelf = self;
     [self.updater performUpdateWithCollectionView:collectionView
                                       fromObjects:fromObjects
@@ -337,6 +339,8 @@
                                 if (completion) {
                                     completion(finished);
                                 }
+
+                                [weakSelf exitBatchUpdates];
                             }];
 }
 
@@ -986,6 +990,8 @@
     IGParameterAssert(updates != nil);
     UICollectionView *collectionView = self.collectionView;
     IGAssert(collectionView != nil, @"Performing batch updates without a collection view.");
+
+    [self enterBatchUpdates];
     
     __weak __typeof__(self) weakSelf = self;
     [self.updater performUpdateWithCollectionView:collectionView animated:animated itemUpdates:^{
@@ -998,6 +1004,8 @@
         if (completion) {
             completion(finished);
         }
+
+        [weakSelf exitBatchUpdates];
     }];
 }
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -18,6 +18,8 @@
 
 @implementation IGListAdapter {
     NSMapTable<UICollectionReusableView *, IGListSectionController *> *_viewSectionControllerMap;
+    // An array of blocks to execute once batch updates are finished
+    NSMutableArray<void (^)()> *_queuedCompletionBlocks;
 }
 
 - (void)dealloc {
@@ -702,6 +704,26 @@
     [_viewSectionControllerMap removeObjectForKey:view];
 }
 
+- (void)deferBlockBetweenBatchUpdates:(void (^)())block {
+    IGAssertMainThread();
+    if (_queuedCompletionBlocks == nil) {
+        block();
+    } else {
+        [_queuedCompletionBlocks addObject:block];
+    }
+}
+
+- (void)enterBatchUpdates {
+    _queuedCompletionBlocks = [NSMutableArray new];
+}
+
+- (void)exitBatchUpdates {
+    for (void (^block)() in _queuedCompletionBlocks) {
+        block();
+    }
+    _queuedCompletionBlocks = nil;
+}
+
 #pragma mark - UIScrollViewDelegate
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView {
@@ -1004,11 +1026,14 @@
     UICollectionViewLayoutInvalidationContext *context = [[[layout.class invalidationContextClass] alloc] init];
     [context invalidateItemsAtIndexPaths:indexPaths];
     
-    void (^block)() = ^{
-        [layout invalidateLayoutWithContext:context];
-    };
-    
-    [_collectionView performBatchUpdates:block completion:completion];
+    __weak __typeof__(_collectionView) weakCollectionView = _collectionView;
+
+    // do not call -[UICollectionView performBatchUpdates:completion:] while already updating. defer it until completed.
+    [self deferBlockBetweenBatchUpdates:^{
+        [weakCollectionView performBatchUpdates:^{
+            [layout invalidateLayoutWithContext:context];
+        } completion:completion];
+    }];
 }
 
 #pragma mark - IGListBatchContext

--- a/Source/IGListAdapterUpdater.m
+++ b/Source/IGListAdapterUpdater.m
@@ -380,6 +380,12 @@ void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
     }
 
     __weak __typeof__(self) weakSelf = self;
+    __weak __typeof__(collectionView) weakCollectionView = collectionView;
+
+    // dispatch_async to give the main queue time to collect more batch updates so that a minimum amount of work
+    // (diffing, etc) is done on main. dispatch_async does not garauntee a full runloop turn will pass though.
+    // see -performUpdateWithCollectionView:fromObjects:toObjects:animated:]objectTransitionBlock:completion: for more
+    // details on how coalescence is done.
     dispatch_async(dispatch_get_main_queue(), ^{
         if (weakSelf.state != IGListBatchUpdateStateIdle
             || ![weakSelf hasChanges]) {
@@ -387,9 +393,9 @@ void convertReloadToDeleteInsert(NSMutableIndexSet *reloads,
         }
 
         if (weakSelf.hasQueuedReloadData) {
-            [weakSelf performReloadDataWithCollectionView:collectionView];
+            [weakSelf performReloadDataWithCollectionView:weakCollectionView];
         } else {
-            [weakSelf performBatchUpdatesWithCollectionView:collectionView];
+            [weakSelf performBatchUpdatesWithCollectionView:weakCollectionView];
         }
     });
 }

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1124,6 +1124,9 @@
 
 - (void)test_whenQueuingUpdate_withSectionControllerBatchUpdate_thatSectionControllerNotRetained {
     __weak id weakSectionController = nil;
+    __weak id weakAdapter = nil;
+    __weak id weakCollectionView = nil;
+
     @autoreleasepool {
         IGListAdapter *adapter = [[IGListAdapter alloc] initWithUpdater:[IGListAdapterUpdater new] viewController:nil];
         IGTestDelegateDataSource *dataSource = [IGTestDelegateDataSource new];
@@ -1146,9 +1149,16 @@
         dataSource.objects = @[object, genTestObject(@2, @2)];
         [adapter performUpdatesAnimated:YES completion:^(BOOL finished) {}];
 
+        weakAdapter = adapter;
+        weakCollectionView = collectionView;
         weakSectionController = section;
+
+        XCTAssertNotNil(weakAdapter);
+        XCTAssertNotNil(weakCollectionView);
         XCTAssertNotNil(weakSectionController);
     }
+    XCTAssertNil(weakAdapter);
+    XCTAssertNil(weakCollectionView);
     XCTAssertNil(weakSectionController);
 }
 

--- a/Tests/IGListAdapterE2ETests.m
+++ b/Tests/IGListAdapterE2ETests.m
@@ -1554,7 +1554,6 @@
 
 - (void)test_whenInvalidatingInsideBatchUpdate_withSystemReleased_thatSystemNil_andCollectionViewDoesntCrashOnDealloc {
     __weak id weakAdapter = nil;
-    __weak id weakCollectionView = nil;
     __block BOOL executedItemUpdate = NO;
     XCTestExpectation *expectation = genExpectation;
 
@@ -1593,16 +1592,12 @@
         }];
 
         weakAdapter = adapter;
-        weakCollectionView = collectionView;
-
         XCTAssertNotNil(weakAdapter);
-        XCTAssertNotNil(weakCollectionView);
     }
 
     [self waitForExpectationsWithTimeout:30 handler:^(NSError * _Nullable error) {
         XCTAssertTrue(executedItemUpdate);
         XCTAssertNil(weakAdapter);
-        XCTAssertNil(weakCollectionView);
     }];
 }
 


### PR DESCRIPTION
## Changes in this pull request

Added a mechanism to `IGListAdapter` to defer (_queue or execute_) blocks around asking the updater to do batch updates. I discovered a crash where the `_updateCompletionHandler` (private ivar) of `UICollectionView` was not being niled when two batch updates collide. There is an assert in `-[UICollectionView dealloc]` that fires if this block != nil. Took some reverse eng to track down what is happening.

Sadly I cannot reproduce the issue in a unit test _or_ sample app. However I can 100% repro this in my GitHawk app. Applying this patch fixes the problem. I added a unit test that got me _close_ to the state of the crash. Consider this new test future-proofing (also covers the enter/exit/defer stuff).

Also dumping the `UICollectionView` internals confirms that the bad state (`_updateCompletionHandler != nil`) is no longer true.

Issue fixed: #929

Depends on #930

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.