### PR TITLE
Negative size assertion

### DIFF
--- a/Source/Internal/IGListAdapter+UICollectionView.m
+++ b/Source/Internal/IGListAdapter+UICollectionView.m
@@ -178,8 +178,8 @@
     IGAssert(![self.collectionViewDelegate respondsToSelector:_cmd], @"IGListAdapter is consuming method also implemented by the collectionViewDelegate: %@", NSStringFromSelector(_cmd));
     
     CGSize size = [self sizeForItemAtIndexPath:indexPath];
-    IGAssert(!isnan(size.height), @"IGListAdapter returned negative height %f for item at indexPath <%@>", size.height, indexPath);
-    IGAssert(!isnan(size.width), @"IGListAdapter returned negative width %f for item at indexPath <%@>", size.width, indexPath);
+    IGAssert(!isnan(size.height), @"IGListAdapter returned negative height = %f for item at indexPath <%@>", size.height, indexPath);
+    IGAssert(!isnan(size.width), @"IGListAdapter returned negative width = %f for item at indexPath <%@>", size.width, indexPath);
     
     return size;
 }

--- a/Source/Internal/IGListAdapter+UICollectionView.m
+++ b/Source/Internal/IGListAdapter+UICollectionView.m
@@ -176,7 +176,12 @@
 
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath {
     IGAssert(![self.collectionViewDelegate respondsToSelector:_cmd], @"IGListAdapter is consuming method also implemented by the collectionViewDelegate: %@", NSStringFromSelector(_cmd));
-    return [self sizeForItemAtIndexPath:indexPath];
+    
+    CGSize size = [self sizeForItemAtIndexPath:indexPath];
+    IGAssert(!isnan(size.height), @"IGListAdapter returned negative height %f for item at indexPath <%@>", size.height, indexPath);
+    IGAssert(!isnan(size.width), @"IGListAdapter returned negative width %f for item at indexPath <%@>", size.width, indexPath);
+    
+    return size;
 }
 
 - (UIEdgeInsets)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout insetForSectionAtIndex:(NSInteger)section {

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -17,6 +17,7 @@
 #import "IGListAdapterInternal.h"
 #import "IGListTestAdapterDataSource.h"
 #import "IGListTestAdapterHorizontalDataSource.h"
+#import "IGListTestOffsettingLayout.h"
 #import "IGListTestSection.h"
 #import "IGTestSupplementarySource.h"
 #import "IGTestNibSupplementaryView.h"
@@ -1289,6 +1290,42 @@
     const CGSize size = [self.adapter sizeForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:0]];
     XCTAssertEqual(size.width, 0.0);
     XCTAssertEqual(size.height, 0.0);
+}
+
+- (void)test_whenSectionControllerReturnsNANHeight_thatAssertionFires {
+    self.adapter.collectionView.collectionViewLayout = [IGListTestOffsettingLayout new];
+    self.dataSource.objects = @[@1];
+    [self.adapter reloadDataWithCompletion:nil];
+    
+    IGListTestSection *section = [self.adapter sectionControllerForObject:self.dataSource.objects[0]];
+    section.size = CGSizeMake(NAN, 1);
+    
+    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+    XCTAssertThrows([self.adapter collectionView:self.collectionView layout:self.collectionView.collectionViewLayout sizeForItemAtIndexPath:indexPath]);
+}
+
+- (void)test_whenSectionControllerReturnsNANWidth_thatAssertionFires {
+    self.adapter.collectionView.collectionViewLayout = [IGListTestOffsettingLayout new];
+    self.dataSource.objects = @[@1];
+    [self.adapter reloadDataWithCompletion:nil];
+    
+    IGListTestSection *section = [self.adapter sectionControllerForObject:self.dataSource.objects[0]];
+    section.size = CGSizeMake(1, NAN);
+    
+    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+    XCTAssertThrows([self.adapter collectionView:self.collectionView layout:self.collectionView.collectionViewLayout sizeForItemAtIndexPath:indexPath]);
+}
+
+- (void)test_whenSectionControllerReturnsNANWidthNANHeight_thatAssertionFires {
+    self.adapter.collectionView.collectionViewLayout = [IGListTestOffsettingLayout new];
+    self.dataSource.objects = @[@1];
+    [self.adapter reloadDataWithCompletion:nil];
+    
+    IGListTestSection *section = [self.adapter sectionControllerForObject:self.dataSource.objects[0]];
+    section.size = CGSizeMake(NAN, NAN);
+    
+    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
+    XCTAssertThrows([self.adapter collectionView:self.collectionView layout:self.collectionView.collectionViewLayout sizeForItemAtIndexPath:indexPath]);
 }
 
 - (void)test_whenSupplementarySourceReturnsNegativeSize_thatAdapterReturnsZero {


### PR DESCRIPTION
## Changes in this pull request

Assertions for item's size added to prevent negative values return from IGListAdapter

Issue fixed: #977 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)