### PR TITLE
Allow IGListKit to be used without -ObjC

### DIFF
--- a/Source/Common/IGListMacros.h
+++ b/Source/Common/IGListMacros.h
@@ -7,6 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#include <os/base.h>
+
 #ifndef IGLK_SUBCLASSING_RESTRICTED
 #if defined(__has_attribute) && __has_attribute(objc_subclassing_restricted)
 #define IGLK_SUBCLASSING_RESTRICTED __attribute__((objc_subclassing_restricted))
@@ -18,6 +20,18 @@
 #ifndef IGLK_UNAVAILABLE
 #define IGLK_UNAVAILABLE(message) __attribute__((unavailable(message)))
 #endif // #ifndef IGLK_UNAVAILABLE
+
+// IGLK_LINKABLE and IGLK_LINK_REQUIRE macros allow categories to be used without requiring -ObjC.
+
+// Annotate category @implementation definitions with this macro.
+#define IGLK_LINKABLE(NAME) \
+  const char IGLKLinkable_ ## NAME = 'L';
+
+// Annotate category @interface declarations with this macro.
+#define IGLK_LINK_REQUIRE(NAME) \
+  extern const char IGLKLinkable_ ## NAME; \
+  extern const void *const OS_WEAK IGLKLink_ ## NAME; \
+  const void *const OS_WEAK IGLKLink_ ## NAME = &IGLKLinkable_ ## NAME;
 
 #if IGLK_LOGGING_ENABLED
 #define IGLKLog( s, ... ) do { NSLog( @"IGListKit: %@", [NSString stringWithFormat: (s), ##__VA_ARGS__] ); } while(0)

--- a/Source/Common/NSNumber+IGListDiffable.h
+++ b/Source/Common/NSNumber+IGListDiffable.h
@@ -10,10 +10,12 @@
 #import <Foundation/Foundation.h>
 
 #import <IGListKit/IGListDiffable.h>
+#import <IGListKit/IGListMacros.h>
 
 /**
  This category provides default `IGListDiffable` conformance for `NSNumber`.
  */
+IGLK_LINK_REQUIRE(NSNumber_IGListDiffable)
 @interface NSNumber (IGListDiffable) <IGListDiffable>
 
 @end

--- a/Source/Common/NSNumber+IGListDiffable.m
+++ b/Source/Common/NSNumber+IGListDiffable.m
@@ -9,6 +9,7 @@
 
 #import "NSNumber+IGListDiffable.h"
 
