### PR TITLE
Remove redundant selector checks in IGListAdapterProxy. #trivial

### DIFF
--- a/Source/Internal/IGListAdapterProxy.m
+++ b/Source/Internal/IGListAdapterProxy.m
@@ -35,12 +35,6 @@ static BOOL isInterceptedSelector(SEL sel) {
             sel == @selector(collectionView:layout:minimumLineSpacingForSectionAtIndex:) ||
             sel == @selector(collectionView:layout:referenceSizeForFooterInSection:) ||
             sel == @selector(collectionView:layout:referenceSizeForHeaderInSection:) ||
-            sel == @selector(collectionView:layout:referenceSizeForHeaderInSection:) ||
-            // UIScrollViewDelegate
-            sel == @selector(scrollViewDidScroll:) ||
-            sel == @selector(scrollViewWillBeginDragging:) ||
-            sel == @selector(scrollViewDidEndDragging:willDecelerate:) ||
-            sel == @selector(scrollViewDidEndDecelerating:) ||
             // IGListCollectionViewDelegateLayout
             sel == @selector(collectionView:layout:customizedInitialLayoutAttributes:atIndexPath:) ||
             sel == @selector(collectionView:layout:customizedFinalLayoutAttributes:atIndexPath:)


### PR DESCRIPTION
## Changes in this pull request
isInterceptedSelector() was redundantly checking equality for several selectors. This change removes the redundancies.

### Checklist

`test_withDuplicateDiffIdentifiers_thatDuplicatesAreRemoved` fails locally before and after this change was added.

No tests were added and no entry was added to `CHANGELOG.md` since this is a trivial change.

- [ ] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
