### PR TITLE
Fix a bug where IGListIndexPathResult returned wrong type #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 - Fixed crash when using `-[IGListCollectionContext dequeueReusableCellOfClass:withReuseIdentifier:forSectionController:atIndex:]` [Jeremy Lawrence](https://github.com/ziewvater) (tbd)
 
+- Fixed a bug where `-[IGListIndexPathResult oldIndexPathForIdentifier:]` and `-[IGListIndexPathResult newIndexPathForIdentifier:]` were returning `NSArray<NSIndexPath *> *` instead of `NSIndexPath *` when diff contained only insertions or deletions. [Anton Sotkov](https://github.com/antons) (tbd)
+
 3.4.0
 -----
 

--- a/Source/Common/IGListDiff.mm
+++ b/Source/Common/IGListDiff.mm
@@ -87,7 +87,7 @@ static NSArray<NSIndexPath *> *indexPathsAndPopulateMap(__unsafe_unretained NSAr
     [array enumerateObjectsUsingBlock:^(id<IGListDiffable> obj, NSUInteger idx, BOOL *stop) {
         NSIndexPath *path = [NSIndexPath indexPathForItem:idx inSection:section];
         [paths addObject:path];
-        [map setObject:paths forKey:[obj diffIdentifier]];
+        [map setObject:path forKey:[obj diffIdentifier]];
     }];
     return paths;
 }


### PR DESCRIPTION
`-[IGListIndexPathResult oldIndexPathForIdentifier:]` and `-[IGListIndexPathResult newIndexPathForIdentifier:]` were returning `NSArray<NSIndexPath *> *` instead of `NSIndexPath *` when diff contained only insertions or deletions.

Introduced in afd2d29eecfac2231d2bcf815c76e844c98d838e.

I have not ran or updated the tests, but I confirmed the fix on the project where I’m using IGListKit. There should probably be a test for this. I’m sorry, I don’t have the time to add them right now.

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)