### PR TITLE
Update queue priority in `Background Diffing`

### DIFF
--- a/Source/IGListAdapterUpdater.m
+++ b/Source/IGListAdapterUpdater.m
@@ -264,7 +264,7 @@ willPerformBatchUpdatesWithCollectionView:collectionView
     };
 
     if (IGListExperimentEnabled(experiments, IGListExperimentBackgroundDiffing)) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
             IGListIndexSetResult *result = performDiff();
             dispatch_async(dispatch_get_main_queue(), ^{
                 performUpdate(result);


### PR DESCRIPTION
## Changes in this pull request

Update to use `QoS` and take higher priority for responsiveness and energy efficiency.

Following the guideline in the doc [Energy Efficiency Guide for iOS Apps](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html).

It's better to use `User-initiated` QoS in `Background Diffing` because it focuses on "Work that the user has initiated and requires immediate results".

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)