### PR TITLE
Remove example code and UI tests from CI #trivial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,18 @@ env:
    - EXAMPLE_SCHEME="IGListKitExamples"
 
    matrix:
-   - DESTINATION="OS=8.4,name=iPhone 5s" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" BUILD_EXAMPLE="YES" RUN_UI_TESTS="NO" RUN_UI_TESTS="NO" POD_LINT="YES" CHECK_MARKDOWN="YES"
+   - DESTINATION="OS=8.4,name=iPhone 5s" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="NO" POD_LINT="YES" CHECK_MARKDOWN="YES"
 
-   - DESTINATION="OS=9.3,name=iPad Air 2"  SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" RUN_UI_TESTS="NO" BUILD_EXAMPLE="YES" POD_LINT="YES"
+   - DESTINATION="OS=9.3,name=iPad Air 2"  SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" POD_LINT="YES"
 
-   - DESTINATION="OS=10.3.1,name=iPhone 7" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" RUN_UI_TESTS="NO" BUILD_EXAMPLE="YES" POD_LINT="NO"
+   - DESTINATION="OS=10.3.1,name=iPhone 7" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" POD_LINT="NO"
 
-   - DESTINATION="OS=11.2,name=iPhone X" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" RUN_UI_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
+   - DESTINATION="OS=11.2,name=iPhone X" SDK="$IOS_SDK" SCHEME="$IOS_SCHEME" RUN_TESTS="YES" POD_LINT="NO"
 
-   - DESTINATION="OS=10.2,name=Apple TV 1080p" SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="NO" RUN_UI_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="NO"
-   - DESTINATION="OS=11.2,name=Apple TV 4K" SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="NO" RUN_UI_TESTS="NO" BUILD_EXAMPLE="NO" POD_LINT="NO"
+   - DESTINATION="OS=10.2,name=Apple TV 1080p" SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="NO" POD_LINT="NO"
+   - DESTINATION="OS=11.2,name=Apple TV 4K" SDK="$TVOS_SDK" SCHEME="$TVOS_SCHEME" RUN_TESTS="NO" POD_LINT="NO"
 
-   - DESTINATION="arch=x86_64" SDK="$MACOS_SDK" SCHEME="$MACOS_SCHEME" RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
+   - DESTINATION="arch=x86_64" SDK="$MACOS_SDK" SCHEME="$MACOS_SCHEME" RUN_TESTS="YES" POD_LINT="NO"
 
 before_install:
   - ruby scripts/generate_ci_yaml.rb
@@ -56,26 +56,6 @@ script:
 
 - if [ $POD_LINT == "YES" ]; then
       bundle exec pod lib lint;
-  fi
-
-
-- if [ $BUILD_EXAMPLE == "YES" ] && [ $SDK == $IOS_SDK ]; then
-      xcodebuild build -workspace "$IOS_EXAMPLE_WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
-  fi
-
-
-- if [ $RUN_UI_TESTS == "YES" ] && [ $SDK == $IOS_SDK ]; then
-      xcodebuild build test -workspace "$IOS_EXAMPLE_WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
-  fi
-
-
-- if [ $BUILD_EXAMPLE == "YES" ] && [ $SDK == $TVOS_SDK ]; then
-      xcodebuild build -workspace "$TVOS_EXAMPLE_WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
-  fi
-
-
-- if [ $BUILD_EXAMPLE == "YES" ] && [ $SDK == $MACOS_SDK ]; then
-      xcodebuild build -workspace "$MACOS_EXAMPLE_WORKSPACE" -scheme "$EXAMPLE_SCHEME" -sdk "$SDK" -destination "$DESTINATION" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO | bundle exec xcpretty -c;
   fi
 
 


### PR DESCRIPTION
I'm over dealing w/ the example projects on CI slowing things down and giving poor signal. Now there's a [SwiftLint error](https://travis-ci.org/Instagram/IGListKit/jobs/332648229) that I don't really understand. At the point where its discouraging me from being more active and keeping PRs moving.

My vote is to burn down examples building on CI, and we can deal w/ breakages as they come. Any objections @jessesquires?