### PR TITLE
fixed Footer is sticky to the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 ### Fixes
 
+- Fixed footer is sticky when `stickyHeader` is `true` [aelam](https://github.com/aelam) [(#1094)](https://github.com/Instagram/IGListKit/pull/1094)
+
 3.2.0
 -----
 

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -319,27 +319,28 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 
     if ([elementKind isEqualToString:UICollectionElementKindSectionHeader]) {
         frame = entry.headerBounds;
+        
+
+        if (self.stickyHeaders) {
+            CGFloat offset = CGPointGetCoordinateInDirection(collectionView.contentOffset, self.scrollDirection) + self.topContentInset + self.stickyHeaderYOffset;
+
+            if (section + 1 == _sectionData.size()) {
+                offset = MAX(minOffset, offset);
+            } else {
+                const CGFloat maxOffset = CGRectGetMinInDirection(_sectionData[section + 1].bounds, self.scrollDirection) - CGRectGetLengthInDirection(frame, self.scrollDirection);
+                offset = MIN(MAX(minOffset, offset), maxOffset);
+            }
+            switch (self.scrollDirection) {
+                case UICollectionViewScrollDirectionVertical:
+                    frame.origin.y = offset;
+                    break;
+                case UICollectionViewScrollDirectionHorizontal:
+                    frame.origin.x = offset;
+                    break;
+            }
+        }
     } else if ([elementKind isEqualToString:UICollectionElementKindSectionFooter]) {
         frame = entry.footerBounds;
-    }
-
-    if (self.stickyHeaders) {
-        CGFloat offset = CGPointGetCoordinateInDirection(collectionView.contentOffset, self.scrollDirection) + self.topContentInset + self.stickyHeaderYOffset;
-
-        if (section + 1 == _sectionData.size()) {
-            offset = MAX(minOffset, offset);
-        } else {
-            const CGFloat maxOffset = CGRectGetMinInDirection(_sectionData[section + 1].bounds, self.scrollDirection) - CGRectGetLengthInDirection(frame, self.scrollDirection);
-            offset = MIN(MAX(minOffset, offset), maxOffset);
-        }
-        switch (self.scrollDirection) {
-            case UICollectionViewScrollDirectionVertical:
-                frame.origin.y = offset;
-                break;
-            case UICollectionViewScrollDirectionHorizontal:
-                frame.origin.x = offset;
-                break;
-        }
     }
 
     attributes = [UICollectionViewLayoutAttributes layoutAttributesForSupplementaryViewOfKind:elementKind withIndexPath:indexPath];


### PR DESCRIPTION
 if `stickyHeader` is true, the footer could be sticky to the top

## Changes in this pull request

Issue fixed: #1093

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
