### PR TITLE
fix crash in case of _intercepter is dealloced

### DIFF
--- a/Source/Internal/IGListAdapterProxy.m
+++ b/Source/Internal/IGListAdapterProxy.m
@@ -71,7 +71,7 @@ static BOOL isInterceptedSelector(SEL sel) {
 }
 
 - (BOOL)respondsToSelector:(SEL)aSelector {
-    return isInterceptedSelector(aSelector)
+    return (isInterceptedSelector(aSelector) && _interceptor)
     || [_collectionViewTarget respondsToSelector:aSelector]
     || [_scrollViewTarget respondsToSelector:aSelector];
 }


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
