### PR TITLE
Added support UICollectionElementKindSectionFooter for IGListCollectionViewLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Updated project settings for iOS 11. [Ryan Nystrom](https://github.com/rnystrom) [(#942)](https://github.com/Instagram/IGListKit/pull/942)
 
+- Added support UICollectionElementKindSectionFooter for IGListCollectionViewLayout [(#1017)](https://github.com/Instagram/IGListKit/pull/1017)
+
 ### Fixes
 
 - Weakly reference the `UICollectionView` in coalescence so that it can be released if the rest of system is destroyed. [Ryan Nystrom](https://github.com/rnystrom) [(#tbd)](https://github.com/Instagram/IGListKit/pull/tbd)

--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		98B4DBF41DC2937A002BA58A /* Demo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98B4DBF31DC2937A002BA58A /* Demo.storyboard */; };
 		C82AE9741251907F18F77350 /* Pods_IGListKitMessageExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7B1FA2EFFA5E994FEE587DE /* Pods_IGListKitMessageExample.framework */; };
 		CBA8F64BE2F00E8B3DEFF6ED /* Pods_IGListKitExamples.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE7316EF8201F89655D39E53 /* Pods_IGListKitExamples.framework */; };
+		FF73FF9C1FBA4B4400F2AB06 /* UserFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF73FF9B1FBA4B4400F2AB06 /* UserFooterView.swift */; };
+		FF73FF9E1FBA4B5500F2AB06 /* UserFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FF73FF9D1FBA4B5500F2AB06 /* UserFooterView.xib */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -243,6 +245,8 @@
 		C544C2903D822EF8E4E91142 /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitExamples.release.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitExamples/Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
 		F59714C01F184FD73C2AE02F /* Pods-IGListKitMessageExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitMessageExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitMessageExample/Pods-IGListKitMessageExample.debug.xcconfig"; sourceTree = "<group>"; };
 		FE7316EF8201F89655D39E53 /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IGListKitExamples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF73FF9B1FBA4B4400F2AB06 /* UserFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFooterView.swift; sourceTree = "<group>"; };
+		FF73FF9D1FBA4B5500F2AB06 /* UserFooterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserFooterView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -436,6 +440,8 @@
 				2961B3A81D68B0B5001C9451 /* SpinnerCell.swift */,
 				821BC4B71DB8B48300172ED0 /* StoryboardCell.swift */,
 				29C629821DCFDB57004A5BB1 /* UserHeaderView.swift */,
+				FF73FF9B1FBA4B4400F2AB06 /* UserFooterView.swift */,
+				FF73FF9D1FBA4B5500F2AB06 /* UserFooterView.xib */,
 				29C629801DCFDAF3004A5BB1 /* UserHeaderView.xib */,
 				56C05B6A1E49B2E80026DB39 /* UserInfoCell.h */,
 				56C05B6B1E49B2E80026DB39 /* UserInfoCell.m */,
