### PR TITLE
Fix SwiftLint warnings

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/PrefixedLabelSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/PrefixedLabelSectionController.swift
@@ -12,8 +12,8 @@
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import UIKit
 import IGListKit
+import UIKit
 
 final class PrefixedLabelSectionController: ListSectionController, ListSupplementaryViewSource {
 

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ReorderableSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/ReorderableSectionController.swift
@@ -12,8 +12,8 @@
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import UIKit
 import IGListKit
+import UIKit
 
 final class ReorderableSectionController: ListSectionController {
 

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/MixedDataViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/MixedDataViewController.swift
@@ -119,7 +119,7 @@ final class MixedDataViewController: UIViewController, ListAdapterDataSource, Li
     func emptyView(for listAdapter: ListAdapter) -> UIView? { return nil }
 
     // MARK: - ListAdapterMoveDelegate
-    
+
     func listAdapter(_ listAdapter: ListAdapter, move object: Any, from previousObjects: [Any], to objects: [Any]) {
         data = objects
     }

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ReorderableStackedViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ReorderableStackedViewController.swift
@@ -12,8 +12,8 @@
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import UIKit
 import IGListKit
+import UIKit
 
 final class LabelsItem: NSObject {
 
@@ -49,10 +49,10 @@ final class ReorderableStackedViewController: UIViewController, ListAdapterDataS
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
 
     var data: [ListDiffable] = [
-        LabelsItem(color: UIColor(red: 56/255.0, green: 151/255.0, blue: 240/255.0, alpha: 1),
+        LabelsItem(color: UIColor(red: 56 / 255.0, green: 151 / 255.0, blue: 240 / 255.0, alpha: 1),
                    labels1: ["A", "B", "C"],
                    labels2: ["1", "2", "3"]),
-        LabelsItem(color: UIColor(red: 128/255.0, green: 240/255.0, blue: 151/255.0, alpha: 1),
+        LabelsItem(color: UIColor(red: 128 / 255.0, green: 240 / 255.0, blue: 151 / 255.0, alpha: 1),
                    labels1: ["D"],
                    labels2: ["4"])
     ]

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ReorderableViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ReorderableViewController.swift
@@ -12,8 +12,8 @@
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import UIKit
 import IGListKit
+import UIKit
 
 final class ReorderableViewController: UIViewController, ListAdapterDataSource, ListAdapterMoveDelegate {
 


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: SwiftLint warnings
- [x] Operator Usage Whitespace Violation: Operators should be surrounded by a single whitespace when they are being used. (operator_usage_whitespace)
- [x] Sorted Imports Violation: Imports should be sorted. (sorted_imports)
- [x] Trailing Whitespace Violation: Lines should not have trailing whitespace. (trailing_whitespace)

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)