### PR TITLE
Fix logic flaw of of shouldInvalidateLayoutForBoundsChange in IGListCollectionViewLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Log instead of assert for duplicate diff identifiers to make code testable. [Adam Stern](https://github.com/adamastern) (tbd)
 
+- Fixed logic flaw in `[IGListCollectionViewLayout shouldInvalidateLayoutForBoundsChange:]`. [Allen Hsu](https://github.com/allenhsu) (tbd)
+
 3.4.0
 -----
 

--- a/Source/IGListCollectionViewLayout.mm
+++ b/Source/IGListCollectionViewLayout.mm
@@ -415,13 +415,17 @@ static void adjustZIndexForAttributes(UICollectionViewLayoutAttributes *attribut
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
     const CGRect oldBounds = self.collectionView.bounds;
 
+    // always invalidate for size changes
+    if (!CGSizeEqualToSize(oldBounds.size, newBounds.size)) {
+        return YES;
+    }
+
     // if the y origin has changed, only invalidate when using sticky headers
     if (CGRectGetMinInDirection(newBounds, self.scrollDirection) != CGRectGetMinInDirection(oldBounds, self.scrollDirection)) {
         return self.stickyHeaders;
     }
 
-    // always invalidate for size changes
-    return !CGSizeEqualToSize(oldBounds.size, newBounds.size);
+    return NO;
 }
 
 - (void)prepareLayout {


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #1235

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
