### PR TITLE
Fix binding SC cell updates when the SC's section changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - `-[IGListSectionController didSelectItemAtIndex:]` is now called when a `scrollViewDelegate` or `collectionViewDelegate` is set. [Ryan Nystrom](https://github.com/rnystrom) [(#1108)](https://github.com/Instagram/IGListKit/pull/1108)
 
-- Fixed binding section controllers failing to update their cells when the section changes. [Chrisna Aing](https://github.com/ccrazy88)
+- Fixed binding section controllers failing to update their cells when the section controller's section changes. [Chrisna Aing](https://github.com/ccrazy88) [(#1144)](https://github.com/Instagram/IGListKit/pull/1144)
 
 3.2.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - `-[IGListSectionController didSelectItemAtIndex:]` is now called when a `scrollViewDelegate` or `collectionViewDelegate` is set. [Ryan Nystrom](https://github.com/rnystrom) [(#1108)](https://github.com/Instagram/IGListKit/pull/1108)
 
+- Fixed binding section controllers failing to update their cells when the section changes. [Chrisna Aing](https://github.com/ccrazy88)
+
 3.2.0
 -----
 

--- a/Source/IGListAdapter.m
+++ b/Source/IGListAdapter.m
@@ -869,7 +869,7 @@
         return nil;
     }
 
-    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousIfInUpdateBlock:NO];
+    NSIndexPath *indexPath = [self indexPathForSectionController:sectionController index:index usePreviousIfInUpdateBlock:YES];
     // prevent querying the collection view if it isn't fully reloaded yet for the current data set
     if (indexPath != nil
         && indexPath.section < [self.collectionView numberOfSections]) {


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #1111

As discussed in the issue's comments, this seems to be the most expedient fix if we accept that `cellForItemAtIndex:` should be allowed within update blocks. I am not familiar enough with `IGListAdapter` to know whether this is the best solution but am willing to make any changes requested!

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
