### PR TITLE
Add missing preprocessors value

### DIFF
--- a/remodel-plugin/src/plugins/iglistdiffable.ts
+++ b/remodel-plugin/src/plugins/iglistdiffable.ts
@@ -20,6 +20,7 @@ import ObjectSpecCodeUtils = require('../object-spec-code-utils');
 
 function isEqualToDiffableObjectMethod():ObjC.Method {
   return {
+    preprocessors:[],
     belongsToProtocol:Maybe.Just<string>('IGListDiffable'),
     code: ['return [self isEqual:object];'],
     comments:[],
@@ -147,6 +148,7 @@ function diffIdentifierMethodImplementation(objectType:ObjectSpec.Type):string[]
 
 function diffIdentifierMethod(objectType:ObjectSpec.Type):ObjC.Method {
   return {
+    preprocessors:[],
     belongsToProtocol:Maybe.Just<string>('IGListDiffable'),
     code: diffIdentifierMethodImplementation(objectType),
     comments:[],


### PR DESCRIPTION
# Changes in this pull request

If you add the IGListDiffable plugin as is and run `./bin/build` on your Remodel install, it'll err out. It's missing the `preprocessor` values so I've added those in for both the required methods.

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
