### PR TITLE
Add SwiftLint installation step

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-VERSION="0.24.2"
+VERSION="0.24.0"
+
+brew switch swiftlint $VERSION
 
 if which swiftlint >/dev/null && [ $(swiftlint version) == $VERSION ]; then
     swiftlint lint --config ../.swiftlint.yml


### PR DESCRIPTION
Alternative to #1065 

From my understanding in the lint.sh script we have a check which is basically saying if the output of `swiftlint version` does not equal "0.24.2" then exit with a failure note

As per this [travis blog](https://blog.travis-ci.com/2017-12-06-xcode-92-has-landed) they currently use "0.24.0" as the pre-installed version therefore this would cause the failure

I'm attempting to add a `brew install` step which _should_ guarantee the version to be something we can deal with!

Would be a shame to just ditch CI on all the example projects!