### PR TITLE
Move the DEBUG uniqueness check outside of for-loop inside IGListAdapter

### DIFF
--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -621,13 +621,13 @@
         }
 
         [sectionControllers addObject:sectionController];
-
-#if DEBUG
-        IGAssert([NSSet setWithArray:sectionControllers].count == sectionControllers.count,
-                 @"Section controllers array is not filled with unique objects; section controllers are being reused");
-#endif
         [validObjects addObject:object];
     }
+    
+#if DEBUG
+    IGAssert([NSSet setWithArray:sectionControllers].count == sectionControllers.count,
+             @"Section controllers array is not filled with unique objects; section controllers are being reused");
+#endif
 
     // clear the view controller and collection context
     IGListSectionControllerPopThread();


### PR DESCRIPTION
Summary:

The original DEBUG was put inside a for loop, which caused a quadratic looping while creating bigger and bigger NSSet.

This is very inefficient and I verified that by profiling with 10000 objects in the array and it caused significant amount of CPU. The main thread is pretty much unresponsive.

Test Plan:

All test cases pass, verify that no more blocking the main thread by the NSSet creation/dealloc.

## Changes in this pull request

Issue fixed: #

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
