### PR TITLE
Remove the redundant __IPHONE_11_0

### DIFF
--- a/Source/Internal/UIScrollView+IGListKit.m
+++ b/Source/Internal/UIScrollView+IGListKit.m
@@ -11,15 +11,11 @@
 
 - (UIEdgeInsets) ig_contentInset
 {
-#ifdef __IPHONE_11_0
     if (@available(iOS 11.0, tvOS 11.0, *)) {
         return self.adjustedContentInset;
     } else {
         return self.contentInset;
     }
-#else
-    return self.contentInset;
-#endif
 }
 
 @end


### PR DESCRIPTION
## Changes in this pull request

Remove the redundant __IPHONE_11_0, because the minimum requirement is Xcode 9.0+ now.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)