### PR TITLE
added Boundable

### DIFF
--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -628,6 +628,7 @@
 		917E89871E800EE70015F934 /* IGListCollectionViewLayoutInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayoutInternal.h; sourceTree = "<group>"; };
 		9574C58371B7A46F62E9AC24 /* Pods-IGListKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitTests/Pods-IGListKitTests.release.xcconfig"; sourceTree = "<group>"; };
 		CA8726D7FF3608E20E9F7EC6 /* Pods-IGListKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IGListKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-IGListKitTests/Pods-IGListKitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D0E3CE742219977B00CE7726 /* IGListBoundable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IGListBoundable.h; sourceTree = "<group>"; };
 		DA5F48491E8E9D7000DAE6DA /* IGListAdapter+UICollectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+UICollectionView.h"; sourceTree = "<group>"; };
 		DA5F484A1E8E9D7000DAE6DA /* IGListAdapter+UICollectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+UICollectionView.m"; sourceTree = "<group>"; };
 		DD3152AC1DE227FA00AC9D2C /* IGListKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = IGListKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -735,6 +736,7 @@
 				0B3B92B31E08D7F5008390ED /* IGListWorkingRangeDelegate.h */,
 				0B3B92B41E08D7F5008390ED /* Info.plist */,
 				0B3B92B51E08D7F5008390ED /* Internal */,
+				D0E3CE742219977B00CE7726 /* IGListBoundable.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";

--- a/IGListKit.xcodeproj/project.pbxproj
+++ b/IGListKit.xcodeproj/project.pbxproj
@@ -710,6 +710,7 @@
 				298DD9C61E3ACFE300F76F50 /* IGListBindingSectionController.m */,
 				2926586B1E75E01A0041B56D /* IGListBindingSectionControllerDataSource.h */,
 				2926586E1E75E0830041B56D /* IGListBindingSectionControllerSelectionDelegate.h */,
+				D0E3CE742219977B00CE7726 /* IGListBoundable.h */,
 				0B3B92A11E08D7F5008390ED /* IGListCollectionContext.h */,
 				E56B7B3020A9D6E90071010C /* IGListCollectionScrollingTraits.h */,
 				29822E521FE3473A008532D2 /* IGListCollectionView.h */,
@@ -736,7 +737,6 @@
 				0B3B92B31E08D7F5008390ED /* IGListWorkingRangeDelegate.h */,
 				0B3B92B41E08D7F5008390ED /* Info.plist */,
 				0B3B92B51E08D7F5008390ED /* Internal */,
-				D0E3CE742219977B00CE7726 /* IGListBoundable.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";

--- a/Source/IGListBoundable.h
+++ b/Source/IGListBoundable.h
@@ -6,9 +6,9 @@
  */
 
 #import <Foundation/Foundation.h>
-
+#import <IGListKit/IGListSectionController.h>
 NS_ASSUME_NONNULL_BEGIN
-
+@class IGListSectionController;
 /**
  A protocol for cells that configure themselves given a view model.
  */
@@ -23,7 +23,7 @@ NS_SWIFT_NAME(ListBoundable)
  @note The view model can change many times throughout the lifetime of a cell as the model values change and the cell
  is reused. Implementations should use only this method to do their configuration.
  */
-- ([IGListSectionController Class])boundedSectionController;
+- (IGListSectionController *)boundedSectionController;
 
 
 @end

--- a/Source/IGListBoundable.h
+++ b/Source/IGListBoundable.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A protocol for cells that configure themselves given a view model.
+ */
+NS_SWIFT_NAME(ListBoundable)
+@protocol IGListBoundable <NSObject>
+
+/**
+ Tells the cell to configure itself with the given view model.
+ 
+ @param viewModel The view model for the cell.
+ 
+ @note The view model can change many times throughout the lifetime of a cell as the model values change and the cell
+ is reused. Implementations should use only this method to do their configuration.
+ */
+- ([IGListSectionController Class])boundedSectionController;
+
+NS_ASSUME_NONNULL_END

--- a/Source/IGListBoundable.h
+++ b/Source/IGListBoundable.h
@@ -25,4 +25,8 @@ NS_SWIFT_NAME(ListBoundable)
  */
 - ([IGListSectionController Class])boundedSectionController;
 
+
+@end
+
+
 NS_ASSUME_NONNULL_END

--- a/Source/IGListBoundable.h
+++ b/Source/IGListBoundable.h
@@ -9,19 +9,12 @@
 #import <IGListKit/IGListSectionController.h>
 NS_ASSUME_NONNULL_BEGIN
 @class IGListSectionController;
-/**
- A protocol for cells that configure themselves given a view model.
- */
+
 NS_SWIFT_NAME(ListBoundable)
 @protocol IGListBoundable <NSObject>
 
 /**
- Tells the cell to configure itself with the given view model.
- 
- @param viewModel The view model for the cell.
- 
- @note The view model can change many times throughout the lifetime of a cell as the model values change and the cell
- is reused. Implementations should use only this method to do their configuration.
+ Tells the caller which sectionController to use section model.
  */
 - (IGListSectionController *)boundedSectionController;
 


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #

problem background: 
majority of people who use IGListkit always have their sectionModel and sectionController depends on each other. 
- the need to have duplicated keys when differentSection controllers being used in different screens
- This will increase cyclomatic complexity as the more types of sectionControllers being used.
- prevent crash when forgetting to add the sectionController at func objects(for listAdapter: ListAdapter) -> [ListDiffable]

solution:
letting the sectionModel to return its sectionController
 
### Checklist

- [x ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
