### PR TITLE
Forward [IGListAdapterProxy isKindOfClass:] calls to its interceptor and delegates. #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Ensuring view models with duplicate diff identifiers are removed when view models are first requested by `IGListBindingSectionController` [Adam Stern](https://github.com/adamastern) (tbd)
 
-- Forward [IGListAdapterProxy isKindOfClass:] calls to its interceptor and delegates to improve support with [material components](https://github.com/material-components/material-components-ios/blob/72045ffd6d303bb99a3e1a71e4f3cdda42fe5ad8/components/Collections/src/MDCCollectionViewFlowLayout.m#L75). [Robbie Kirk](https://github.com/jgheab) (tbd)
+- Forward [IGListAdapterProxy isKindOfClass:] calls to its interceptor and delegates. [Robbie Kirk](https://github.com/jgheab) [(#1196)](https://github.com/Instagram/IGListKit/pull/1196)
 
 3.4.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Ensuring view models with duplicate diff identifiers are removed when view models are first requested by `IGListBindingSectionController` [Adam Stern](https://github.com/adamastern) (tbd)
 
+- Forward [IGListAdapterProxy isKindOfClass:] calls to its interceptor and delegates to improve support with [material components](https://github.com/material-components/material-components-ios/blob/72045ffd6d303bb99a3e1a71e4f3cdda42fe5ad8/components/Collections/src/MDCCollectionViewFlowLayout.m#L75). [Robbie Kirk](https://github.com/jgheab) (tbd)
+
 3.4.0
 -----
 

--- a/Source/Internal/IGListAdapterProxy.m
+++ b/Source/Internal/IGListAdapterProxy.m
@@ -50,7 +50,7 @@ static BOOL isInterceptedSelector(SEL sel) {
 @interface IGListAdapterProxy () {
     __weak id _collectionViewTarget;
     __weak id _scrollViewTarget;
-    __weak IGListAdapter *_interceptor;
+    __weak id _interceptor;
 }
 
 @end
@@ -74,6 +74,12 @@ static BOOL isInterceptedSelector(SEL sel) {
     return isInterceptedSelector(aSelector)
     || [_collectionViewTarget respondsToSelector:aSelector]
     || [_scrollViewTarget respondsToSelector:aSelector];
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+    return [_interceptor isKindOfClass:aClass]
+    || [_collectionViewTarget isKindOfClass:aClass]
+    || [_scrollViewTarget isKindOfClass:aClass];
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector {

--- a/Tests/IGListAdapterProxyTests.m
+++ b/Tests/IGListAdapterProxyTests.m
@@ -79,7 +79,7 @@
     [(id)proxy scrollViewDidZoom:scrollView];
 }
 
-- (void)test_whenCallingIsKindOfClass_thatCallIsForwardedToDelegatesAndInterceptor {
+- (void)test_whenCallingIsKindOfClass_thatCallIsForwardedToDelegates {
     id mockAdapter = [OCMockObject mockForClass:[IGListAdapter class]];
 
     id mockCollectionViewDelegate = [OCMockObject mockForProtocol:@protocol(UICollectionViewDelegate)];

--- a/Tests/IGListAdapterProxyTests.m
+++ b/Tests/IGListAdapterProxyTests.m
@@ -79,4 +79,21 @@
     [(id)proxy scrollViewDidZoom:scrollView];
 }
 
+- (void)test_whenCallingIsKindOfClass_thatCallIsForwardedToDelegatesAndInterceptor {
+    id mockAdapter = [OCMockObject mockForClass:[IGListAdapter class]];
+
+    id mockCollectionViewDelegate = [OCMockObject mockForProtocol:@protocol(UICollectionViewDelegate)];
+    Class expectedCollectionViewDelegate = [UICollectionView class];
+    [[[mockCollectionViewDelegate stub] andReturnValue:@YES] isKindOfClass:expectedCollectionViewDelegate];
+
+    id mockScrollViewDelegate = [OCMockObject mockForProtocol:@protocol(UIScrollViewDelegate)];
+    Class expectedScrollViewDelegate = [UICollectionView class];
+    [[[mockCollectionViewDelegate stub] andReturnValue:@YES] isKindOfClass:expectedScrollViewDelegate];
+
+    IGListAdapterProxy *proxy = [[IGListAdapterProxy alloc] initWithCollectionViewTarget:mockCollectionViewDelegate scrollViewTarget:mockScrollViewDelegate interceptor:mockAdapter];
+
+    XCTAssertTrue([proxy isKindOfClass:expectedCollectionViewDelegate]);
+    XCTAssertTrue([proxy isKindOfClass:expectedScrollViewDelegate]);
+}
+
 @end


### PR DESCRIPTION
## Changes in this pull request

This extends the proxy's behavior and fixes compatibility issues with [material-components](https://github.com/material-components/material-components-ios/blob/72045ffd6d303bb99a3e1a71e4f3cdda42fe5ad8/components/Collections/src/MDCCollectionViewFlowLayout.m#L75). 

Added unit test to verify isKindOfClass: is forwarded to delegates.

test_withDuplicateDiffIdentifiers_thatDuplicatesAreRemoved fails locally before and after this change was added.

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
