### PR TITLE
Add correct comment syntax for Remodel

### DIFF
--- a/Guides/Generating your models.md
+++ b/Guides/Generating your models.md
@@ -64,7 +64,7 @@ This is especially useful if you plan to change/extend the plugin in any way.
 Now you are ready to generate your `IGListDiffable` conforming models! To generate a model, create a new `.value` file. Here's an example:
 
 ```
-// PersonModel.value
+# PersonModel.value
 PersonModel includes(IGListDiffable) {
   NSString *firstName
   NSString *lastName


### PR DESCRIPTION

## Changes in this pull request

Using "//" causing a parsing issue with Remodel, whereas "#" appears to be the correct syntax. This pull simply updates the code sample using the correct syntax.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)