### PR TITLE
Copy and nil block queue before executing #trivial

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -749,10 +749,11 @@
 }
 
 - (void)exitBatchUpdates {
-    for (void (^block)(void) in _queuedCompletionBlocks) {
+    NSArray *blocks = [_queuedCompletionBlocks copy];
+    _queuedCompletionBlocks = nil;
+    for (void (^block)(void) in blocks) {
         block();
     }
-    _queuedCompletionBlocks = nil;
 }
 
 #pragma mark - UIScrollViewDelegate


### PR DESCRIPTION
Discovered in rnystrom/GitHawk#781 and introduced in d9a89c9b00aa1a9537a24d9affb6919f83065f65. Can't repro in unit test, but have obvious stack traces (see GitHawk issue) that collection is being mutated while enumerated.

No changelog since this is a new fix for 3.2.