### PR TITLE
Fix - Cell Reordering in IGListBindingSectionController (viewModels array not being updated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 - Log instead of assert for duplicate diff identifiers to make code testable. [Adam Stern](https://github.com/adamastern) (tbd)
 
 - Fixed crash when using `-[IGListCollectionContext dequeueReusableCellOfClass:withReuseIdentifier:forSectionController:atIndex:]` [Jeremy Lawrence](https://github.com/ziewvater) (tbd)
+- Added missing method override to `IGListBindingSectionController` that updates the internal `viewModels` array after moving a cell. [Dennis Müller](https://github.com/d3mueller) (see [#1262](https://github.com/Instagram/IGListKit/issues/1262))
 
 3.4.0
 -----

--- a/Source/IGListBindingSectionController.h
+++ b/Source/IGListBindingSectionController.h
@@ -77,6 +77,8 @@ NS_SWIFT_NAME(ListBindingSectionController)
  */
 - (void)updateAnimated:(BOOL)animated completion:(nullable void (^)(BOOL updated))completion;
 
+- (void)moveObjectFromIndex:(NSInteger)sourceIndex toIndex:(NSInteger)destinationIndex NS_REQUIRES_SUPER;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/IGListBindingSectionController.h
+++ b/Source/IGListBindingSectionController.h
@@ -77,6 +77,14 @@ NS_SWIFT_NAME(ListBindingSectionController)
  */
 - (void)updateAnimated:(BOOL)animated completion:(nullable void (^)(BOOL updated))completion;
 
+/**
+ Notifies the section that a list object should move within a section as the result of interactive reordering.
+ 
+ @param sourceIndex The starting index of the object.
+ @param destinationIndex The ending index of the object.
+ 
+ @note this method must be implemented if interactive reordering is enabled. To ensure updating the internal viewModels array, **calling super is required**, preferably before your own implementation.
+ */
 - (void)moveObjectFromIndex:(NSInteger)sourceIndex toIndex:(NSInteger)destinationIndex NS_REQUIRES_SUPER;
 
 @end

--- a/Source/IGListBindingSectionController.m
+++ b/Source/IGListBindingSectionController.m
@@ -125,6 +125,16 @@ typedef NS_ENUM(NSInteger, IGListDiffingSectionState) {
     }
 }
 
+- (void)moveObjectFromIndex:(NSInteger)sourceIndex toIndex:(NSInteger)destinationIndex {
+    NSMutableArray *viewModels = [self.viewModels mutableCopy];
+    
+    id modelAtSource = [viewModels objectAtIndex:sourceIndex];
+    [viewModels removeObjectAtIndex:sourceIndex];
+    [viewModels insertObject:modelAtSource atIndex:destinationIndex];
+    
+    self.viewModels = viewModels;
+}
+
 - (void)didSelectItemAtIndex:(NSInteger)index {
     [self.selectionDelegate sectionController:self didSelectItemAtIndex:index viewModel:self.viewModels[index]];
 }

--- a/Tests/IGListBindingSectionControllerTests.m
+++ b/Tests/IGListBindingSectionControllerTests.m
@@ -395,5 +395,21 @@
     XCTAssertNotEqualObjects(initObjects, section.viewModels);
 }
 
+- (void)test_viewModelsUpdate_afterCellHasBeenMoved {
+    [self setupWithObjects:@[
+                             [[IGTestDiffingObject alloc] initWithKey:@1 objects:@[@7, @"seven", @20]],
+                             ]];
+    
+    IGTestDiffingSectionController *section = [self.adapter sectionControllerForObject:self.dataSource.objects.firstObject];
+    
+    [section moveObjectFromIndex:0 toIndex:2];
+    XCTAssertEqual([section.viewModels firstObject], @"seven");
+    XCTAssertEqual([section.viewModels lastObject], @7);
+    
+    [section moveObjectFromIndex:2 toIndex:1];
+    XCTAssertEqual([section.viewModels objectAtIndex: 1], @7);
+    XCTAssertEqual([section.viewModels lastObject], @20);
+}
+
 @end
 


### PR DESCRIPTION
- See #1262 (cell reordering using a binding section controller caused problems)

## Changes in this pull request
- Added method override in `IGListBindingSectionController` to update the internal `viewModels` array after a cell has been moved
- Subclasses of IGListBindingSectionController require to call super

Issue fixed: #1262 

I've added a test for this change. Is this enough? Or should I add more corner cases or something?

### Checklist

Some tests fail, but they do seem unrelated. I don't know if this is normal. I haven't changed anything regarding those failing tests.

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)