### PR TITLE
Swift: Minor changes to protocols and extensions

### DIFF
--- a/Source/Swift/ListSwift+Foundation.swift
+++ b/Source/Swift/ListSwift+Foundation.swift
@@ -12,7 +12,7 @@ import Foundation
 /**
  Automatically conform `Hashable` structures to the identification part of `ListSwiftDiffable`.
  */
-public extension Hashable {
+public extension ListSwiftIdentifiable where Self: Hashable {
 
     /**
      :nodoc:
@@ -24,9 +24,9 @@ public extension Hashable {
 }
 
 /**
- Automatically conform `Hashable` structures to the identification part of `ListSwiftDiffable`.
+ Automatically conform `Equatable` structures to the equality part of `ListSwiftDiffable`.
  */
-public extension Equatable {
+public extension ListSwiftEquatable where Self: Equatable {
 
     /**
      :nodoc:

--- a/Source/Swift/ListSwiftDiffable+Boxed.swift
+++ b/Source/Swift/ListSwiftDiffable+Boxed.swift
@@ -7,7 +7,8 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-internal extension ListSwiftDiffable {
+// Not very clean, but it's not possible to write extensions on a composed Protocols.
+internal extension ListSwiftIdentifiable where Self: ListSwiftEquatable {
 
     var boxed: ListDiffable {
         return ListDiffableBox(value: self)

--- a/Source/Swift/ListSwiftDiffable.swift
+++ b/Source/Swift/ListSwiftDiffable.swift
@@ -15,26 +15,29 @@ public protocol ListSwiftEquatable {
     func isEqual(to value: ListSwiftDiffable) -> Bool
 }
 
-/**
- Conform a Swift `struct` or `class` so that it can be diffed and used with IGListKit.
- */
-public protocol ListSwiftDiffable: ListSwiftIdentifiable, ListSwiftEquatable {
+public typealias ListSwiftDiffable = ListSwiftIdentifiable & ListSwiftEquatable
 
-    /**
-     Return a `String` that uniquely identifies the instance.
+///**
+// Conform a Swift `struct` or `class` so that it can be diffed and used with IGListKit.
+// */
+//public protocol ListSwiftDiffable: ListSwiftIdentifiable, ListSwiftEquatable {
+//
+//    /**
+//     Return a `String` that uniquely identifies the instance.
+//
+//     @note These identifiers are namespaced to the object type to avoid colliding identifiers between different value
+//     types.
+//     */
+////    var identifier: String { get }
+//
+//    /**
+//     Indicate if the value is equal to another value.
+//
+//     @param object The value to compare against.
+//
+//     @return `true` if the two instances are equal in value. Otherwise `false`.
+//     */
+////    func isEqual(to value: ListSwiftDiffable) -> Bool
+//
+//}
 
-     @note These identifiers are namespaced to the object type to avoid colliding identifiers between different value
-     types.
-     */
-//    var identifier: String { get }
-
-    /**
-     Indicate if the value is equal to another value.
-
-     @param object The value to compare against.
-
-     @return `true` if the two instances are equal in value. Otherwise `false`.
-     */
-//    func isEqual(to value: ListSwiftDiffable) -> Bool
-
-}

--- a/Source/Swift/ListSwiftSectionController.swift
+++ b/Source/Swift/ListSwiftSectionController.swift
@@ -13,9 +13,11 @@ public protocol ListSwiftBindable {
     func bind(value: ListSwiftDiffable)
 }
 
+public typealias ListSwiftBindableCell = UICollectionViewCell & ListSwiftBindable
+
 public struct BindingData {
     let value: ListSwiftDiffable
-    let cellType: (UICollectionViewCell & ListSwiftBindable).Type
+    let cellType: ListSwiftBindableCell.Type
     let size: (ListCollectionContext, Int) -> CGSize
 }
 
@@ -29,7 +31,7 @@ open class ListSwiftSectionController<T: ListSwiftIdentifiable>: ListSectionCont
 
     public func bindingData<T: ListSwiftDiffable>(
         _ value: T,
-        cellType: (UICollectionViewCell & ListSwiftBindable).Type,
+        cellType: ListSwiftBindableCell.Type,
         size: @escaping (Context<T>) -> CGSize
         ) -> BindingData {
         return BindingData(value: value, cellType: cellType, size: { (context, index) -> CGSize in
@@ -72,7 +74,7 @@ open class ListSwiftSectionController<T: ListSwiftIdentifiable>: ListSectionCont
                 option: .equality
             )
 
-            for (i, update) in result.updates.enumerated() {
+            for (i, _) in result.updates.enumerated() {
                 let identifier = fromBoxed[i].diffIdentifier()
                 let toIndex = result.newIndex(forIdentifier: identifier)
                 if toIndex != NSNotFound,
@@ -107,7 +109,7 @@ open class ListSwiftSectionController<T: ListSwiftIdentifiable>: ListSectionCont
     }
 
     public final override func cellForItem(at index: Int) -> UICollectionViewCell {
-        guard let cell = collectionContext?.dequeueReusableCell(of: data[index].cellType, for: self, at: index) as? UICollectionViewCell & ListSwiftBindable
+        guard let cell = collectionContext?.dequeueReusableCell(of: data[index].cellType, for: self, at: index) as? ListSwiftBindableCell
             else { fatalError() }
         cell.bind(value: data[index].value)
         return cell


### PR DESCRIPTION
## Changes in this pull request
- Structures only automatically conform to `ListSwiftIdentifiable` / `ListSwiftEquatable` when setting the protocol
- Turn `ListSwiftDiffable` into a composed protocol of `ListSwiftIdentifiable & ListSwiftEquatable`
- Introduced `ListSwiftBindableCell` (typealias for `UICollectionViewCell & ListSwiftBindable`)
- Removed warning for unused `update` in `ListSwiftSectionController`