### PR TITLE
IGListAdapterDelegate needs Swift name of ListAdapterDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The changelog for `IGListKit`. Also see the [releases](https://github.com/instagram/IGListKit/releases) on GitHub.
 
+4.0.0 (upcoming release)
+-----
+
+### Breaking Changes
+
+- Added Swift annotation name to `IGListAdapterDelegate` which remove `IG` prefixe. The new name is Swift clients is `ListAdapterDelegate`. [Andrea Antonioni](https://github.com/andreaantonioni)[(tbd)](tbd)
+
 3.3.0 (upcoming release)
 -----
 

--- a/Source/IGListAdapterDelegate.h
+++ b/Source/IGListAdapterDelegate.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Conform to `IGListAdapterDelegate` to receive display events for objects in a list.
  */
+NS_SWIFT_NAME(ListAdapterDelegate)
 @protocol IGListAdapterDelegate <NSObject>
 
 /**


### PR DESCRIPTION
## Changes in this pull request

Add Swift name annotation `ListAdapterDelegate` to `IGListAdapterDelegate`. The breaking change is written in the `CHANGELOG.md` for the `4.0.0` release

Issue fixed: #1115 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
