### PR TITLE
Show header when section item empty 

### DIFF
--- a/Source/IGListCollectionViewLayout.h
+++ b/Source/IGListCollectionViewLayout.h
@@ -129,6 +129,21 @@ NS_SWIFT_NAME(ListCollectionViewLayout)
                         stretchToEdge:(BOOL)stretchToEdge;
 
 /**
+ Create and return a new vertically scrolling collection view layout.
+ 
+ @param stickyHeaders Set to `YES` to stick section headers to the top of the bounds while scrolling.
+ @param showHeaderWhenEmpty Set to `YES` to show sticky header when a section had no item
+ @param topContentInset The top content inset used to offset the sticky headers. Ignored if stickyHeaders is `NO`.
+ @param stretchToEdge Specifies whether to stretch width of last item to right edge when distance from last item to right edge < epsilon(1)
+ 
+ @return A new collection view layout.
+ */
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                  showHeaderWhenEmpty:(BOOL)showHeaderWhenEmpty
+                      topContentInset:(CGFloat)topContentInset
+                        stretchToEdge:(BOOL)stretchToEdge;
+
+/**
  :nodoc:
  */
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -150,6 +150,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 @property (nonatomic, assign, readonly) BOOL stickyHeaders;
 @property (nonatomic, assign, readonly) CGFloat topContentInset;
 @property (nonatomic, assign, readonly) BOOL stretchToEdge;
+@property (nonatomic, assign, readonly) BOOL showHeaderWhenEmpty;
 
 @end
 