@@ -666,6 +672,7 @@
 			files = (
 				29C629811DCFDAF3004A5BB1 /* UserHeaderView.xib in Resources */,
 				296DD75B1DD217C000206780 /* NibSelfSizingCell.xib in Resources */,
+				FF73FF9E1FBA4B5500F2AB06 /* UserFooterView.xib in Resources */,
 				2961B3981D68B031001C9451 /* LaunchScreen.storyboard in Resources */,
 				26271C921DAE9EFC0073E116 /* NibCell.xib in Resources */,
 				2961B3951D68B031001C9451 /* Assets.xcassets in Resources */,
@@ -866,6 +873,7 @@
 				56C05B751E49B33C0026DB39 /* InteractiveCell.m in Sources */,
 				2991F9301D7BC0E400B0C58F /* EmptyViewController.swift in Sources */,
 				29F7E2AF1E92858500197586 /* ListeningSectionController.swift in Sources */,
+				FF73FF9C1FBA4B4400F2AB06 /* UserFooterView.swift in Sources */,
 				29D2E4AD1DD69B6000CD255D /* DisplaySectionController.swift in Sources */,
 				2991F91E1D7BB30C00B0C58F /* User.swift in Sources */,
 				2991F9241D7BB89F00B0C58F /* NestedAdapterViewController.swift in Sources */,

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/FeedItemSectionController.swift
@@ -48,24 +48,48 @@ final class FeedItemSectionController: ListSectionController, ListSupplementaryV
     // MARK: ListSupplementaryViewSource
 
     func supportedElementKinds() -> [String] {
-        return [UICollectionElementKindSectionHeader]
+        return [UICollectionElementKindSectionHeader, UICollectionElementKindSectionFooter]
     }
 
     func viewForSupplementaryElement(ofKind elementKind: String, at index: Int) -> UICollectionReusableView {
-        guard let view = collectionContext?.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader,
-                                                                       for: self,
-                                                                       nibName: "UserHeaderView",
-                                                                       bundle: nil,
-                                                                       at: index) as? UserHeaderView else {
-                                                                        fatalError()
+        switch elementKind {
+        case UICollectionElementKindSectionHeader:
+            return userHeaderView(atIndex: index)
+        case UICollectionElementKindSectionFooter:
+            return userFooterView(atIndex: index)
+        default:
+            fatalError()
         }
-        view.handle = "@" + feedItem.user.handle
-        view.name = feedItem.user.name
-        return view
     }
 
     func sizeForSupplementaryView(ofKind elementKind: String, at index: Int) -> CGSize {
         return CGSize(width: collectionContext!.containerSize.width, height: 40)
     }
 
+    // MARK: Private
+    private func userHeaderView(atIndex index: Int) -> UICollectionReusableView {
+        guard let view = collectionContext?.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionHeader,
+                                                                             for: self,
+                                                                             nibName: "UserHeaderView",
+                                                                             bundle: nil,
+                                                                             at: index) as? UserHeaderView else {
+                                                                                fatalError()
+        }
+        view.handle = "@" + feedItem.user.handle
+        view.name = feedItem.user.name
+        return view
+    }
+    
+    private func userFooterView(atIndex index: Int) -> UICollectionReusableView {
+        guard let view = collectionContext?.dequeueReusableSupplementaryView(ofKind: UICollectionElementKindSectionFooter,
+                                                                             for: self,
+                                                                             nibName: "UserFooterView",
+                                                                             bundle: nil,
+                                                                             at: index) as? UserFooterView else {
+                                                                                fatalError()
+        }
+        
+        view.commentsCount = "\(feedItem.comments.count)"
+        return view
+    }
 }