+IGLK_LINKABLE(NSNumber_IGListDiffable)
 @implementation NSNumber (IGListDiffable)
 
 - (id<NSObject>)diffIdentifier {

--- a/Source/Common/NSString+IGListDiffable.h
+++ b/Source/Common/NSString+IGListDiffable.h
@@ -10,10 +10,12 @@
 #import <Foundation/Foundation.h>
 
 #import <IGListKit/IGListDiffable.h>
+#import <IGListKit/IGListMacros.h>
 
 /**
  This category provides default `IGListDiffable` conformance for `NSString`.
  */
+IGLK_LINK_REQUIRE(NSString_IGListDiffable)
 @interface NSString (IGListDiffable) <IGListDiffable>
 
 @end

--- a/Source/Common/NSString+IGListDiffable.m
+++ b/Source/Common/NSString+IGListDiffable.m
@@ -9,6 +9,7 @@
 
 #import "NSString+IGListDiffable.h"
 
+IGLK_LINKABLE(NSString_IGListDiffable)
 @implementation NSString (IGListDiffable)
 
 - (id<NSObject>)diffIdentifier {

--- a/Source/Internal/IGListAdapter+DebugDescription.h
+++ b/Source/Internal/IGListAdapter+DebugDescription.h
@@ -8,7 +8,9 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListMacros.h>
 
+IGLK_LINK_REQUIRE(IGListAdapter_DebugDescription)
 @interface IGListAdapter (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines;

--- a/Source/Internal/IGListAdapter+DebugDescription.m
+++ b/Source/Internal/IGListAdapter+DebugDescription.m
@@ -15,6 +15,7 @@
 #import "UICollectionView+DebugDescription.h"
 #import "IGListDebuggingUtilities.h"
 
+IGLK_LINKABLE(IGListAdapter_DebugDescription)
 @implementation IGListAdapter (DebugDescription)
 
 - (NSString *)debugDescription {

--- a/Source/Internal/IGListAdapter+UICollectionView.h
+++ b/Source/Internal/IGListAdapter+UICollectionView.h
@@ -10,7 +10,9 @@
 #import <UIKit/UIKit.h>
 
 #import <IGListKit/IGListAdapter.h>
+#import <IGListKit/IGListMacros.h>
 
+IGLK_LINK_REQUIRE(IGListAdapter_UICollectionView)
 @interface IGListAdapter (UICollectionView)
 <
 UICollectionViewDataSource,

--- a/Source/Internal/IGListAdapter+UICollectionView.m
+++ b/Source/Internal/IGListAdapter+UICollectionView.m
@@ -13,6 +13,7 @@
 #import <IGListKit/IGListAssert.h>
 #import <IGListKit/IGListSectionController.h>
 
+IGLK_LINKABLE(IGListAdapter_UICollectionView)
 @implementation IGListAdapter (UICollectionView)
 
 #pragma mark - UICollectionViewDataSource

--- a/Source/Internal/IGListAdapterUpdater+DebugDescription.h
+++ b/Source/Internal/IGListAdapterUpdater+DebugDescription.h
@@ -8,7 +8,9 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListMacros.h>
 
+IGLK_LINK_REQUIRE(IGListAdapterUpdater_DebugDescription)
 @interface IGListAdapterUpdater (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines;

--- a/Source/Internal/IGListAdapterUpdater+DebugDescription.m
+++ b/Source/Internal/IGListAdapterUpdater+DebugDescription.m
@@ -24,6 +24,7 @@ static NSMutableArray *linesFromObjects(NSArray *objects) {
 }
 #endif // #if IGLK_DEBUG_DESCRIPTION_ENABLED
 
+IGLK_LINKABLE(IGListAdapterUpdater_DebugDescription)
 @implementation IGListAdapterUpdater (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines {

--- a/Source/Internal/IGListBatchUpdateData+DebugDescription.h
+++ b/Source/Internal/IGListBatchUpdateData+DebugDescription.h
@@ -8,7 +8,9 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListMacros.h>
 
+IGLK_LINK_REQUIRE(IGListBatchUpdateData_DebugDescription)
 @interface IGListBatchUpdateData (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines;

--- a/Source/Internal/IGListBatchUpdateData+DebugDescription.m
+++ b/Source/Internal/IGListBatchUpdateData+DebugDescription.m
@@ -9,6 +9,7 @@
 
 #import "IGListBatchUpdateData+DebugDescription.h"
 
+IGLK_LINKABLE(IGListBatchUpdateData_DebugDescription)
 @implementation IGListBatchUpdateData (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines {

--- a/Source/Internal/IGListBindingSectionController+DebugDescription.h
+++ b/Source/Internal/IGListBindingSectionController+DebugDescription.h
@@ -8,7 +8,9 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListMacros.h>
 
+IGLK_LINK_REQUIRE(IGListBindingSectionController_DebugDescription)
 @interface IGListBindingSectionController (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines;

--- a/Source/Internal/IGListBindingSectionController+DebugDescription.m
+++ b/Source/Internal/IGListBindingSectionController+DebugDescription.m
@@ -11,6 +11,7 @@
 
 #import "IGListDebuggingUtilities.h"
 
+IGLK_LINKABLE(IGListBindingSectionController_DebugDescription)
 @implementation IGListBindingSectionController (DebugDescription)
 
 - (NSString *)debugDescription {

--- a/Source/Internal/IGListSectionMap+DebugDescription.h
+++ b/Source/Internal/IGListSectionMap+DebugDescription.h
@@ -9,8 +9,10 @@
 
 #import <Foundation/Foundation.h>
 
+#import <IGListKit/IGListMacros.h>
 #import "IGListSectionMap.h"
 
+IGLK_LINK_REQUIRE(IGListSectionMap_DebugDescription)
 @interface IGListSectionMap (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines;

--- a/Source/Internal/IGListSectionMap+DebugDescription.m
+++ b/Source/Internal/IGListSectionMap+DebugDescription.m
@@ -10,6 +10,7 @@
 #import "IGListSectionMap+DebugDescription.h"
 #import "IGListBindingSectionController.h"
 
+IGLK_LINKABLE(IGListSectionMap_DebugDescription)
 @implementation IGListSectionMap (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines {

--- a/Source/Internal/UICollectionView+DebugDescription.h
+++ b/Source/Internal/UICollectionView+DebugDescription.h
@@ -9,6 +9,9 @@
 
 #import <UIKit/UIKit.h>
 
+#import <IGListKit/IGListMacros.h>
+
+IGLK_LINK_REQUIRE(UICollectionView_DebugDescription)
 @interface UICollectionView (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines;

--- a/Source/Internal/UICollectionView+DebugDescription.m
+++ b/Source/Internal/UICollectionView+DebugDescription.m
@@ -11,6 +11,7 @@
 
 #import <IGListKit/IGListMacros.h>
 
+IGLK_LINKABLE(UICollectionView_DebugDescription)
 @implementation UICollectionView (DebugDescription)
 
 - (NSArray<NSString *> *)debugDescriptionLines {

--- a/Source/Internal/UICollectionView+IGListBatchUpdateData.h
+++ b/Source/Internal/UICollectionView+IGListBatchUpdateData.h
@@ -9,8 +9,11 @@
 
 #import <UIKit/UIKit.h>
 
+#import <IGListKit/IGListMacros.h>
+
 @class IGListBatchUpdateData;
 
+IGLK_LINK_REQUIRE(UICollectionView_IGListBatchUpdateData)
 @interface UICollectionView (IGListBatchUpdateData)
 
 - (void)ig_applyBatchUpdateData:(IGListBatchUpdateData *)updateData;

--- a/Source/Internal/UICollectionView+IGListBatchUpdateData.m
+++ b/Source/Internal/UICollectionView+IGListBatchUpdateData.m
@@ -11,6 +11,7 @@
 
 #import "IGListBatchUpdateData.h"
 
+IGLK_LINKABLE(UICollectionView_IGListBatchUpdateData)
 @implementation UICollectionView (IGListBatchUpdateData)
 
 - (void)ig_applyBatchUpdateData:(IGListBatchUpdateData *)updateData {


### PR DESCRIPTION
The `-ObjC` linker flag is used to work around a mismatch between how Mach-O
files are linked, and how the Objective-C runtime operates.

With this change, IGListKit can be used without requiring the `-ObjC` linker flag.

This change annotates the headers and sources for categories. Categories are the primary reason for using the `-ObjC` flag. The annotations setup dummy variables which create a relationship between files that `#import` a category, and the file that implements a category. These dummy variables are marked weak, to prevent redundant copies of them. Also, the `-dead_strip` flag will remove the dummy variables from the final binary.

Related, see: "What causes those exceptions?" in https://developer.apple.com/library/content/qa/qa1490/_index.html

#trivial

## Changes in this pull request

Issue fixed: #

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