@@ -174,10 +175,22 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 }
 
 - (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
+                  showHeaderWhenEmpty:(BOOL)showHeaderWhenEmpty
+                      topContentInset:(CGFloat)topContentInset
+                        stretchToEdge:(BOOL)stretchToEdge {
+    _showHeaderWhenEmpty = showHeaderWhenEmpty;
+    
+    return [self initWithStickyHeaders:stickyHeaders
+                       scrollDirection:UICollectionViewScrollDirectionVertical
+                       topContentInset:topContentInset
+                         stretchToEdge:stretchToEdge];
+}
+
+- (instancetype)initWithStickyHeaders:(BOOL)stickyHeaders
                       topContentInset:(CGFloat)topContentInset
                         stretchToEdge:(BOOL)stretchToEdge {
     return [self initWithStickyHeaders:stickyHeaders
-                       scrollDirection:UICollectionViewScrollDirectionVertical
+                   showHeaderWhenEmpty:NO
                        topContentInset:topContentInset
                          stretchToEdge:stretchToEdge];
 }
@@ -245,7 +258,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         const NSInteger itemCount = _sectionData[section].itemBounds.size();
 
         // do not add headers if there are no items
-//        if (itemCount > 0) {
+        if (itemCount > 0 || self.showHeaderWhenEmpty) {
             for (NSString *elementKind in _supplementaryAttributesCache.allKeys) {
                 NSIndexPath *indexPath = indexPathForSection(section);
                 UICollectionViewLayoutAttributes *attributes = [self layoutAttributesForSupplementaryViewOfKind:elementKind
@@ -257,7 +270,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
                     [result addObject:attributes];
                 }
             }
-//        }
+        }
 
         // add all cells within the rect, return early if it starts iterating outside
         for (NSInteger item = 0; item < itemCount; item++) {
@@ -593,7 +606,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         if (itemCount == 0) {
             rollingSectionBounds = headerBounds;
         }
-
+        
         const CGRect footerBounds = (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
                 CGRectMake(insets.left,
                         CGRectGetMaxY(rollingSectionBounds),

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -245,7 +245,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
         const NSInteger itemCount = _sectionData[section].itemBounds.size();
 
         // do not add headers if there are no items
-        if (itemCount > 0) {
+//        if (itemCount > 0) {
             for (NSString *elementKind in _supplementaryAttributesCache.allKeys) {
                 NSIndexPath *indexPath = indexPathForSection(section);
                 UICollectionViewLayoutAttributes *attributes = [self layoutAttributesForSupplementaryViewOfKind:elementKind
@@ -257,7 +257,7 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
                     [result addObject:attributes];
                 }
             }
-        }
+//        }
 
         // add all cells within the rect, return early if it starts iterating outside
         for (NSInteger item = 0; item < itemCount; item++) {
@@ -577,18 +577,22 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
                 rollingSectionBounds = CGRectUnion(rollingSectionBounds, frame);
             }
         }
-
+       
         const CGRect headerBounds = (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
                 CGRectMake(insets.left,
-                        CGRectGetMinY(rollingSectionBounds) - headerSize.height,
+                        (itemCount == 0) ? CGRectGetMaxY(rollingSectionBounds) : CGRectGetMinY(rollingSectionBounds) - headerSize.height,
                         paddedLengthInFixedDirection,
                         headerSize.height) :
-                CGRectMake(CGRectGetMinX(rollingSectionBounds) - headerSize.width,
+                CGRectMake((itemCount == 0) ? CGRectGetMaxX(rollingSectionBounds) : CGRectGetMinX(rollingSectionBounds) - headerSize.width,
                         insets.top,
                         headerSize.width,
                         paddedLengthInFixedDirection);
 
         _sectionData[section].headerBounds = headerBounds;
+        
+        if (itemCount == 0) {
+            rollingSectionBounds = headerBounds;
+        }
 
         const CGRect footerBounds = (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
                 CGRectMake(insets.left,

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -41,6 +41,11 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     return [self.collectionView supplementaryViewForElementKind:UICollectionElementKindSectionFooter atIndexPath:genIndexPath(section, 0)];
 }
 
+- (void)setUpWithStickyHeaders:(BOOL)sticky showHeaderWhenEmpty:(BOOL)showHeaderWhenEmpty {
+    self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:YES showHeaderWhenEmpty:showHeaderWhenEmpty topContentInset:0 stretchToEdge:NO];
+    [self setUpCollectionViewAndDataSource:kTestFrame];
+}
+
 - (void)setUpWithStickyHeaders:(BOOL)sticky topInset:(CGFloat)inset {
     [self setUpWithStickyHeaders:sticky topInset:inset stretchToEdge:NO];
 }
@@ -55,6 +60,10 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
 
 - (void)setUpWithStickyHeaders:(BOOL)sticky scrollDirection:(UICollectionViewScrollDirection)scrollDirection topInset:(CGFloat)inset stretchToEdge:(BOOL)stretchToEdge testFrame:(CGRect)testFrame {
     self.layout = [[IGListCollectionViewLayout alloc] initWithStickyHeaders:sticky scrollDirection:scrollDirection topContentInset:inset stretchToEdge:stretchToEdge];
+    [self setUpCollectionViewAndDataSource:testFrame];
+}
+
+- (void)setUpCollectionViewAndDataSource:(CGRect)testFrame {
     self.dataSource = [IGLayoutTestDataSource new];
     self.collectionView = [[UICollectionView alloc] initWithFrame:testFrame collectionViewLayout:self.layout];
     self.collectionView.dataSource = self.dataSource;
@@ -84,6 +93,33 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     // check so that nil messaging doesn't default size to 0
     XCTAssertEqual(self.layout.collectionView, self.collectionView);
     XCTAssertTrue(CGSizeEqualToSize(CGSizeZero, self.collectionView.contentSize));
+}
+
+- (void)test_whenSectionDataIsEmpty_thatStickyHeaderStillShow {
+    [self setUpWithStickyHeaders:YES showHeaderWhenEmpty:YES];
+    
+    [self prepareWithData:@[[[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                           footerHeight:0
+                                                                  items:nil],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:20
+                                                           footerHeight:0
+                                                                  items:nil],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:30
+                                                           footerHeight:0
+                                                                  items:nil]]];
+    
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 0, 100, 10);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 10, 100, 20);
+    IGAssertEqualFrame([self headerForSection:2].frame, 0, 30, 100, 30);
 }
 
 - (void)test_whenLayingOutCellsVertically_withHeaderHeight_withLineSpacing_withInsets_thatFramesCorrect {

--- a/Tests/IGListCollectionViewLayoutTests.m
+++ b/Tests/IGListCollectionViewLayoutTests.m
@@ -122,6 +122,27 @@ static const CGRect kTestFrame = (CGRect){{0, 0}, {100, 100}};
     IGAssertEqualFrame([self headerForSection:2].frame, 0, 30, 100, 30);
 }
 
+- (void)test_whenSectionDataIsEmpty_thatStickyHeaderShouldBeHidden {
+    [self setUpWithStickyHeaders:YES showHeaderWhenEmpty:NO];
+    
+    [self prepareWithData:@[[[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:10
+                                                           footerHeight:0
+                                                                  items:nil],
+                            [[IGLayoutTestSection alloc] initWithInsets:UIEdgeInsetsZero
+                                                            lineSpacing:0
+                                                       interitemSpacing:0
+                                                           headerHeight:20
+                                                           footerHeight:0
+                                                                  items:nil]]];
+    
+    IGAssertEqualFrame([self headerForSection:0].frame, 0, 0, 0, 0);
+    IGAssertEqualFrame([self headerForSection:1].frame, 0, 0, 0, 0);
+}
+
+
 - (void)test_whenLayingOutCellsVertically_withHeaderHeight_withLineSpacing_withInsets_thatFramesCorrect {
     [self setUpWithStickyHeaders:NO topInset:0];
 


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #1117

I adding a new constructor for making a `IGListCollectionViewLayout` instance that can always show sticky header although section data is empty.

It's working well and [this is demo project](https://github.com/marcuswu0814/IGListKit_ShowStickyHeaderWhenDataEmpty).

Bug I'm not sure is any good way to let this much more readability. Is there any good advice?

```objc
const CGRect headerBounds = (self.scrollDirection == UICollectionViewScrollDirectionVertical) ?
                CGRectMake(insets.left,
                        (itemCount == 0) ? CGRectGetMaxY(rollingSectionBounds) : CGRectGetMinY(rollingSectionBounds) - headerSize.height,
                        paddedLengthInFixedDirection,
                        headerSize.height) :
                CGRectMake((itemCount == 0) ? CGRectGetMaxX(rollingSectionBounds) : CGRectGetMinX(rollingSectionBounds) - headerSize.width,
                        insets.top,
                        headerSize.width,
                        paddedLengthInFixedDirection);
```



### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)