--- a/Examples/Examples-iOS/IGListKitExamples/Views/UserFooterView.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/UserFooterView.swift
@@ -1,0 +1,30 @@
+/**
+ Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+ 
+ The examples provided by Facebook are for non-commercial testing and evaluation
+ purposes only. Facebook reserves all rights not expressly granted.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import UIKit
+
+final class UserFooterView: UICollectionViewCell {
+    
+    @IBOutlet private weak var commentsCountLabel: UILabel!
+    
+    var commentsCount: String? {
+        get {
+            return commentsCountLabel.text
+        }
+        set {
+            commentsCountLabel.text = newValue
+        }
+    }
+    
+}

--- a/Examples/Examples-iOS/IGListKitExamples/Views/UserFooterView.xib
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/UserFooterView.xib
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="sK0-Gb-e13" customClass="UserFooterView" customModule="IGListKitExamples" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="312" height="50"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="312" height="50"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments Count" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pey-dw-Req" userLabel="Posts Label">
+                        <rect key="frame" x="15" y="16.5" width="127.5" height="18"/>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H34-DS-ndd" userLabel="Posts Count Label">
+                        <rect key="frame" x="259.5" y="16" width="37.5" height="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <color key="textColor" red="0.46274509800000002" green="0.52941176469999995" blue="0.61568627450000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+            </view>
+            <color key="backgroundColor" white="0.90492134349999998" alpha="1" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="Pey-dw-Req" firstAttribute="centerY" secondItem="sK0-Gb-e13" secondAttribute="centerY" id="IW4-A8-AHN"/>
+                <constraint firstAttribute="trailing" secondItem="H34-DS-ndd" secondAttribute="trailing" constant="15" id="N4i-rG-Bx7"/>
+                <constraint firstItem="H34-DS-ndd" firstAttribute="centerY" secondItem="sK0-Gb-e13" secondAttribute="centerY" id="Ohg-3S-N1c"/>
+                <constraint firstItem="Pey-dw-Req" firstAttribute="leading" secondItem="sK0-Gb-e13" secondAttribute="leading" constant="15" id="rlg-Sg-YQE"/>
+            </constraints>
+            <size key="customSize" width="312" height="50"/>
+            <connections>
+                <outlet property="commentsCountLabel" destination="H34-DS-ndd" id="45B-Yl-fi4"/>
+            </connections>
+            <point key="canvasLocation" x="-10" y="-282"/>
+        </collectionViewCell>
+    </objects>
+</document>

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -106,8 +106,6 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
             attributes.zIndex = baseZIndex + attributes.indexPath.item;
             break;
         case UICollectionElementCategorySupplementaryView:
-            IGAssert([attributes.representedElementKind isEqualToString:UICollectionElementKindSectionHeader],
-                     @"Only support for element kind header, not %@", attributes.representedElementKind);
             attributes.zIndex = baseZIndex + maxZIndexPerSection - 1;
             break;
         case UICollectionElementCategoryDecorationView:

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -106,11 +106,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
             attributes.zIndex = baseZIndex + attributes.indexPath.item;
             break;
         case UICollectionElementCategorySupplementaryView:
-            if ([attributes.representedElementKind isEqualToString:UICollectionElementKindSectionFooter]) {
-                attributes.zIndex = baseZIndex + maxZIndexPerSection + 1;
-            } else {
-                attributes.zIndex = baseZIndex + maxZIndexPerSection - 1;
-            }
+            attributes.zIndex = baseZIndex + maxZIndexPerSection - 1;
             break;
         case UICollectionElementCategoryDecorationView:
             attributes.zIndex = baseZIndex - 1;

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -549,7 +549,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
                         CGRectGetMaxY(rollingSectionBounds),
                         paddedLengthInFixedDirection,
                         footerSize.height) :
-                CGRectMake(CGRectGetMaxX(rollingSectionBounds),
+                CGRectMake(CGRectGetMaxX(rollingSectionBounds) + insets.right,
                         insets.top,
                         footerSize.width,
                         paddedLengthInFixedDirection);

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -37,18 +37,26 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     return [self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionHeader atIndexPath:genIndexPath(section, 0)];
 }
 
+- (UICollectionReusableView *)footerForSection:(NSInteger)section {
+    return [self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:genIndexPath(section, 0)];
+}
+
 - (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset {
     [self setUpWithStickyHeaders:sticky topInset:inset stretchToEdge:NO];
 }
 
-- (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
-    [self setUpWithStickyHeaders:sticky scrollDirection:UICollectionViewScrollDirectionVertical topInset:inset stretchToEdge:stretchToEdge];
+- (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset testFrame:(CGRect)testFrame {
+    [self setUpWithStickyHeaders:sticky scrollDirection:UICollectionViewScrollDirectionVertical topInset:inset stretchToEdge:NO testFrame:testFrame];
 }
 
-- (void)setUpWithStickyHeaders:(BOOL)sticky scrollDirection:(UICollectionViewScrollDirection)scrollDirection topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
+- (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge {
+    [self setUpWithStickyHeaders:sticky scrollDirection:UICollectionViewScrollDirectionVertical topInset:inset stretchToEdge:stretchToEdge testFrame:kTestFrame];
+}
+
+- (void)setUpWithStickyHeaders:(BOOL)sticky scrollDirection:(UICollectionViewScrollDirection)scrollDirection topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge testFrame:(CGRect)testFrame {
     self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky scrollDirection:scrollDirection topContentInset:inset stretchToEdge:stretchToEdge];
     self.dataSource = [IGLayoutTestDataSource new];
-    self.collectionView = [[UICollectionView alloc] initWithFrame:kTestFrame collectionViewLayout:self.layout];
+    self.collectionView = [[UICollectionView alloc] initWithFrame:testFrame collectionViewLayout:self.layout];
     self.collectionView.dataSource = self.dataSource;
     self.collectionView.delegate = self.dataSource;
     [self.dataSource configCollectionView:self.collectionView];
@@ -86,22 +94,25 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 30}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 120);
     IGAssertEqualFrame([self headerForSection:0].frame, 10, 10, 85, 10);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 10, 20, 85, 10);
@@ -110,30 +121,106 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 85, 85, 30);
 }
 
--(void)test_whenLayingOutCellsHorizontally_withHeaderHeight_withLineSpacing_withInsets_thatFramesCorrect {
-    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
+- (void)test_whenLayingOutCellsVertically_withFooterHeight_withLineSpacing_withInsets_thatFramesCorrect {
+    [self setUpWithStickyHeaders:NO topInset:0 testFrame:CGRectMake(0, 0, 100, 150)];
+
+    const CGFloat footerHeight = 10;
+    const CGFloat lineSpacing = 10;
+    const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
+
+    [self prepareWithData:@[
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:footerHeight
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:footerHeight
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 30}],
+                                                  ]],
+    ]];
+
+    XCTAssertEqual(self.collectionView.contentSize.height, 120);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 10, 10, 85, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 10, 30, 85, 20);
+    IGAssertEqualFrame([self footerForSection:0].frame, 10, 50, 85, 10);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 75, 85, 30);
+    IGAssertEqualFrame([self footerForSection:1].frame, 10, 105, 85, 10);
+}
+
+- (void)test_whenLayingOutCellsVertically_withHeaderHeight_withFooterHeight_withLineSpacing_withInsets_thatFramesCorrect {
+    [self setUpWithStickyHeaders:NO topInset:0 testFrame:CGRectMake(0, 0, 100, 150)];
+
+    const CGFloat headerHeight = 10;
+    const CGFloat footerHeight = 10;
+    const CGFloat lineSpacing = 10;
+    const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
+
+    [self prepareWithData:@[
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:footerHeight
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:footerHeight
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 30}],
+                                                  ]],
+    ]];
+
+    XCTAssertEqual(self.collectionView.contentSize.height, 140);
+    IGAssertEqualFrame([self headerForSection:0].frame, 10, 10, 85, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 10, 20, 85, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 10, 40, 85, 20);
+    IGAssertEqualFrame([self footerForSection:0].frame, 10, 60, 85, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 10, 85, 85, 10);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 95, 85, 30);
+    IGAssertEqualFrame([self footerForSection:1].frame, 10, 125, 85, 10);
+}
+
+- (void)test_whenLayingOutCellsHorizontally_withHeaderHeight_withLineSpacing_withInsets_thatFramesCorrect {
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO testFrame:kTestFrame];
     
     const CGFloat headerHeight = 10;
     const CGFloat lineSpacing = 10;
     const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
-    
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){45,10}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){45,20}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){45,30}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {45, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {45, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {45, 30}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.width, 140);
     IGAssertEqualFrame([self headerForSection:0].frame, 10, 10, 10, 85);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 20, 10, 45, 10);
@@ -142,29 +229,65 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 90, 10, 45, 30);
 }
 
+- (void)test_whenLayingOutCellsHorizontally_withFooterHeight_withLineSpacing_withInsets_thatFramesCorrect {
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO testFrame:kTestFrame];
+
+    const CGFloat footerHeight = 10;
+    const CGFloat lineSpacing = 10;
+    const UIEdgeInsets insets = UIEdgeInsetsMake(10, 10, 5, 5);
+
+    [self prepareWithData:@[
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:footerHeight
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {45, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {45, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets
+                                            lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:footerHeight
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {45, 30}],
+                                                  ]],
+    ]];
+
+    XCTAssertEqual(self.collectionView.contentSize.width, 75);
+    IGAssertEqualFrame([self footerForSection:0].frame, 60, 10, 10, 85);
+    IGAssertEqualFrame([self cellForSection:0 item:0].frame, 10, 10, 45, 10);
+    IGAssertEqualFrame([self cellForSection:0 item:1].frame, 10, 20, 45, 20);
+    IGAssertEqualFrame([self footerForSection:1].frame, 60, 10, 10, 85);
+    IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 55, 45, 30);
+}
 
 - (void)test_whenUsingStickyHeaders_withSimulatedScrolling_thatYPositionsAdjusted {
     [self setUpWithStickyHeaders:YES topInset:10];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 20}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 30}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 30}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 30}],
+                                                  ]],
+    ]];
 
     // scroll header 0 halfway
     self.collectionView.contentOffset = CGPointMake(0, 5);
@@ -180,27 +303,29 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 - (void)test_whenUsingStickyHeaders_withSimulatedHorizontalScrolling_thatXPositionsAdjusted {
-    [self setUpWithStickyHeaders:YES scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:10 stretchToEdge:NO];
-    
+    [self setUpWithStickyHeaders:YES scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:10 stretchToEdge:NO testFrame:kTestFrame];
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){20,100}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){20,100}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){30,100}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){30,100}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){30,100}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {20, 100}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {20, 100}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {30, 100}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {30, 100}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {30, 100}],
+                                                  ]],
+    ]];
     
     // scroll header 0 halfway
     self.collectionView.contentOffset = CGPointMake(5, 0);
@@ -219,24 +344,26 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:YES topInset:10];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,10}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,30}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,40}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){100,50}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 30}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 40}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 50}],
+                                                  ]],
+    ]];
 
     // scroll header 0 off and 1 up
     self.collectionView.contentOffset = CGPointMake(0, 35);
@@ -259,23 +386,26 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 66);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:0 item:1].frame, 33, 0, 33, 33);
@@ -287,16 +417,18 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0.5
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0.5
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     const CGRect rect = IGListRectIntegralScaled(CGRectMake(33.5, 0, 33, 33));
@@ -305,19 +437,21 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 - (void)test_whenItemsLargerThanContainerHeight_withHorizontalScrolling_with5PointItemSpacing_with0Insets_with10PointLineSpacing_thatItemsBumpToNewColumn {
-    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
-    
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO testFrame:kTestFrame];
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:10
-                                                       interitemSpacing:5
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:10
+                                       interitemSpacing:5
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.width, 76);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:0 item:1].frame, 0, 38, 33, 33);
@@ -328,28 +462,32 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 33, 0, 33, 33);
@@ -357,31 +495,32 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 }
 
 - (void)test_whenSectionsSmallerThanContainerHeight_withHorizontalScrolling_with0ItemSpacing_with0Insets_with0LineSpacing_thatSectionsFitSameColumn {
-    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
-    
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO testFrame:kTestFrame];
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.width, 33);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 33, 33, 33);
@@ -392,28 +531,32 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0.5
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0.5
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0.5
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0.5
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0.5
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0.5
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     const CGRect rect = IGListRectIntegralScaled(CGRectMake(33.5, 0, 33, 33));
@@ -425,35 +568,40 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){13,50}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 10, 10)
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {13, 50}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 103);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 43, 10, 13, 50);
@@ -465,21 +613,24 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 5, 5)
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,50}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsMake(10, 10, 5, 5)
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 50}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 98);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 10, 43, 85, 50);
@@ -489,45 +640,51 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 76);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 0, 43, 33, 33);
 }
 
 - (void)test_whenSectionsSmallerThanHeight_withHorizontalScrolling_withSectionHeader_thatHeaderCausesNewline {
-    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO];
-    
+    [self setUpWithStickyHeaders:NO scrollDirection:UICollectionViewScrollDirectionHorizontal topInset:0 stretchToEdge:NO testFrame:kTestFrame];
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.width, 76);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:1 item:0].frame, 43, 0, 33, 33);
@@ -544,76 +701,80 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     self.collectionView.frame = CGRectMake(0, 0, 100, 400);
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,60}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                            lineSpacing:lineSpacing
-                                                       interitemSpacing:0
-                                                           headerHeight:headerHeight
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:insets lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 20}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 30}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 60}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:insets lineSpacing:lineSpacing
+                                       interitemSpacing:0
+                                           headerHeight:headerHeight
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 40}],
+                                                  ]],
+    ]];
 
     XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
 
     [self.collectionView performBatchUpdates:^{
         self.dataSource.sections = @[
-                                     [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                                     lineSpacing:lineSpacing
-                                                                interitemSpacing:0
-                                                                    headerHeight:headerHeight
-                                                                           items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}], // reloaded
-                                                                                   // deleted
-                                                                                   ]],
-                                     // moved from section 3 to 1
-                                     [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                                     lineSpacing:lineSpacing
-                                                                interitemSpacing:0
-                                                                    headerHeight:headerHeight
-                                                                           items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,40}],
-                                                                                   ]],
-                                     // deleted section 2
-                                     [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                                     lineSpacing:lineSpacing
-                                                                interitemSpacing:0
-                                                                    headerHeight:headerHeight
-                                                                           items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,30}],
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}], // inserted
-                                                                                   ]],
-                                     // inserted
-                                     [[IGLayoutTestSection alloc] initWithInsets:insets
-                                                                     lineSpacing:lineSpacing
-                                                                interitemSpacing:0
-                                                                    headerHeight:headerHeight
-                                                                           items:@[
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,10}],
-                                                                                   [[IGLayoutTestItem alloc] initWithSize:(CGSize){85,20}],
-                                                                                   ]],
-                                     ];
+                [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                lineSpacing:lineSpacing
+                                           interitemSpacing:0
+                                               headerHeight:headerHeight
+                                               footerHeight:0
+                                                      items:@[
+                                                              [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 30}], // reloaded
+                                                              // deleted
+                                                      ]],
+                // moved from section 3 to 1
+                [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                lineSpacing:lineSpacing
+                                           interitemSpacing:0
+                                               headerHeight:headerHeight
+                                               footerHeight:0
+                                                      items:@[
+                                                              [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 40}],
+                                                      ]],
+                // deleted section 2
+                [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                lineSpacing:lineSpacing
+                                           interitemSpacing:0
+                                               headerHeight:headerHeight
+                                               footerHeight:0
+                                                      items:@[
+                                                              [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 30}],
+                                                              [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 10}], // inserted
+                                                      ]],
+                // inserted
+                [[IGLayoutTestSection alloc] initWithInsets:insets
+                                                lineSpacing:lineSpacing
+                                           interitemSpacing:0
+                                               headerHeight:headerHeight
+                                               footerHeight:0
+                                                      items:@[
+                                                              [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 10}],
+                                                              [[IGLayoutTestItem alloc] initWithSize:(CGSize) {85, 20}],
+                                                      ]],
+        ];
 
         [self.collectionView deleteSections:[NSIndexSet indexSetWithIndex:2]];
         [self.collectionView insertSections:[NSIndexSet indexSetWithIndex:3]];
@@ -652,16 +813,17 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 
     NSMutableArray *items = [NSMutableArray new];
     for (NSInteger i = 0; i < 1000; i++) {
-        [items addObject:[[IGLayoutTestItem alloc] initWithSize:(CGSize){100,20}]];
+        [items addObject:[[IGLayoutTestItem alloc] initWithSize:(CGSize) {100, 20}]];
     }
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:items]
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:items]
+    ]];
 
     XCTAssertEqual([self.layout layoutAttributesForElementsInRect:CGRectMake(0, 500, 100, 100)].count, 5);
     XCTAssertEqual([self.layout layoutAttributesForElementsInRect:CGRectMake(0, 0, 100, 1000)].count, 50);
@@ -677,10 +839,11 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
                                                         lineSpacing:0
                                                    interitemSpacing:0
                                                        headerHeight:0
+                                                       footerHeight:0
                                                               items:@[
-                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize){50, 100}],
-                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize){50, 10}],
-                                                                      ]]];
+                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize) {50, 100}],
+                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize) {50, 10}],
+                                                              ]]];
     }
     [self prepareWithData:data];
     
@@ -704,11 +867,12 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
                                                         lineSpacing:0
                                                    interitemSpacing:0
                                                        headerHeight:0
+                                                       footerHeight:0
                                                               items:@[
-                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize){30, 100}],
-                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize){30, 10}],
-                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize){30, 10}],
-                                                                      ]]];
+                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize) {30, 100}],
+                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize) {30, 10}],
+                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize) {30, 10}],
+                                                              ]]];
     }
     [self prepareWithData:data];
     
@@ -731,28 +895,31 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){33,33}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {33, 33}],
+                                                  ]],
+    ]];
 
     XCTAssertEqual(self.collectionView.contentSize.height, 33);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
@@ -774,15 +941,17 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     self.collectionView.contentInset = UIEdgeInsetsMake(0, 30, 0, 30);
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:10
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){40,10}],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize){40,20}],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:10
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {40, 10}],
+                                                          [[IGLayoutTestItem alloc] initWithSize:(CGSize) {40, 20}],
+                                                  ]],
+    ]];
+
     XCTAssertEqual(self.collectionView.contentSize.height, 40);
     IGAssertEqualFrame([self headerForSection:0].frame, 0, 0, 40, 10);
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 10, 40, 10);
@@ -794,16 +963,17 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 
     const CGSize size = CGSizeMake(33, 33);
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:size],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:size],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:size],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:size],
+                                                          [[IGLayoutTestItem alloc] initWithSize:size],
+                                                          [[IGLayoutTestItem alloc] initWithSize:size],
+                                                  ]],
+    ]];
 
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:0 item:1].frame, 33, 0, 33, 33);
@@ -814,15 +984,16 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0 stretchToEdge:YES];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(33, 33)],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(65, 33)],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(33, 33)],
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(65, 33)],
+                                                  ]],
+    ]];
 
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 33, 33);
     IGAssertEqualFrame([self cellForSection:0 item:1].frame, 33, 0, 65, 33);
@@ -832,15 +1003,16 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(50, 50)],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(51, 50)],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(50, 50)],
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(51, 50)],
+                                                  ]],
+    ]];
 
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 50, 50);
     IGAssertEqualFrame([self cellForSection:0 item:1].frame, 50, 0, 51, 50);
@@ -850,15 +1022,16 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     [self setUpWithStickyHeaders:NO topInset:0];
 
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(50, 50)],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(52, 50)],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(50, 50)],
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(52, 50)],
+                                                  ]],
+    ]];
 
     IGAssertEqualFrame([self cellForSection:0 item:0].frame, 0, 0, 50, 50);
     IGAssertEqualFrame([self cellForSection:0 item:1].frame, 0, 50, 52, 50);
@@ -874,9 +1047,10 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
                                                         lineSpacing:0
                                                    interitemSpacing:0
                                                        headerHeight:0
+                                                       footerHeight:0
                                                               items:@[
-                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize){136, 136}],
-                                                                      ]]];
+                                                                      [[IGLayoutTestItem alloc] initWithSize:(CGSize) {136, 136}],
+                                                              ]]];
     }
     [self prepareWithData:data];
 
@@ -891,31 +1065,37 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 
 - (void)test_whenQueryingAttributes_withSectionOOB_thatReturnsNil {
     [self setUpWithStickyHeaders:NO topInset:0 stretchToEdge:YES];
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(33, 33)],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(65, 33)],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(33, 33)],
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(65, 33)],
+                                                  ]],
+    ]];
+
     XCTAssertNil([self.layout layoutAttributesForItemAtIndexPath:genIndexPath(4, 0)]);
 }
 
 - (void)test_whenQueryingAttributes_withItemOOB_thatReturnsNil {
     [self setUpWithStickyHeaders:NO topInset:0 stretchToEdge:YES];
+
     [self prepareWithData:@[
-                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
-                                                            lineSpacing:0
-                                                       interitemSpacing:0
-                                                           headerHeight:0
-                                                                  items:@[
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(33, 33)],
-                                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(65, 33)],
-                                                                          ]],
-                            ]];
+            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                            lineSpacing:0
+                                       interitemSpacing:0
+                                           headerHeight:0
+                                           footerHeight:0
+                                                  items:@[
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(33, 33)],
+                                                          [[IGLayoutTestItem alloc] initWithSize:CGSizeMake(65, 33)],
+                                                  ]],
+    ]];
+
     XCTAssertNil([self.layout layoutAttributesForItemAtIndexPath:genIndexPath(0, 4)]);
 }
 

--- a/Tests/Objects/IGLayoutTestDataSource.m
+++ b/Tests/Objects/IGLayoutTestDataSource.m
@@ -14,6 +14,7 @@
 
 static NSString * const kCellIdentifier = @"cell";
 static NSString * const kHeaderIdentifier = @"header";
+static NSString * const kFooterIdentifier = @"footer";
 
 @implementation IGLayoutTestDataSource
 
@@ -23,6 +24,9 @@ static NSString * const kHeaderIdentifier = @"header";
     [collectionView registerClass:[UICollectionReusableView class]
        forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
               withReuseIdentifier:kHeaderIdentifier];
+    [collectionView registerClass:[UICollectionReusableView class]
+       forSupplementaryViewOfKind:UICollectionElementKindSectionFooter
+              withReuseIdentifier:kFooterIdentifier];
 }
 
 #pragma mark - UICollectionViewDataSource
@@ -40,8 +44,9 @@ static NSString * const kHeaderIdentifier = @"header";
 }
 
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath {
-    return [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionHeader
-                                              withReuseIdentifier:kHeaderIdentifier
+    NSString *reuseIdentifier = [kind isEqualToString:UICollectionElementKindSectionHeader]? kHeaderIdentifier : kFooterIdentifier;
+    return [collectionView dequeueReusableSupplementaryViewOfKind:kind
+                                              withReuseIdentifier:reuseIdentifier
                                                      forIndexPath:indexPath];
 }
 

--- a/Tests/Objects/IGLayoutTestDataSource.m
+++ b/Tests/Objects/IGLayoutTestDataSource.m
@@ -67,4 +67,8 @@ static NSString * const kHeaderIdentifier = @"header";
     return CGSizeMake(self.sections[section].headerHeight, self.sections[section].headerHeight); // Only the dimension along scrolling direction is used
 }
 
+- (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout *)collectionViewLayout referenceSizeForFooterInSection:(NSInteger)section {
+    return CGSizeMake(self.sections[section].footerHeight, self.sections[section].footerHeight); // Only the dimension along scrolling direction is used
+}
+
 @end

--- a/Tests/Objects/IGLayoutTestSection.h
+++ b/Tests/Objects/IGLayoutTestSection.h
@@ -24,6 +24,7 @@
                    lineSpacing:(CGFloat)lineSpacing
               interitemSpacing:(CGFloat)interitemSpacing
                   headerHeight:(CGFloat)headerHeight
+                  footerHeight:(CGFloat)footerHeight
                          items:(NSArray<IGLayoutTestItem *> *)items;
 
 @end

--- a/Tests/Objects/IGLayoutTestSection.h
+++ b/Tests/Objects/IGLayoutTestSection.h
@@ -17,6 +17,7 @@
 @property (nonatomic, assign, readonly) CGFloat lineSpacing;
 @property (nonatomic, assign, readonly) CGFloat interitemSpacing;
 @property (nonatomic, assign, readonly) CGFloat headerHeight;
+@property (nonatomic, assign, readonly) CGFloat footerHeight;
 @property (nonatomic, strong, readonly) NSArray<IGLayoutTestItem *> *items;
 
 - (instancetype)initWithInsets:(UIEdgeInsets)insets

--- a/Tests/Objects/IGLayoutTestSection.m
+++ b/Tests/Objects/IGLayoutTestSection.m
@@ -15,12 +15,14 @@
                    lineSpacing:(CGFloat)lineSpacing
               interitemSpacing:(CGFloat)interitemSpacing
                   headerHeight:(CGFloat)headerHeight
+                  footerHeight:(CGFloat)footerHeight
                          items:(NSArray<IGLayoutTestItem *> *)items {
     if (self = [super init]) {
         _insets = insets;
         _lineSpacing = lineSpacing;
         _interitemSpacing = interitemSpacing;
         _headerHeight = headerHeight;
+        _footerHeight = footerHeight;
         _items = [items copy];
     }
     return self;


### PR DESCRIPTION
## Changes in this pull request

**Changes occurred only for the IGListCollectionViewLayout.**

**Specifically:**
1. Harnessed the hardcore to the fact that it is possible to use only headers.
2. Assertions removed
3. Caching for layout of attributes of footers
4. Implemented the location of the footers in any orientation scroll

Issue fixed: #898 

I need this enhancement ASAP 🙏  

**Example:**
Footers with user comments count
![simulator screen shot - iphone 6 - 2017-11-14 at 13 35 22](https://user-images.githubusercontent.com/7735730/32775551-c69868cc-c940-11e7-8307-ae2e353519ff.png)


### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
- [x] I updated example project with implemented feature
