### PR TITLE
Suppress warnings for pod lint #trivial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
   include:
     - stage: pod lint
       name: Cocoapods Lint
-      script: bundle exec pod lib lint
+      script: bundle exec pod lib lint --allow-warnings
 
     # Build example projects
     - &build-examples


### PR DESCRIPTION
* The warning that is triggered (see:
  https://travis-ci.org/Instagram/IGListKit/builds/564842923) warns
  about not having a proper team ID. Since this is a library, I think
  it is ok to ignore this error.

## Changes in this pull request

Issue fixed: #

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
