### PR TITLE
Remove references to removed files in pbxproj files

### DIFF
--- a/Examples/Examples-iOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,131 +7,128 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		076D3C5F732E7060BFD8115BE93C5504 /* IGListBindingSectionControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DA546B8ADF45E9C49AE21793AF908FC2 /* IGListBindingSectionControllerDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		078EE7F0A6C0C05D4ADC51A649E71D8A /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 692D718E1FB846F471F1E238A8073509 /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		083707D4DFB99E435B8AB9E765D21F01 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 03DC4A19E3A79A7E24ACAC28C702E4CD /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		08C84BEE894A14E5766B5C50E23274FC /* IGListCollectionViewDelegateLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 371F3D6B1997EAA65386CD36258CFDAA /* IGListCollectionViewDelegateLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10CF8697DC9BF0D2014652FC30C3DDDC /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D8A4F47558918ACF83FD1EB0FA758D0 /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		17DEE94EE7607E6C31C347D1872A83C4 /* IGListDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = 42D4500DB4DC33B1253A4883F8411E64 /* IGListDebugger.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		194775034FF52A1FF3EE93459DD1AAA8 /* IGListGenericSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F48717FE518B8DE09365412671B917A /* IGListGenericSectionController.m */; };
-		1BA5D4302BBB5DC62D2CF4587FB5D3BE /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7B97C6FC6D3C89142CAF905A5E8A9790 /* IGListWorkingRangeHandler.mm */; };
-		1E7429F48A1A2FD6C378A301CBC97251 /* IGListAdapterUpdater+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 211F7C53AD1EA83FFE09E9444F559E8A /* IGListAdapterUpdater+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1F1B534348B5B6583D691176D3FA980C /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9612085D18B7AF158EBEDF462F481763 /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1F20AAB4355466D60A46BDA391AB86EE /* IGListReloadIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 3882A6E3B7945735D6D90090096760E7 /* IGListReloadIndexPath.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1F327C2BF81FD3A44F3C928E0A2790B4 /* UIScrollView+IGListKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FEFC6C17288EDA681F2DA7AA9931B7C /* UIScrollView+IGListKit.m */; };
-		216E86A5811F0D2957308B2985C906A1 /* IGListGenericSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0383D34B2EE0202A75A7D5FDDDE43E55 /* IGListGenericSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		22D3785E32AAA7E050355166AB53F34E /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EA5F1CAD4062FDA7678FCEA53EACE33D /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0094D67D82CF064A7A4598D2B1458C42 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = F0949488A81E86CFA1CD1B92CE084E42 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0140E79E9A78DCC82A9E0499D6D505A4 /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 41006E0540A00C0AA37FF6E8488171D3 /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02BF2B7603D611AAACC331E2352B590C /* IGSystemVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E12F60BE657ECDC2B431C6BE8096001 /* IGSystemVersion.m */; };
+		050CB37AEE76ECE3542C348937096F72 /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D0CA665052C5446A2BB26EE0066DC427 /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07B148F761AF9AC40BBC3A463A21ACAF /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 22B2104FE3B310C2ACC9EA50D39DABA7 /* NSNumber+IGListDiffable.m */; };
+		07BD381C9D8D8AE0B30B9A2497AF58C3 /* IGListSectionMap+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B7B482F0D9FC2FBD5EB6A16F9E67C6F /* IGListSectionMap+DebugDescription.m */; };
+		0927D0B030275F5F0AA4D5BFC98C5C24 /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E5527C92FCC72200F4FEC95EAA18AD3 /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09FE869D7DF75AED14C5ECBC9BBE0E77 /* IGListAdapterUpdater+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FC2F856D00467B0D1788FFE6149787B /* IGListAdapterUpdater+DebugDescription.m */; };
+		0CDD22A418A269BE2CF27654D0DDF4A4 /* UICollectionViewLayout+InteractiveReordering.h in Headers */ = {isa = PBXBuildFile; fileRef = 5653B6F57FD69B70F0280EE456DE9B71 /* UICollectionViewLayout+InteractiveReordering.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1137E7A3F0AE912B05C6C75267B22948 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 46EA5FAFA4C1C031D2CBEECD2A50FE34 /* IGListDisplayHandler.m */; };
+		120E8310162E61C5E350C905BBD0642F /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = C2C98958388A5D10B6A6F8653FC324C8 /* IGListAdapter.m */; };
+		1282117007BC677B95A4CF52D2257565 /* IGListAdapter+UICollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 854ECCEE735014C5D9C30E8105C10E94 /* IGListAdapter+UICollectionView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1397AE7BC9FA504F98363C065FBC834B /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = C7DD0A25CCB7775738D04DD0553DE010 /* IGListReloadDataUpdater.m */; };
+		159144DE9AB96730A5314BA992AA7D8A /* IGSystemVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 75429017957DF51361DBC74F40F2F21A /* IGSystemVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		170E95301CA7DE703CAAC56EE0061081 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3365241B64D1A5B0CC65B5942328C88D /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		20785A08B96FE648530D7BDFEB0AE7C4 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FDB300A5525F994AC561F71C5D828D8 /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2597177736599EB00615821EEFF28192 /* Pods-IGListKitTodayExample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D77D965BFCDDDD13E3099D899B536201 /* Pods-IGListKitTodayExample-dummy.m */; };
-		25D85AC1A76829D45B602529486E1703 /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DFD4F2B2D29AB4A18B5120452176853 /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		267F7A5F03290F54BCEFDBF866970EE5 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DE9BBF67B3ADDABCF919D37C121CF8C3 /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26EA0A48BB89E5440059AECCEB46A14F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */; };
-		281DEA132034220BBC681103A1AF5CE1 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 92F4552DDE17BE53E61F1886DCDE7B70 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2AD3B0BF6A79019B8C6814F242C804D1 /* IGListDebuggingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC1C637F9C0AE29D72685C77819220E /* IGListDebuggingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2BC5A51D82B86957A3BFC7B16F988040 /* IGListBindable.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AC78C46C87E838A6509F554738EB8EE /* IGListBindable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		332DF287144C586ED4D9CE3C2297656B /* IGListBindingSectionControllerSelectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 440E3FF7AC26E6111E65519935642573 /* IGListBindingSectionControllerSelectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		339DE064A51B93D31F00ADD08D65232D /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F793EC4F27EB18E43481C8411FA2729 /* IGListSectionController.m */; };
-		35A6013FD8BDA2148972A36AB0ABB8C5 /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1A9022CD0D4E43FA62B9F30CAE92CA69 /* IGListCollectionViewLayout.mm */; };
-		369279995C112E3620C3DFF8675BA23B /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 62CBBC4894F382BC5AF8D2C38BBA0F32 /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3876E9EB11373F8E2EF342CB3691BAED /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 2ED46836AFB8D88B1D96399D09F978EA /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A94977553916C52A0235B48111926ED /* IGListCollectionViewLayoutCompatible.h in Headers */ = {isa = PBXBuildFile; fileRef = CFF408C087E56123D872C50FCFA40AFA /* IGListCollectionViewLayoutCompatible.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D1D111DEF3B0541CC0715B8F070075F /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = F1B830E3D3F859A4D05A6EC4B93431F4 /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3F8CF4DE5BAEBEE19C08579E38BB776C /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2D8C2174EEB190F934FE496A7DFFBD /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3F9AC999133EF04647D1A660FD61955D /* IGListReloadIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B0687400523ED7A1194B47E87FB9526 /* IGListReloadIndexPath.m */; };
-		3FE2AF8CFFF1CBCF2EA692B01FDD7AE1 /* IGListStackedSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1B786CE2B90C71EF0828B4448AEE3BE6 /* IGListStackedSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40E56342CF63845B458EAFCBD66CD14A /* IGListDebuggingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D1C74FFB6B4579E2C45F3AB95BC283C3 /* IGListDebuggingUtilities.m */; };
-		426248B7E67B3A847AF1B1BD2A19A103 /* IGListBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C7396F7915F4497DFFBCB46D1B33B1 /* IGListBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		42F62DDD9364FC4702EABDE4FB168626 /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D3F2B108AFE983D69E84996ED566057 /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43BFAA66A206E8A6F9D8301F70B0AE4D /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AF4B55C8C1668B91FA680D052072D6A /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		46C8A5977F015698E3F8441FD78B3815 /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E48B6C09DB4B87AB8F2523A79B1D6B /* IGListAdapter.m */; };
-		4783C07C11C07427C43BBCC93AC5143C /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = E9D67F2AF1177C61845A3BBEE77A5D38 /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		512468176AE53D4E243476E371CA6384 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 674E727C976C2FB76C9D4A4689ADE85F /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		52DE97F84FF8E239C11E6946678B3752 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 066B551EEA2FA468D3E99C1880375E35 /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		558A1592B706959921A3548BF42088F4 /* IGListBatchUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = 420B83CB934E78E8B8A75F7C8AA173F4 /* IGListBatchUpdateState.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		55D072F3C077B3BF47C2A71295522BD9 /* IGListSectionMap+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = D1506F96A7CBC596094F7B2A33ACD435 /* IGListSectionMap+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5C3085AEB7ECFA44C0CBCC574C814C22 /* IGSystemVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 69937996A99F521B10DD3272B5CCBB0B /* IGSystemVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D8602CAA6AE82D1560BA27DB004A614 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A9F5E70A8B4308AB52FC695A00EE707 /* IGListDisplayHandler.m */; };
-		5DBA9B53681CF227C9411BCA2020BD6E /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECF2A2B0720AE923C22BED3192888BE0 /* UIKit.framework */; };
-		60B47D935CBB717BC0D1E8B47887CD7D /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = BE726AF43888DF0C7F7C1D8C6866E3B9 /* IGListMoveIndex.m */; };
-		639D19E840CEE47B8A8CDAE0DD96AD76 /* IGListBindingSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F5AA1D844489BAA60ADE9B02C921B6D /* IGListBindingSectionController.m */; };
-		63BDFADF7142DE39365962DCFDF68E5F /* IGListBindingSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3954471B291B5095C6676EC5FBA2A8B9 /* IGListBindingSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A09094BFB39A6184C10B74746FF7A78 /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 80B5F0BFE12986E9CC6F8E23DB5DBAD7 /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A3BCB64AA8A37F9D5739904743287A8 /* IGListBatchUpdates.m in Sources */ = {isa = PBXBuildFile; fileRef = DC61EFBCDE4460EE8D51971199FE4C4A /* IGListBatchUpdates.m */; };
+		2EB99C6459645C76EAEDB614B96E8A7F /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 1017DFA89762EF68154C9E85645E54D3 /* IGListAdapterUpdater.m */; };
+		304B559EB0E2155CF01FCD80F852CA08 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 66749052BF9812D222F45DA1D65C0AC2 /* IGListDiff.mm */; };
+		328119A6B5C29D0E167DD4BB2D4B8815 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EDF72970B37AA776A8291F8928739C0 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		359CF0381AF5C7F81C800A6174A2F5A7 /* IGListGenericSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B90C679A42A6521974D50D15EE81A6E /* IGListGenericSectionController.m */; };
+		369C7F203DAF3C82297169F7A76F2898 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 81733DEBAC61ED8C226AA787201F4AA6 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3713990BA33D5B668C51C9BC030FFAF2 /* IGListBindingSectionControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = EFF7CC987D1C5138F502D14214368771 /* IGListBindingSectionControllerDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		385487A89C4A821AEEC11A3ECFC021A3 /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BAD2E8CDCA43740CC5C6A0AA76BFF324 /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		386AD898815E39BB26F3ED97D5F52A0B /* UICollectionViewLayout+InteractiveReordering.m in Sources */ = {isa = PBXBuildFile; fileRef = 28CDC9AC99FB2C69EE4B400136D05E45 /* UICollectionViewLayout+InteractiveReordering.m */; };
+		39E96236BA4786C17E251772B00FC9D5 /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B119D3CD073B6AA1D33D5C80E926EC8 /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3E2924EBCF6D645982DD9872C75329C3 /* IGListCollectionScrollingTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F9E145973E0C159BF76941D9009E3B4 /* IGListCollectionScrollingTraits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		407343653DCC836D08B1A2FB99194E07 /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = C46720A53A5175FFF5858F9184B0B377 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		436DE67F0C1A1EE7ADD1A104D19783DC /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B63E0E9A01385088DC950A9958EBDB03 /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		44A1CBBE52A752A925DC49D95C78DB10 /* IGListDebuggingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = D3B50C9C20677607D48A07C2E38E5F34 /* IGListDebuggingUtilities.m */; };
+		479781E2935028998C7016CFEBBC37C3 /* IGListGenericSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 614A557F6569A1145F876B51D590AE61 /* IGListGenericSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4A86719B3012A63F47DD316DFA63D67B /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 744A5E861F2D9316E0458C3F0408C123 /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B62113EF5872F1B7752C955DEF03E35 /* IGListDebuggingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 878AF2F118E2CCA640970F33A07C73B8 /* IGListDebuggingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4C04FC1C6AA89AB03E1703184E79245F /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 8AA8A1C3856DE7F7B8E4E2E34C682509 /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D5FC94F0F38840B4F4EF0125C28C073 /* IGListBatchUpdateData+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D10370D2A7ACBA4B732EE229BF52FA1 /* IGListBatchUpdateData+DebugDescription.m */; };
+		4DA167EA9BD179605B00005E81582825 /* IGListSectionMap+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E124A5D40B16D8B177697C053F6CC2B /* IGListSectionMap+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4E3B217C44E988031BF24FAD15FCEDEF /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9A3C79F564AA50DDB644338C95A6DC5A /* IGListWorkingRangeHandler.mm */; };
+		50202E0D9BA01738C86218DE29F79FB2 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2D6949DF6B5D2CC431EDDDF11918FFD /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		502EE857A881018E5FD387A6E23A38F0 /* IGListAdapter+UICollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0706B22AA2831FE881AF3A3089E9CF8B /* IGListAdapter+UICollectionView.m */; };
+		543E895A12B5E4989593120AC9272064 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 01D64D6A05BB4F6E57D4315BD8B500FE /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565010349B072FD721B750E287779F29 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 82D9B57140A46A523A476A8C988DA6ED /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5938F6A23F345135DB251AC12D2C9CB0 /* IGListBatchUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = C5F187AC8488CF9E490F2C4200CFA292 /* IGListBatchUpdateState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5C1B34C156605E407A0F6DE20FD9AE9E /* IGListBatchUpdates.h in Headers */ = {isa = PBXBuildFile; fileRef = B251F53F7135E93A7A3FE4ACDE0E6E6C /* IGListBatchUpdates.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6026AC58E181E1A3411CE6E99F01E136 /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = BEF2D5AF7527A2EEA2CB61D3B93318E9 /* NSString+IGListDiffable.m */; };
+		60C252DEA16FA0201AE31B7A516DA2D7 /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = E9C97D5A25B37D88574660E311BBF291 /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		64DC64858505AB25CB8C628E85E98245 /* Pods-IGListKitMessageExample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DD11FA4F4D747228292F39CDD7808F85 /* Pods-IGListKitMessageExample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		69C18F1791460A078F2E7503DF52D3A9 /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = FB6422637E1B4DC6603EC538CA47F177 /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B074FAE1C973F3B2FD5A329D8400CF5 /* IGListCollectionScrollingTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 389848B46317660EF32A43516ECCCA03 /* IGListCollectionScrollingTraits.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D1F1EC22DF9780694EF665E670E5D1A /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 1411C6EFE7A6CAAE16FE65EBD2D55890 /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6F0CC3FFAF4600EB5B32D2F997FE9661 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = CA37B2EEC914A0785E29D2047C0FD1E9 /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		71AA970A0AB7DF31644D77F84231EEBF /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F7FBDA249198E78AD1871D9160C88D /* IGListCollectionView.m */; };
-		73E9A9FDB94FB973A3582D675BAF95FF /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D30D598272340D656FE6EA38F0B7B7E /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		775D3EA9ACADCB1061579432AF46A03A /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 37BEAFA0459AAB1874E601F51BC110D1 /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		78CAAB972EBDE8B6D7E8EA4C8950177A /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F96F6A0856664D181DD81B5EF2A48172 /* IGListCollectionViewLayoutInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		78D3337F28EB0D85D3C227CCA1CAC487 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = C2267D810839A15755F5E28197B069E3 /* IGListDiff.mm */; };
-		798199A75C4A7C31E97B38AA4B037C96 /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E0CCC606FB1769C523803BD2F809E7D /* NSNumber+IGListDiffable.m */; };
-		7B356E78CB42542D40440815A32AC0D0 /* IGListBatchUpdateData+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B82F9610386A9EFA9762299B844AF90 /* IGListBatchUpdateData+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7C29839EB19D7F709F28FED9CB32402D /* IGListArrayUtilsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE0909C45B4B4F12E2F68766E666043 /* IGListArrayUtilsInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7C3A33BD13E4E4BDBBA2A94219AA452D /* UICollectionView+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C07BE03D8DEC89C003163AC23C43A4F /* UICollectionView+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7C9CDAA99E50763C7A7993D6013C3D82 /* IGListBatchUpdates.m in Sources */ = {isa = PBXBuildFile; fileRef = E309AE66E886B34FA6C73F9729951CA5 /* IGListBatchUpdates.m */; };
-		81F8452E9117587E205091DE73A80B76 /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = A20E8B1E857182C050621491326DEC24 /* IGListSingleSectionController.m */; };
-		85360445E5C3E9174495212901A7490D /* IGListBatchUpdates.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D7D84E512916E93A503CBF6F88524D6 /* IGListBatchUpdates.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		85893A0F1D8732D0D28035E406DAEF5F /* IGSystemVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 67832F3519DB4B210CDF5A5860353925 /* IGSystemVersion.m */; };
-		860968484A55F57A2E0160414C601EFC /* IGListBatchUpdateData+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 67AE8CAAEBAFEE2A970AE7375EEFF9A9 /* IGListBatchUpdateData+DebugDescription.m */; };
-		894295A77D2FE6D08956E31F5E4BEA90 /* IGListAdapterUpdater+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = E833589E26237AA174C0E9EA6465FEB3 /* IGListAdapterUpdater+DebugDescription.m */; };
-		89C9164445EBBEE72A39B233293B1DAC /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = 044FCE0682D64C46BD87A96F0E3DBF7B /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A407059D7A86F31421960855E58D4F9 /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FDF5D9B5791BC8D09BF19CAE1F9006D8 /* IGListIndexSetResult.m */; };
+		65D8D6778D494967E8D1857E33EB06B2 /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 811398241EF7EF12BDAF0E2F2257C18E /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66F3C1A0EA3BB9007A18C3671A707474 /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 62486C1A8C8ABBE1D22AEACA3CE0E675 /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6A1EFB64B94A1F9BB4616092D761C9AF /* IGListReloadIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = A1F08F237941A456565584EC6342BD28 /* IGListReloadIndexPath.m */; };
+		6C62504ABCCD830B5CCB0701657BAAAF /* UICollectionView+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 64BC4005A78CE1E91774D507CACD1564 /* UICollectionView+DebugDescription.m */; };
+		6D89FDE6F52F9C3191B616E9B0E05DD5 /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BE925F92B712604FCE780CA91550C5B /* IGListSectionMap.m */; };
+		6DD73C34CC787C0D145CA6E408EF42F1 /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A33E8B1DA72B5B88794B3F3F1DCF7328 /* IGListCollectionViewLayoutInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7080F30B82C53E9D621D85B78B0B465C /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 1430048F0DC6C8CB7000F61F3AB84DE1 /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		72CCC85E803626A6E85AE3249A918510 /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F632BA2C517D3BC6CBF4433D61E094 /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72E4DF6E435AAED14B9C27571DC08FA0 /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = DF0974E1FC25B9A25FFCE4C76A54DCBE /* IGListMoveIndex.m */; };
+		7337162978A882C23723096E5F4A0E75 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AEC9D3C7F018C772C2994836AD3555 /* IGListIndexPathResult.m */; };
+		786E49A8F53ED48AEB69D807A208853B /* IGListReloadIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = FBD424E50E3FDAA66D2D09EACF0E498F /* IGListReloadIndexPath.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		80C765861733FEB163A4689F40D889E7 /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E3327FB501A44D2B9DF8AA2FBDFF7F6 /* UICollectionView+IGListBatchUpdateData.m */; };
+		82DB51EE154C7EACF2ECAEA4ACAB7C71 /* IGListBindingSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0B90E49E53717C10ACE475A6F47E6C19 /* IGListBindingSectionController.m */; };
+		835F8A26E9D9ED7B28B1A5A8E720D8A5 /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = D0C4A37D30725BCC1CBD2795A7E79BFB /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		837263F72812458D17329664715B9E00 /* IGListTransitionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 74E9D33F9DEBE578466CF8D08D60D3CB /* IGListTransitionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		842C3167B5F677583A4EB995A0AB9144 /* IGListDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = 298BE78BD8B2ED70E3A67B1508ED63B3 /* IGListDebugger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		84EDB91D8FEC7B4F430E9483AE203741 /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = F20B6A958066540F4B5523C3E48B9F12 /* IGListSectionController.m */; };
+		87703E311264E96792C69BA3B11A7A8D /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = EBB996C88B4D76F0A2A3F0E0D3F6EA5E /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		89EF06907B308D35A992588930244256 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 55C4C0A2D93C9CF65908D7E7EC1D339A /* IGListAdapterProxy.m */; };
 		8A8A09B29217B1320F61CA97102E4ADC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */; };
-		8AA91E8D505AAA0E8B448ABF59CD2E95 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = ECB918404917AD4FDCBAA810A7DFF624 /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8C567AD1964B194962A00D3E5AD25E27 /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 30DBEF45C2E728D1090A961614EE47E6 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8DDEB77D26E101539FBC32073BCC91BC /* IGListSectionMap+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FFB3F2020528EE055DD35388C7D7C87 /* IGListSectionMap+DebugDescription.m */; };
+		8C381DB929831D42ADFA58031B0111CD /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 76F8DB4CA32E315073C5AF2F5964BDA1 /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8DEB6A80425E81F141AFA892B539A17A /* IGListBindingSectionController+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 6643BED0640FDC23F264B6E30762B99F /* IGListBindingSectionController+DebugDescription.m */; };
 		8DF20D300CF0694BCF3AB1FD0A3ADF3F /* Pods-IGListKitTodayExample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B8E527B1425066B71919F9E92AFF926 /* Pods-IGListKitTodayExample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8ECF5C6225FE112FFBB5E5C0767BE421 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2315909B6F12DA63EE28E3FE987E8908 /* IGListBatchUpdateData.mm */; };
-		913D28466D2B34E687DC0D9702062054 /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A03A8B550799920D1B3E989D1335998 /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		92A0098963EEABBCE7891AEF2BBEFEB9 /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = A273F1EDF2D368DFE57EB7B6C2CAA4F7 /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		98FDEA8D5C95BB0DFFDA1B059141FB8E /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = E45EDD691FF311B8A3B3DA94C707AAF0 /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8E8B4C9FA06F091842EB606AE8499CCE /* IGListAdapter+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 993C1BC004AC4BC65B9A3B052E39F9E0 /* IGListAdapter+DebugDescription.m */; };
+		9010A8434B660C2264AA992949930C32 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0A0E48D597836337EF70C29E49E57634 /* IGListBatchUpdateData.mm */; };
+		91B9729085E3DFFF6A2493C75D946344 /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D17F1144C7FADAC5C843161AE4563B3 /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		921B146558C8ABF2838644BE0995FE9D /* IGListAdapter+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 9752CAC78ECDDAD7EBC30468E07B3675 /* IGListAdapter+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		924CBB03106BFF159DE0DEC543355B9E /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 44C8F823D204055646A63EE044B5656D /* IGListKit-dummy.m */; };
+		940829814B26541CB202AF8F1BE1F6DA /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B35F8F140F5687C2CBB2B18E492F0CC /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94D1B6BA3DA2B691BB3C07A95A011F01 /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E593D64A5E553F6D8C4C9072A7F02C9 /* IGListSingleSectionController.m */; };
+		96F95E57CF553C5BBEEEAED9B91B2FAB /* UICollectionView+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 21DD4062A25AF8B16D5602BE3B603577 /* UICollectionView+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9AE5EFDE583ACD4786CF07074474B00D /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E92037D172FBA797EC96E20D2F748E /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B6A75415BEF5385B5C3D382B1763A0B /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 441D39CA85B2D166D8B80F8A56F7C8BA /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D28FB3BC158D10F2D39688D02EB8DD2 /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = C52D3728817A5D029C6DB61E4DA9FBD8 /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9DC1744CB33691C06684873DBFFCBBE7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */; };
-		A9A9279564936FE0EAF95F89EB0B8AAD /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FDEDAD33401B1C42CC43C96F2328C25 /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB14E01885528EF9C1895FA1FDCCA52A /* IGListBindingSectionController+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 61F8D7D92B91C024F2066C168321AA92 /* IGListBindingSectionController+DebugDescription.m */; };
-		AB3D3CF8A734B837A488538B52411004 /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 77C12F2A7ABA79BCC15AD7CDDFEBB09F /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ACBC251FDC68254A12F7D7B8C763095D /* UICollectionViewLayout+InteractiveReordering.h in Headers */ = {isa = PBXBuildFile; fileRef = 63A47D737C4BD54D40504B4EE5F809E9 /* UICollectionViewLayout+InteractiveReordering.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		AE0BD12CEAA45873317AE6718BC8506D /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 90DA75A42732723728B7EC12D9DAAAF9 /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFF9372D26BC23508C305031EF5BD98A /* IGListDebugger.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A794A13E30ED1A1B1117EC695A24CDB /* IGListDebugger.m */; };
-		B15652D58487B23119F5CD952287BF46 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 593AB20FE2F62DCCF55CC8C621A87A13 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B32CD5CBE9F25F88399132223D39EA98 /* IGListTransitionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F3B589E41CFF0D2CFCEC848E2A5D5BAC /* IGListTransitionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3D57B439E9CA31E04FD392FEA45209B /* UICollectionViewLayout+InteractiveReordering.m in Sources */ = {isa = PBXBuildFile; fileRef = 8A886B504C19BA83BB5179DFA3C7074B /* UICollectionViewLayout+InteractiveReordering.m */; };
-		B46B92DA6C28CB6F5322747DA7FA9259 /* IGListAdapter+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B377708F6EE994BC1010B6BD38A3886 /* IGListAdapter+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B5C62515D6137F11E5EE5A150FA4EEA5 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C7C6F0859B45281DE2F20F302A29ED68 /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BD9BCBC78D070DFF8403401E12EFD09B /* IGListAdapterMoveDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C420FE671C4EFB6345F7882E71E5E4DA /* IGListAdapterMoveDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C330A515296CBE24A82292B534CECD32 /* IGListAdapter+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA143C1A19EDA1CBBFE996AC7222DFD /* IGListAdapter+DebugDescription.m */; };
-		C3B987D343F39BD8AAD53F80B48CC011 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E87589679047DFEA4C0CF7F76D19965 /* IGListIndexPathResult.m */; };
-		C4D746E4DD31BF495BAD1E424D3E67CA /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = E09C30D85E9DDEB527C77C9AFE8D6B76 /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C53C3D9ADC9FF6A72B758299182BF2EF /* IGListAdapter+UICollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A8725312F557AB63A46D940FDA5F35A /* IGListAdapter+UICollectionView.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C61723062C613D10AE505D7D3C851A3F /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F285B85787EB2EBAA85D53861B22942 /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9F2A844A340283F45D94389D884EB8C2 /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2776F2557F1B9AB75979FF8A420E484B /* IGListCollectionView.m */; };
+		A6F4826056A25D8BA1510E4F9C145841 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2211947B53C9C1733D2FA851AC8CD9B2 /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9E893D7A41C4582B1D87D1B03671A2B /* IGListBindingSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4325D4F044E926B1FA04C7627F239E82 /* IGListBindingSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B0B9AC8BB0CDE9B87FBB7E2DE4723A06 /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4A012974BA15CE66B6582B2C7FD68665 /* IGListCollectionViewLayout.mm */; };
+		B0BA766330939CD91E034BD23BA0F030 /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EE4B06CE8B9AD78FC7EA9B08B555F77 /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B25C040E31E7B1BF90B87B1152A19D0C /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 701851857ED864923D686B19C1F130ED /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B56F1064287CC0E3B444CE9A3B8EEE70 /* UIScrollView+IGListKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8AF835DC4362F43842DA5E46471231 /* UIScrollView+IGListKit.m */; };
+		B5FBE3FD9252B5AB8A13AE29BA9F7735 /* IGListAdapterMoveDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DB15E81008571D85246D9DD43A9C176 /* IGListAdapterMoveDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6430BBDD033522F9563BF53B299937B /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 72813F0A42ABCB57CC7FDDD48D6525CB /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BCEFC1DC0089468111DD45674FA6CF38 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = C88734A4CEB37D3DEE450C9DB8633296 /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDC091D1C2757D68D3AB5A323A4AFD8E /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = F3739218A19D5E056E29E85AFAB750D8 /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C171FDB4097450BEDF90D08A275628E3 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = AE45701181220FC066F21669CDC35EED /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C92D69E1A5C840EFA261D5BE92D0B665 /* IGListBindingSectionControllerSelectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B33C79CC157FEA65CBDDFBB8751AB38C /* IGListBindingSectionControllerSelectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB9636D8302B605D7F331306729AFD63 /* UIScrollView+IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = A6795F66FBAB470CE23EDA7241825D05 /* UIScrollView+IGListKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CC6AFDA8443BD5CF747C7210A24EE3B1 /* Pods-IGListKitMessageExample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 523654D67C41985094E1A2FF2FF8566C /* Pods-IGListKitMessageExample-dummy.m */; };
-		CCB60B65002D2605C230376170062394 /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D31AD0C93848779245330326E657A4 /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CCF21C54492902F6AB5756105A55777F /* IGListAdapter+UICollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EE5A843C04930DC9339D6AA1082C72C /* IGListAdapter+UICollectionView.m */; };
-		CDCE0F8949FCDA85DCC07A91EA102106 /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = FBE985E43CE368AA737BFE297FFFF930 /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CEBECDD6178C3F768D2FF4BD80405BDE /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 92F335A785084C07099C58BC3A93E574 /* IGListSectionMap.m */; };
-		CF552B2C48B9493D33F1C7FEB4852AAC /* IGListAdapterPerformanceDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = C7F3DDBC4E623739466845B9A9F0FE8C /* IGListAdapterPerformanceDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D2198FE4B115B262C08ED2B1164838DA /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B2C0C25765F7F31D3CA044F2F86C3E /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D2E724C95E02C007C0C65791B11865FB /* IGListBindingSectionController+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A89A7D5D864313B7254DA66F8E90249 /* IGListBindingSectionController+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D350E679B53B363E68753893E2ABEA93 /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 6A159BFCD8301C03E679149E499C1E6B /* IGListMoveIndexPath.m */; };
-		D408771CF05B12485C14D5A819D04B43 /* IGListStackedSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 970A241B1B809D2A10F86A7127FD5581 /* IGListStackedSectionController.m */; };
-		D6B9D0372AFCFDB89F5B18A96A9CD0B2 /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = 8696286ED5A79E4AF1AFA2D44920C90B /* UICollectionView+IGListBatchUpdateData.m */; };
-		D709E3D33001D8C64533654DFD7A627D /* UICollectionView+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = EDD27A8476E8722E951B2DA4445E7A2F /* UICollectionView+DebugDescription.m */; };
-		D75260F59B10CAEA2E52C2206EE7B0D3 /* UIScrollView+IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = FC796A62B892E50A529ACDCC7667F086 /* UIScrollView+IGListKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CEEC931F251E36D412DBFDB798D60F94 /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ED072E8B6EF370BD02525AC0C66DF5D /* IGListMoveIndexPath.m */; };
+		D075D5B1D729FBD5D467B9247B36EAD7 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = DA952D32E01044CED53295436E89D88B /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D5C431990C04DDD62B11DDA8E66B824C /* IGListCollectionViewLayoutCompatible.h in Headers */ = {isa = PBXBuildFile; fileRef = D187C0E5DB27F1AE8701ED1644D57506 /* IGListCollectionViewLayoutCompatible.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D7F710D485982645AE922C5D6839901F /* IGListDebugger.m in Sources */ = {isa = PBXBuildFile; fileRef = D16B36F2C78B68C15C9B30BC770265D4 /* IGListDebugger.m */; };
 		D9026A81BC6387ABC7E1898D5E710CBD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */; };
 		D90781179CA274125422700EC52D0C79 /* Pods-IGListKitExamples-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DED9369B12236529C64756DDD159A5FB /* Pods-IGListKitExamples-dummy.m */; };
+		D976B548E97A8472DD03C110D5840C87 /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = F5EC716FD2106CEA5A413425306D3050 /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC490E762CE343241684A362B9D5FDE6 /* Pods-IGListKitExamples-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D7A363B477B31B91C9136FCAC2A9FA9B /* Pods-IGListKitExamples-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E06A01FAC1C0F8053DB7F7D5110B1E9E /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EEA22BAE075D9E81B2A849ED64BF95D /* NSString+IGListDiffable.m */; };
-		E0F57C7DBAC24D7DC63160DA5812C370 /* IGListStackedSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = CF28E4393C715BB0FC81A5CFB00D6ACD /* IGListStackedSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E5F12B8EFEBBC571F67F578DC427BF82 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 05D3F2BA94861E7615792CDA068A4CF2 /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E7F66F981EF91FC8B590E7B75487053B /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8153098818861F304A24806868095861 /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E8BFE6C8932B728BADACF1C377CC232C /* IGListAdapterUpdateListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 34D1309F73A540453DCD26645B813697 /* IGListAdapterUpdateListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9D5623481C8CB91D32BDE1D78ED40ED /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 365225A14D2009FDF38E6B2C044533AF /* IGListReloadDataUpdater.m */; };
-		EB9DE9CECB4E21D81D66C5F80C2D6209 /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 87D90284ADC918AE3C5A00FB90A38707 /* IGListAdapterUpdater.m */; };
-		ED5C65077D8311258083BF27DAEDCEC8 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = CE77CFD6A72590901219325F80A7D9B7 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDFE97C739D7C27EB5DF573623146AE0 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = D952A047D5FB197406B63B5ADA927302 /* IGListAdapterProxy.m */; };
-		EEA0D92EB192DB986DB66AA5371AA45D /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A79365D845D6146F294238A9CD843F /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FB2987DAC40437D72958533E7B955EF5 /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C0525529DA2B84B1F3CD5C39968556C7 /* IGListKit-dummy.m */; };
-		FD153EA9B5A2B8D878F3DEF858A6A3A0 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 472224FBB7A3B56A05FC530CB0167EF2 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FF7E567E457135B97BD182D8C67F75F4 /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B1D71CBC7B01980F106DF1EE3F9F9BE /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFBAE4FD38CA5B58A0C156DED6D1C701 /* IGListBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 77561C468BC2B1F1F01CD942A77A5895 /* IGListBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E588EB6372FB13A5CA9B6ACD668E6935 /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 2F2A4059963DF52C6EC18223E51B96C4 /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E870D65E97CFAEB3539758BB9FA0E21E /* IGListBindingSectionController+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 876ACA760F9A1500014557081A588CF2 /* IGListBindingSectionController+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EAEC3F09A8484F35F7FE3672321E2361 /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 10E2B7E0666B218A43B24AB03E869FE4 /* IGListIndexSetResult.m */; };
+		EC480E1CF76B2A831A24F0B9EA07DA85 /* IGListAdapterPerformanceDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C406DC1E4D3C6B18F012C04608B8DBE /* IGListAdapterPerformanceDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECDC0BB3D3F98877AF8562A597899A35 /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0C118026309C2B39D3DD29B7649911E7 /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EFBDE12C77935B722442BB23A4DDDB75 /* IGListCollectionViewDelegateLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = C536C62EC1F5CCE91F3BCDF37C9C347E /* IGListCollectionViewDelegateLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1344FCB2E4119A707F82DCF02B1AAFF /* IGListArrayUtilsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F9096A156E32C6DDE6F4897C0A69871C /* IGListArrayUtilsInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F20FD96E6EBAF2BCE079A1B391EB6605 /* IGListAdapterUpdater+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = C1ED33F61FEC5AAAF032B8C0F5574ABB /* IGListAdapterUpdater+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F2568F0CB73D4BDCA314C8125D36F364 /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 805DC02CD9DFA67ABACEE7D83C1FBC3E /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4E4600D6EDFF3B1A79E23ECEA796186 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */; };
+		F80F75C42FD5B327999F711986A2851F /* IGListBatchUpdateData+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F2A430DE0506907558C17D55F9C4708 /* IGListBatchUpdateData+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F9F8DAB415C72F2ACE0C77FCF6A891B7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECF2A2B0720AE923C22BED3192888BE0 /* UIKit.framework */; };
+		FA49227F4FF92FB7205D8ED3984DAE2C /* IGListBindable.h in Headers */ = {isa = PBXBuildFile; fileRef = F8148402E66986003F6673D9E412A99C /* IGListBindable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCE38CF740B20F9C36A8F74665226E45 /* IGListAdapterUpdateListener.h in Headers */ = {isa = PBXBuildFile; fileRef = CBD7DB84695BF777CC376FE0B4C6E0DC /* IGListAdapterUpdateListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD8AD5D12D11003C2A062BE079937D79 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E12138C62489CFAF670C584626B6A8CF /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -139,243 +136,240 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E744CEE24C044B1DCCAA8DFFBCACB6C;
+			remoteGlobalIDString = D10AD9FAD40B191F43F847DCF504FE0B;
 			remoteInfo = IGListKit;
 		};
 		57CA669B239472F35B1A8FB80D4C1B4A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E744CEE24C044B1DCCAA8DFFBCACB6C;
+			remoteGlobalIDString = D10AD9FAD40B191F43F847DCF504FE0B;
 			remoteInfo = IGListKit;
 		};
 		ECFCADAB141C83EEB8CC1527E24DFABD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E744CEE24C044B1DCCAA8DFFBCACB6C;
+			remoteGlobalIDString = D10AD9FAD40B191F43F847DCF504FE0B;
 			remoteInfo = IGListKit;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		009674E801ED42DA88E2A7E17B464694 /* IGListDiffable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffable.html; path = docs/Protocols/IGListDiffable.html; sourceTree = "<group>"; };
+		01D64D6A05BB4F6E57D4315BD8B500FE /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDataSource.h; path = Source/IGListAdapterDataSource.h; sourceTree = "<group>"; };
 		02595E813596A994ADE9011797E4BE80 /* Pods-IGListKitExamples.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-IGListKitExamples.modulemap"; sourceTree = "<group>"; };
-		02CCE4EC31039FE9608A03FAF2CF8D34 /* IGListBindingSectionControllerDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerDataSource.html; path = docs/Protocols/IGListBindingSectionControllerDataSource.html; sourceTree = "<group>"; };
-		0383D34B2EE0202A75A7D5FDDDE43E55 /* IGListGenericSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListGenericSectionController.h; path = Source/IGListGenericSectionController.h; sourceTree = "<group>"; };
-		03DC4A19E3A79A7E24ACAC28C702E4CD /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDataSource.h; path = Source/IGListAdapterDataSource.h; sourceTree = "<group>"; };
-		044FCE0682D64C46BD87A96F0E3DBF7B /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
-		05D3F2BA94861E7615792CDA068A4CF2 /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionView.h; path = Source/IGListCollectionView.h; sourceTree = "<group>"; };
-		066B551EEA2FA468D3E99C1880375E35 /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDelegate.h; path = Source/IGListAdapterDelegate.h; sourceTree = "<group>"; };
-		07A79365D845D6146F294238A9CD843F /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
-		07B3DE78C6980BB6995E7C6ADF5EFA9C /* installation.html */ = {isa = PBXFileReference; includeInIndex = 1; name = installation.html; path = docs/installation.html; sourceTree = "<group>"; };
-		0A794A13E30ED1A1B1117EC695A24CDB /* IGListDebugger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebugger.m; sourceTree = "<group>"; };
-		0A8725312F557AB63A46D940FDA5F35A /* IGListAdapter+UICollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+UICollectionView.h"; sourceTree = "<group>"; };
-		0AF4B55C8C1668B91FA680D052072D6A /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
+		0706B22AA2831FE881AF3A3089E9CF8B /* IGListAdapter+UICollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+UICollectionView.m"; sourceTree = "<group>"; };
+		089FF2A854F52C96BCC1D01A9442C11E /* IGListTransitionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListTransitionDelegate.html; path = docs/Protocols/IGListTransitionDelegate.html; sourceTree = "<group>"; };
+		0945AF09BF9D60192B8D5FCCFE4979D0 /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/img/dash.png; sourceTree = "<group>"; };
+		0A0E48D597836337EF70C29E49E57634 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
+		0A474A78E15DAFA304A953A3FBD6A4C6 /* IGListAdapterUpdaterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdaterDelegate.html; path = docs/Protocols/IGListAdapterUpdaterDelegate.html; sourceTree = "<group>"; };
 		0B56345FD25C104EF7A417A3CBFB156D /* Pods_IGListKitMessageExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitMessageExample.framework; path = "Pods-IGListKitMessageExample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0BC5635A74E73EDFE4E276EC7737EE67 /* LICENSE.md */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE.md; sourceTree = "<group>"; };
-		0C07BE03D8DEC89C003163AC23C43A4F /* UICollectionView+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+DebugDescription.h"; sourceTree = "<group>"; };
-		0D8A4F47558918ACF83FD1EB0FA758D0 /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListKit.h; path = Source/IGListKit.h; sourceTree = "<group>"; };
-		0F2D8C2174EEB190F934FE496A7DFFBD /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
-		1411C6EFE7A6CAAE16FE65EBD2D55890 /* IGListKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-umbrella.h"; sourceTree = "<group>"; };
-		1594390C09EC59E43B1F638396EEEA2A /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jquery.min.js; path = docs/js/jquery.min.js; sourceTree = "<group>"; };
-		18D96B30D2A3A2F6F0FE3EEF1774CAC5 /* IGListKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = IGListKit.modulemap; sourceTree = "<group>"; };
-		1925B17DBA76D8F40C9AF6C3D9C94A1C /* IGListSingleSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionController.html; path = docs/Classes/IGListSingleSectionController.html; sourceTree = "<group>"; };
-		1A89A7D5D864313B7254DA66F8E90249 /* IGListBindingSectionController+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBindingSectionController+DebugDescription.h"; sourceTree = "<group>"; };
-		1A9022CD0D4E43FA62B9F30CAE92CA69 /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.mm; path = Source/IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
-		1B786CE2B90C71EF0828B4448AEE3BE6 /* IGListStackedSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListStackedSectionController.h; path = Source/IGListStackedSectionController.h; sourceTree = "<group>"; };
-		1CA143C1A19EDA1CBBFE996AC7222DFD /* IGListAdapter+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+DebugDescription.m"; sourceTree = "<group>"; };
-		211F7C53AD1EA83FFE09E9444F559E8A /* IGListAdapterUpdater+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapterUpdater+DebugDescription.h"; sourceTree = "<group>"; };
-		22742EF0B6DE8261AB1B378987151EDD /* IGListStackedSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListStackedSectionController.html; path = docs/Classes/IGListStackedSectionController.html; sourceTree = "<group>"; };
-		22B293012506ACB2C3B45678B518F484 /* IGListKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IGListKit.xcconfig; sourceTree = "<group>"; };
-		2315909B6F12DA63EE28E3FE987E8908 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
-		23EBEFE61B8B248618693FD011E1CEE0 /* IGListAdapterUpdateListener.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateListener.html; path = docs/Protocols/IGListAdapterUpdateListener.html; sourceTree = "<group>"; };
-		2629974FAAACF45FA8B2310E5DAF982F /* undocumented.json */ = {isa = PBXFileReference; includeInIndex = 1; name = undocumented.json; path = docs/undocumented.json; sourceTree = "<group>"; };
-		29F39249FF9402BF48F4E050FD49AF48 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		0B90E49E53717C10ACE475A6F47E6C19 /* IGListBindingSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListBindingSectionController.m; path = Source/IGListBindingSectionController.m; sourceTree = "<group>"; };
+		0C118026309C2B39D3DD29B7649911E7 /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
+		1017DFA89762EF68154C9E85645E54D3 /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapterUpdater.m; path = Source/IGListAdapterUpdater.m; sourceTree = "<group>"; };
+		10E2B7E0666B218A43B24AB03E869FE4 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
+		1430048F0DC6C8CB7000F61F3AB84DE1 /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
+		15D914ED60DBD308D0AC8BD035FA2247 /* IGListKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "IGListKit-Info.plist"; sourceTree = "<group>"; };
+		16168A6EEF34A8A1EAD3D0C6500C94D5 /* Protocols.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Protocols.html; path = docs/Protocols.html; sourceTree = "<group>"; };
+		18F5774A460120CA1A7E6AA8686F56B7 /* IGListKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = IGListKit.modulemap; sourceTree = "<group>"; };
+		1C406DC1E4D3C6B18F012C04608B8DBE /* IGListAdapterPerformanceDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterPerformanceDelegate.h; path = Source/IGListAdapterPerformanceDelegate.h; sourceTree = "<group>"; };
+		1CB7C84EEF54FEE734C2BBAAAC2A6ADB /* working-with-uicollectionview.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-uicollectionview.html"; path = "docs/working-with-uicollectionview.html"; sourceTree = "<group>"; };
+		1D7BE3AB5968D829FC7FCA8F26AE9375 /* Functions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Functions.html; path = docs/Functions.html; sourceTree = "<group>"; };
+		21DD4062A25AF8B16D5602BE3B603577 /* UICollectionView+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+DebugDescription.h"; sourceTree = "<group>"; };
+		2211947B53C9C1733D2FA851AC8CD9B2 /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionView.h; path = Source/IGListCollectionView.h; sourceTree = "<group>"; };
+		22B2104FE3B310C2ACC9EA50D39DABA7 /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
+		24F2376EFBD9C1C408C89E2B094DAA4F /* IGListAdapterUpdateListener.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateListener.html; path = docs/Protocols/IGListAdapterUpdateListener.html; sourceTree = "<group>"; };
+		26F52B05C2E7ABB97E721E8B32631396 /* IGListBatchContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchContext.html; path = docs/Protocols/IGListBatchContext.html; sourceTree = "<group>"; };
+		2776F2557F1B9AB75979FF8A420E484B /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListCollectionView.m; path = Source/IGListCollectionView.m; sourceTree = "<group>"; };
+		28CDC9AC99FB2C69EE4B400136D05E45 /* UICollectionViewLayout+InteractiveReordering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionViewLayout+InteractiveReordering.m"; sourceTree = "<group>"; };
+		2911EA29C22A6FAF5526EB699584F3D2 /* IGListCollectionViewLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.html; path = docs/Classes/IGListCollectionViewLayout.html; sourceTree = "<group>"; };
+		298BE78BD8B2ED70E3A67B1508ED63B3 /* IGListDebugger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebugger.h; sourceTree = "<group>"; };
 		2A65C6B86C5BF9E79A93925EDC0E9C70 /* Pods-IGListKitExamples-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitExamples-frameworks.sh"; sourceTree = "<group>"; };
-		2B1D71CBC7B01980F106DF1EE3F9F9BE /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListWorkingRangeDelegate.h; path = Source/IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
-		2D7D84E512916E93A503CBF6F88524D6 /* IGListBatchUpdates.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdates.h; sourceTree = "<group>"; };
-		2DC1C637F9C0AE29D72685C77819220E /* IGListDebuggingUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebuggingUtilities.h; sourceTree = "<group>"; };
-		2ED46836AFB8D88B1D96399D09F978EA /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSectionController.h; path = Source/IGListSectionController.h; sourceTree = "<group>"; };
-		2EEA22BAE075D9E81B2A849ED64BF95D /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
-		30DBEF45C2E728D1090A961614EE47E6 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
-		31A7A42011C196C3CDF1AD81D38FE86C /* IGListAdapterMoveDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterMoveDelegate.html; path = docs/Protocols/IGListAdapterMoveDelegate.html; sourceTree = "<group>"; };
-		3427C6194DEF85513980D8D53F1DA3C5 /* iglistdiffable-and-equality.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "iglistdiffable-and-equality.html"; path = "docs/iglistdiffable-and-equality.html"; sourceTree = "<group>"; };
-		34D1309F73A540453DCD26645B813697 /* IGListAdapterUpdateListener.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdateListener.h; path = Source/IGListAdapterUpdateListener.h; sourceTree = "<group>"; };
-		365225A14D2009FDF38E6B2C044533AF /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListReloadDataUpdater.m; path = Source/IGListReloadDataUpdater.m; sourceTree = "<group>"; };
-		36E67F21E86A610819B6CA1E18795F40 /* IGListWorkingRangeDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListWorkingRangeDelegate.html; path = docs/Protocols/IGListWorkingRangeDelegate.html; sourceTree = "<group>"; };
-		370B9601EB583565F97117E9BC072ED1 /* IGListKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = IGListKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		371F3D6B1997EAA65386CD36258CFDAA /* IGListCollectionViewDelegateLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewDelegateLayout.h; path = Source/IGListCollectionViewDelegateLayout.h; sourceTree = "<group>"; };
-		37BEAFA0459AAB1874E601F51BC110D1 /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
-		380947FA77199189124E703DC1C0CF75 /* vision.html */ = {isa = PBXFileReference; includeInIndex = 1; name = vision.html; path = docs/vision.html; sourceTree = "<group>"; };
-		3882A6E3B7945735D6D90090096760E7 /* IGListReloadIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadIndexPath.h; sourceTree = "<group>"; };
-		389848B46317660EF32A43516ECCCA03 /* IGListCollectionScrollingTraits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionScrollingTraits.h; path = Source/IGListCollectionScrollingTraits.h; sourceTree = "<group>"; };
-		3954471B291B5095C6676EC5FBA2A8B9 /* IGListBindingSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionController.h; path = Source/IGListBindingSectionController.h; sourceTree = "<group>"; };
-		3AA060DDCDAA5270488259126A847E6E /* best-practices-and-faq.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "best-practices-and-faq.html"; path = "docs/best-practices-and-faq.html"; sourceTree = "<group>"; };
-		3B377708F6EE994BC1010B6BD38A3886 /* IGListAdapter+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+DebugDescription.h"; sourceTree = "<group>"; };
-		3DDEA6E6559142DCD014E5C226253368 /* IGListTransitionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListTransitionDelegate.html; path = docs/Protocols/IGListTransitionDelegate.html; sourceTree = "<group>"; };
-		3EB8531CEB83B8AEC812345FA390180F /* IGListBindable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindable.html; path = docs/Protocols/IGListBindable.html; sourceTree = "<group>"; };
-		3EE5A843C04930DC9339D6AA1082C72C /* IGListAdapter+UICollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+UICollectionView.m"; sourceTree = "<group>"; };
-		3FEFC6C17288EDA681F2DA7AA9931B7C /* UIScrollView+IGListKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+IGListKit.m"; sourceTree = "<group>"; };
-		403CCAEBD2A66F06F9192886315B108B /* IGListCollectionViewLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.html; path = docs/Classes/IGListCollectionViewLayout.html; sourceTree = "<group>"; };
+		2D10370D2A7ACBA4B732EE229BF52FA1 /* IGListBatchUpdateData+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBatchUpdateData+DebugDescription.m"; sourceTree = "<group>"; };
+		2D17F1144C7FADAC5C843161AE4563B3 /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapter.h; path = Source/IGListAdapter.h; sourceTree = "<group>"; };
+		2F2A4059963DF52C6EC18223E51B96C4 /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
+		3302914E2CA9E19D6778CB6C051C1A49 /* IGListScrollDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListScrollDelegate.html; path = docs/Protocols/IGListScrollDelegate.html; sourceTree = "<group>"; };
+		3365241B64D1A5B0CC65B5942328C88D /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
+		34B6D9A34471548301BDB3993FA9528F /* IGListSingleSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionController.html; path = docs/Classes/IGListSingleSectionController.html; sourceTree = "<group>"; };
+		351B73556627AFF478B894B1B0B8334E /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; name = search.json; path = docs/search.json; sourceTree = "<group>"; };
+		3791CC242750A8F4B0C14A469468BDBF /* generating-your-models.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "generating-your-models.html"; path = "docs/generating-your-models.html"; sourceTree = "<group>"; };
+		395BB0B42D829322A7AF0C44A9063062 /* IGListAdapter.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapter.html; path = docs/Classes/IGListAdapter.html; sourceTree = "<group>"; };
+		3B9384CB37292879DF0B7EF59807FB68 /* Classes.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Classes.html; path = docs/Classes.html; sourceTree = "<group>"; };
+		3E124A5D40B16D8B177697C053F6CC2B /* IGListSectionMap+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListSectionMap+DebugDescription.h"; sourceTree = "<group>"; };
+		3ED072E8B6EF370BD02525AC0C66DF5D /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
+		3F1B2DF23B5B4F797C037C61F75F104D /* working-with-core-data.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-core-data.html"; path = "docs/working-with-core-data.html"; sourceTree = "<group>"; };
+		3F2A430DE0506907558C17D55F9C4708 /* IGListBatchUpdateData+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBatchUpdateData+DebugDescription.h"; sourceTree = "<group>"; };
+		3F417F895C267FC58F619284C73E15D4 /* IGListIndexSetResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexSetResult.html; path = docs/Classes/IGListIndexSetResult.html; sourceTree = "<group>"; };
+		3FC2F856D00467B0D1788FFE6149787B /* IGListAdapterUpdater+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapterUpdater+DebugDescription.m"; sourceTree = "<group>"; };
+		409B74D2D8B125E57D47D5BAFF83AEE2 /* IGListStackedSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListStackedSectionController.html; path = docs/Classes/IGListStackedSectionController.html; sourceTree = "<group>"; };
 		40CB39E715FBCDAA142E6513E126200A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		420B83CB934E78E8B8A75F7C8AA173F4 /* IGListBatchUpdateState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateState.h; sourceTree = "<group>"; };
+		41006E0540A00C0AA37FF6E8488171D3 /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
 		4226AB171A6B2A3D19639487FDB961B7 /* Pods-IGListKitMessageExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitMessageExample-acknowledgements.markdown"; sourceTree = "<group>"; };
-		42D4500DB4DC33B1253A4883F8411E64 /* IGListDebugger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebugger.h; sourceTree = "<group>"; };
-		43727BA21BE0954130910417C151DA7C /* IGListSingleSectionControllerDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionControllerDelegate.html; path = docs/Protocols/IGListSingleSectionControllerDelegate.html; sourceTree = "<group>"; };
-		440E3FF7AC26E6111E65519935642573 /* IGListBindingSectionControllerSelectionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerSelectionDelegate.h; path = Source/IGListBindingSectionControllerSelectionDelegate.h; sourceTree = "<group>"; };
-		472224FBB7A3B56A05FC530CB0167EF2 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
-		4A16647937945685F1D9E31020CB7B63 /* migration.html */ = {isa = PBXFileReference; includeInIndex = 1; name = migration.html; path = docs/migration.html; sourceTree = "<group>"; };
-		4EDC7D950B56ABC34AC29691AA21774D /* IGListMoveIndex.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndex.html; path = docs/Classes/IGListMoveIndex.html; sourceTree = "<group>"; };
-		4F48717FE518B8DE09365412671B917A /* IGListGenericSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListGenericSectionController.m; path = Source/IGListGenericSectionController.m; sourceTree = "<group>"; };
-		4F793EC4F27EB18E43481C8411FA2729 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSectionController.m; path = Source/IGListSectionController.m; sourceTree = "<group>"; };
+		42D9B0C949975C67157B981125D5A87E /* getting-started.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "getting-started.html"; path = "docs/getting-started.html"; sourceTree = "<group>"; };
+		4325D4F044E926B1FA04C7627F239E82 /* IGListBindingSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionController.h; path = Source/IGListBindingSectionController.h; sourceTree = "<group>"; };
+		441D39CA85B2D166D8B80F8A56F7C8BA /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdaterDelegate.h; path = Source/IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
+		44C8F823D204055646A63EE044B5656D /* IGListKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListKit-dummy.m"; sourceTree = "<group>"; };
+		467AFE05CB3A1F8DA52EB49487AC6AD7 /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/img/carat.png; sourceTree = "<group>"; };
+		46EA5FAFA4C1C031D2CBEECD2A50FE34 /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
+		490E2370BB09C802D69D5E62060F5CB9 /* IGListSingleSectionControllerDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionControllerDelegate.html; path = docs/Protocols/IGListSingleSectionControllerDelegate.html; sourceTree = "<group>"; };
+		4A012974BA15CE66B6582B2C7FD68665 /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.mm; path = Source/IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
+		4B35F8F140F5687C2CBB2B18E492F0CC /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
+		4E95D758C8E7D7F9D1B5C6AC9AEF00F4 /* IGListAdapterMoveDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterMoveDelegate.html; path = docs/Protocols/IGListAdapterMoveDelegate.html; sourceTree = "<group>"; };
+		4FDB300A5525F994AC561F71C5D828D8 /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
+		5019AEFA6A4686D98190A81B26242344 /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jquery.min.js; path = docs/js/jquery.min.js; sourceTree = "<group>"; };
+		50331FD388EB8F1FE1E20A4BB4E1220D /* IGListBindingSectionControllerDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerDataSource.html; path = docs/Protocols/IGListBindingSectionControllerDataSource.html; sourceTree = "<group>"; };
 		523654D67C41985094E1A2FF2FF8566C /* Pods-IGListKitMessageExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitMessageExample-dummy.m"; sourceTree = "<group>"; };
 		52DB07457D8D45C52857436B70A7BD64 /* Pods-IGListKitTodayExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitTodayExample.release.xcconfig"; sourceTree = "<group>"; };
-		5436E630F35AEB6EEA0604E60680261D /* IGListBindingSectionControllerSelectionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerSelectionDelegate.html; path = docs/Protocols/IGListBindingSectionControllerSelectionDelegate.html; sourceTree = "<group>"; };
-		593AB20FE2F62DCCF55CC8C621A87A13 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListScrollDelegate.h; path = Source/IGListScrollDelegate.h; sourceTree = "<group>"; };
+		55C4C0A2D93C9CF65908D7E7EC1D339A /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
+		560C673AF5C711F3689CEE41244B364D /* Type Definitions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "Type Definitions.html"; path = "docs/Type Definitions.html"; sourceTree = "<group>"; };
+		5648C76FD3F37647CA0368C4CB65FE49 /* IGListKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IGListKit.xcconfig; sourceTree = "<group>"; };
+		5653B6F57FD69B70F0280EE456DE9B71 /* UICollectionViewLayout+InteractiveReordering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionViewLayout+InteractiveReordering.h"; sourceTree = "<group>"; };
+		5973AAAEACF20A24793A9E8BE1E38769 /* LICENSE.md */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE.md; sourceTree = "<group>"; };
+		59B5055F68D6BDDACA5AFA9312F8D462 /* IGListSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSectionController.html; path = docs/Classes/IGListSectionController.html; sourceTree = "<group>"; };
+		59C22462AD117D30DE0A755213954765 /* iglistdiffable-and-equality.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "iglistdiffable-and-equality.html"; path = "docs/iglistdiffable-and-equality.html"; sourceTree = "<group>"; };
 		59FCB1109ABBB22F5B4AFCB3A09E8820 /* Pods-IGListKitMessageExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitMessageExample.release.xcconfig"; sourceTree = "<group>"; };
-		5A03A8B550799920D1B3E989D1335998 /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListUpdatingDelegate.h; path = Source/IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		5A8AF835DC4362F43842DA5E46471231 /* UIScrollView+IGListKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+IGListKit.m"; sourceTree = "<group>"; };
 		5B2A9D84CA0388C9B26C3475B05ADCD2 /* Pods-IGListKitTodayExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitTodayExample.debug.xcconfig"; sourceTree = "<group>"; };
+		5B90C679A42A6521974D50D15EE81A6E /* IGListGenericSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListGenericSectionController.m; path = Source/IGListGenericSectionController.m; sourceTree = "<group>"; };
+		5BE925F92B712604FCE780CA91550C5B /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
 		5C87C061377DD9791EBC94A0E43BE899 /* Pods-IGListKitMessageExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitMessageExample.debug.xcconfig"; sourceTree = "<group>"; };
-		5F5AA1D844489BAA60ADE9B02C921B6D /* IGListBindingSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListBindingSectionController.m; path = Source/IGListBindingSectionController.m; sourceTree = "<group>"; };
-		5F78C2BDDE88CACE848F107C875BD986 /* Functions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Functions.html; path = docs/Functions.html; sourceTree = "<group>"; };
-		61F8D7D92B91C024F2066C168321AA92 /* IGListBindingSectionController+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBindingSectionController+DebugDescription.m"; sourceTree = "<group>"; };
-		62CBBC4894F382BC5AF8D2C38BBA0F32 /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
-		639E982B1958907B824A6568ADD32EF3 /* IGListAdapterDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDataSource.html; path = docs/Protocols/IGListAdapterDataSource.html; sourceTree = "<group>"; };
-		63A47D737C4BD54D40504B4EE5F809E9 /* UICollectionViewLayout+InteractiveReordering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionViewLayout+InteractiveReordering.h"; sourceTree = "<group>"; };
-		64B2C0C25765F7F31D3CA044F2F86C3E /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionContext.h; path = Source/IGListCollectionContext.h; sourceTree = "<group>"; };
-		674E727C976C2FB76C9D4A4689ADE85F /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
-		67832F3519DB4B210CDF5A5860353925 /* IGSystemVersion.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGSystemVersion.m; sourceTree = "<group>"; };
-		67AE8CAAEBAFEE2A970AE7375EEFF9A9 /* IGListBatchUpdateData+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBatchUpdateData+DebugDescription.m"; sourceTree = "<group>"; };
+		5DB15E81008571D85246D9DD43A9C176 /* IGListAdapterMoveDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterMoveDelegate.h; path = Source/IGListAdapterMoveDelegate.h; sourceTree = "<group>"; };
+		5E0846871994F31B9C0A2775DCFF4C86 /* IGListKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = IGListKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		614A557F6569A1145F876B51D590AE61 /* IGListGenericSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListGenericSectionController.h; path = Source/IGListGenericSectionController.h; sourceTree = "<group>"; };
+		62486C1A8C8ABBE1D22AEACA3CE0E675 /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
+		6301C379D70453401D6568EA54FC2CEF /* IGListBatchUpdateData.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchUpdateData.html; path = docs/Classes/IGListBatchUpdateData.html; sourceTree = "<group>"; };
+		64B5714ED21DE4FCCAE13B42FE88EAB4 /* migration.html */ = {isa = PBXFileReference; includeInIndex = 1; name = migration.html; path = docs/migration.html; sourceTree = "<group>"; };
+		64BC4005A78CE1E91774D507CACD1564 /* UICollectionView+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+DebugDescription.m"; sourceTree = "<group>"; };
+		6643BED0640FDC23F264B6E30762B99F /* IGListBindingSectionController+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBindingSectionController+DebugDescription.m"; sourceTree = "<group>"; };
+		66749052BF9812D222F45DA1D65C0AC2 /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
 		68037F304CD34327A2ABDB9CBE2FD6A8 /* IGListKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = IGListKit.framework; path = IGListKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		692D718E1FB846F471F1E238A8073509 /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
-		69937996A99F521B10DD3272B5CCBB0B /* IGSystemVersion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGSystemVersion.h; sourceTree = "<group>"; };
-		6A159BFCD8301C03E679149E499C1E6B /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
-		6E443F767BF22D0CDB1998518D50F4E2 /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/img/dash.png; sourceTree = "<group>"; };
-		6F285B85787EB2EBAA85D53861B22942 /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
-		6F996AC3C81FF26AB9D7C06F73C95F1E /* Type Definitions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "Type Definitions.html"; path = "docs/Type Definitions.html"; sourceTree = "<group>"; };
-		6FDEDAD33401B1C42CC43C96F2328C25 /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
-		6FF6DD132F04866BE8D01F15E7AA656C /* IGListDiffable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffable.html; path = docs/Protocols/IGListDiffable.html; sourceTree = "<group>"; };
+		6B7B482F0D9FC2FBD5EB6A16F9E67C6F /* IGListSectionMap+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListSectionMap+DebugDescription.m"; sourceTree = "<group>"; };
+		6E5527C92FCC72200F4FEC95EAA18AD3 /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionContext.h; path = Source/IGListCollectionContext.h; sourceTree = "<group>"; };
+		6E593D64A5E553F6D8C4C9072A7F02C9 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSingleSectionController.m; path = Source/IGListSingleSectionController.m; sourceTree = "<group>"; };
+		701851857ED864923D686B19C1F130ED /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListDisplayDelegate.h; path = Source/IGListDisplayDelegate.h; sourceTree = "<group>"; };
+		726E9F22C7F35CCABBA5C3DC0F464425 /* IGListAdapterUpdateType.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateType.html; path = docs/Enums/IGListAdapterUpdateType.html; sourceTree = "<group>"; };
+		72813F0A42ABCB57CC7FDDD48D6525CB /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
 		741DB68552400F56D67F824600BEEF64 /* Pods-IGListKitExamples-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitExamples-acknowledgements.markdown"; sourceTree = "<group>"; };
-		74F7FBDA249198E78AD1871D9160C88D /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListCollectionView.m; path = Source/IGListCollectionView.m; sourceTree = "<group>"; };
-		77C12F2A7ABA79BCC15AD7CDDFEBB09F /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		744A5E861F2D9316E0458C3F0408C123 /* IGListKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-umbrella.h"; sourceTree = "<group>"; };
+		74E9D33F9DEBE578466CF8D08D60D3CB /* IGListTransitionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListTransitionDelegate.h; path = Source/IGListTransitionDelegate.h; sourceTree = "<group>"; };
+		75429017957DF51361DBC74F40F2F21A /* IGSystemVersion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGSystemVersion.h; sourceTree = "<group>"; };
+		7593379DF002548C7A41CF74A1316543 /* IGListUpdatingDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListUpdatingDelegate.html; path = docs/Protocols/IGListUpdatingDelegate.html; sourceTree = "<group>"; };
+		76F8DB4CA32E315073C5AF2F5964BDA1 /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
+		77561C468BC2B1F1F01CD942A77A5895 /* IGListBatchContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBatchContext.h; path = Source/IGListBatchContext.h; sourceTree = "<group>"; };
 		78021B5D0B2D31B9A9960D3087C4E08C /* Pods-IGListKitTodayExample-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitTodayExample-Info.plist"; sourceTree = "<group>"; };
-		797A2FE675EBCEBB8A6228FB6E63F28F /* IGListCollectionViewDelegateLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewDelegateLayout.html; path = docs/Protocols/IGListCollectionViewDelegateLayout.html; sourceTree = "<group>"; };
+		7878C27766439441462BD57C3C1E99A7 /* IGListBindable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindable.html; path = docs/Protocols/IGListBindable.html; sourceTree = "<group>"; };
 		79F7125229B543AFB0BE793C65A24084 /* Pods-IGListKitTodayExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitTodayExample-acknowledgements.markdown"; sourceTree = "<group>"; };
 		7B8B8E6F11BAD6BEC0F22843D754D848 /* Pods-IGListKitMessageExample-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitMessageExample-Info.plist"; sourceTree = "<group>"; };
 		7B8E527B1425066B71919F9E92AFF926 /* Pods-IGListKitTodayExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitTodayExample-umbrella.h"; sourceTree = "<group>"; };
-		7B97C6FC6D3C89142CAF905A5E8A9790 /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
-		7DA9982D4A447DCFDEC6BC8373AFD90A /* IGListScrollDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListScrollDelegate.html; path = docs/Protocols/IGListScrollDelegate.html; sourceTree = "<group>"; };
-		7DFD4F2B2D29AB4A18B5120452176853 /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
-		7E0CCC606FB1769C523803BD2F809E7D /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
-		7E87589679047DFEA4C0CF7F76D19965 /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
-		7F59E34855A27D2382355F64059CB3E7 /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/img/carat.png; sourceTree = "<group>"; };
-		7FFB3F2020528EE055DD35388C7D7C87 /* IGListSectionMap+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListSectionMap+DebugDescription.m"; sourceTree = "<group>"; };
-		804AF2931D217E1708961001108574D5 /* IGListExperiment.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListExperiment.html; path = docs/Enums/IGListExperiment.html; sourceTree = "<group>"; };
-		805DD65287244E65D8FE988C5544C264 /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; name = search.json; path = docs/search.json; sourceTree = "<group>"; };
-		8119818F252591E5B1CCD7009B67FC92 /* Enums.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Enums.html; path = docs/Enums.html; sourceTree = "<group>"; };
-		8153098818861F304A24806868095861 /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
+		7DD6C706C7826AADAC31A84BEEB458FC /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; name = highlight.css; path = docs/css/highlight.css; sourceTree = "<group>"; };
+		7EDF72970B37AA776A8291F8928739C0 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
+		7EE4B06CE8B9AD78FC7EA9B08B555F77 /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
+		805DC02CD9DFA67ABACEE7D83C1FBC3E /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
+		80B5F0BFE12986E9CC6F8E23DB5DBAD7 /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
+		811398241EF7EF12BDAF0E2F2257C18E /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
+		81733DEBAC61ED8C226AA787201F4AA6 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
+		82D9B57140A46A523A476A8C988DA6ED /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListScrollDelegate.h; path = Source/IGListScrollDelegate.h; sourceTree = "<group>"; };
+		83ABB67F6B46E509EDD59E671A84C614 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/img/gh.png; sourceTree = "<group>"; };
 		84A2CC04EEE310D61FC6E3D34F9C3BD6 /* Pods_IGListKitTodayExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitTodayExample.framework; path = "Pods-IGListKitTodayExample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		867C7513C719378D50D129144163DF43 /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.css; path = docs/css/jazzy.css; sourceTree = "<group>"; };
-		8696286ED5A79E4AF1AFA2D44920C90B /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
-		8794F31CBD1686730DEA031E7727054A /* IGListMoveIndexPath.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndexPath.html; path = docs/Classes/IGListMoveIndexPath.html; sourceTree = "<group>"; };
-		87D08C9EFF4873483EC004BA363EE0C3 /* IGListIndexPathResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexPathResult.html; path = docs/Classes/IGListIndexPathResult.html; sourceTree = "<group>"; };
-		87D90284ADC918AE3C5A00FB90A38707 /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapterUpdater.m; path = Source/IGListAdapterUpdater.m; sourceTree = "<group>"; };
-		89C7396F7915F4497DFFBCB46D1B33B1 /* IGListBatchContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBatchContext.h; path = Source/IGListBatchContext.h; sourceTree = "<group>"; };
-		8A886B504C19BA83BB5179DFA3C7074B /* UICollectionViewLayout+InteractiveReordering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionViewLayout+InteractiveReordering.m"; sourceTree = "<group>"; };
-		8A9F5E70A8B4308AB52FC695A00EE707 /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
-		8AC78C46C87E838A6509F554738EB8EE /* IGListBindable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindable.h; path = Source/IGListBindable.h; sourceTree = "<group>"; };
+		854ECCEE735014C5D9C30E8105C10E94 /* IGListAdapter+UICollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+UICollectionView.h"; sourceTree = "<group>"; };
+		876ACA760F9A1500014557081A588CF2 /* IGListBindingSectionController+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBindingSectionController+DebugDescription.h"; sourceTree = "<group>"; };
+		878AF2F118E2CCA640970F33A07C73B8 /* IGListDebuggingUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebuggingUtilities.h; sourceTree = "<group>"; };
+		8AA8A1C3856DE7F7B8E4E2E34C682509 /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListReloadDataUpdater.h; path = Source/IGListReloadDataUpdater.h; sourceTree = "<group>"; };
+		8BEEA4D1495834AD797B585E28AB2B43 /* IGListWorkingRangeDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListWorkingRangeDelegate.html; path = docs/Protocols/IGListWorkingRangeDelegate.html; sourceTree = "<group>"; };
 		8C40D77B01771F4097EE288B1C63C084 /* Pods-IGListKitTodayExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-IGListKitTodayExample.modulemap"; sourceTree = "<group>"; };
-		8CC3824F2A3EC593EF4B54B9EC914FC1 /* IGListBindingSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionController.html; path = docs/Classes/IGListBindingSectionController.html; sourceTree = "<group>"; };
-		8D3F2B108AFE983D69E84996ED566057 /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdater.h; path = Source/IGListAdapterUpdater.h; sourceTree = "<group>"; };
-		8DFE07B690FEFECB7A8F905715E66254 /* IGListAdapterUpdateType.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateType.html; path = docs/Enums/IGListAdapterUpdateType.html; sourceTree = "<group>"; };
-		9019EE7B092696DF05B3BDC321A07833 /* Guides.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Guides.html; path = docs/Guides.html; sourceTree = "<group>"; };
-		90DA75A42732723728B7EC12D9DAAAF9 /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
-		92D47D16C4CFAE67F015643F7510C084 /* IGListBatchContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchContext.html; path = docs/Protocols/IGListBatchContext.html; sourceTree = "<group>"; };
-		92F335A785084C07099C58BC3A93E574 /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
-		92F4552DDE17BE53E61F1886DCDE7B70 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
+		8E12F60BE657ECDC2B431C6BE8096001 /* IGSystemVersion.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGSystemVersion.m; sourceTree = "<group>"; };
+		8F9E145973E0C159BF76941D9009E3B4 /* IGListCollectionScrollingTraits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionScrollingTraits.h; path = Source/IGListCollectionScrollingTraits.h; sourceTree = "<group>"; };
+		8FD448F150946AEA5A8F422D15207E40 /* IGListMoveIndexPath.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndexPath.html; path = docs/Classes/IGListMoveIndexPath.html; sourceTree = "<group>"; };
+		91769718316CC21FE82BBDC422AEA87B /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
 		951BA6529143AFD5DF9813FE4E535C3B /* Pods-IGListKitExamples-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitExamples-acknowledgements.plist"; sourceTree = "<group>"; };
-		9612085D18B7AF158EBEDF462F481763 /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListDisplayDelegate.h; path = Source/IGListDisplayDelegate.h; sourceTree = "<group>"; };
-		970A241B1B809D2A10F86A7127FD5581 /* IGListStackedSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListStackedSectionController.m; path = Source/IGListStackedSectionController.m; sourceTree = "<group>"; };
-		98D31AD0C93848779245330326E657A4 /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdaterDelegate.h; path = Source/IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
-		9B0687400523ED7A1194B47E87FB9526 /* IGListReloadIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadIndexPath.m; sourceTree = "<group>"; };
-		9B82F9610386A9EFA9762299B844AF90 /* IGListBatchUpdateData+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBatchUpdateData+DebugDescription.h"; sourceTree = "<group>"; };
-		9D30D598272340D656FE6EA38F0B7B7E /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayout.h; path = Source/IGListCollectionViewLayout.h; sourceTree = "<group>"; };
+		96C35CD69BD0F69865F1E4DDE236074A /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.css; path = docs/css/jazzy.css; sourceTree = "<group>"; };
+		9752CAC78ECDDAD7EBC30468E07B3675 /* IGListAdapter+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+DebugDescription.h"; sourceTree = "<group>"; };
+		97C2B26F441E28E533217E3C03697616 /* IGListAdapterDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDataSource.html; path = docs/Protocols/IGListAdapterDataSource.html; sourceTree = "<group>"; };
+		98173EEA7D8C33730B1F33BE63C9AA09 /* IGListAdapterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDelegate.html; path = docs/Protocols/IGListAdapterDelegate.html; sourceTree = "<group>"; };
+		993C1BC004AC4BC65B9A3B052E39F9E0 /* IGListAdapter+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+DebugDescription.m"; sourceTree = "<group>"; };
+		9A3C79F564AA50DDB644338C95A6DC5A /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
+		9B119D3CD073B6AA1D33D5C80E926EC8 /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9EF1992B9850A9877FA806094D9AB0FE /* working-with-uicollectionview.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-uicollectionview.html"; path = "docs/working-with-uicollectionview.html"; sourceTree = "<group>"; };
+		9E3327FB501A44D2B9DF8AA2FBDFF7F6 /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
+		A1F08F237941A456565584EC6342BD28 /* IGListReloadIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadIndexPath.m; sourceTree = "<group>"; };
 		A1FC80B7115766B99265EF7C3D5C33A8 /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
-		A20E8B1E857182C050621491326DEC24 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSingleSectionController.m; path = Source/IGListSingleSectionController.m; sourceTree = "<group>"; };
-		A273F1EDF2D368DFE57EB7B6C2CAA4F7 /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
-		A5D764AD481EBE76DA25BF5BB4C7AD0D /* IGListCollectionContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionContext.html; path = docs/Protocols/IGListCollectionContext.html; sourceTree = "<group>"; };
-		A6A7903FB9DFBA3BA30EF026FCC2DF9D /* IGListIndexSetResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexSetResult.html; path = docs/Classes/IGListIndexSetResult.html; sourceTree = "<group>"; };
-		AB62E1C6DA9E14B68122D3D4DB6E968B /* Protocols.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Protocols.html; path = docs/Protocols.html; sourceTree = "<group>"; };
-		AB796D0CAB4048AF7FC98EBBF4917723 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/img/gh.png; sourceTree = "<group>"; };
-		AC900FECC58A646F4B1790A8457854CC /* IGListBatchUpdateData.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchUpdateData.html; path = docs/Classes/IGListBatchUpdateData.html; sourceTree = "<group>"; };
-		B542DB33EAAFB9AFC94CAC082FED0286 /* IGListUpdatingDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListUpdatingDelegate.html; path = docs/Protocols/IGListUpdatingDelegate.html; sourceTree = "<group>"; };
-		B56084A88F0BC291A6880E34E328C7BC /* IGListDisplayDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDisplayDelegate.html; path = docs/Protocols/IGListDisplayDelegate.html; sourceTree = "<group>"; };
+		A2B2882030226183EA50205324149F52 /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; name = index.html; path = docs/index.html; sourceTree = "<group>"; };
+		A313396A1949030A4D6F748F4BF86A9A /* IGListCollectionContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionContext.html; path = docs/Protocols/IGListCollectionContext.html; sourceTree = "<group>"; };
+		A33E8B1DA72B5B88794B3F3F1DCF7328 /* IGListCollectionViewLayoutInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayoutInternal.h; sourceTree = "<group>"; };
+		A6795F66FBAB470CE23EDA7241825D05 /* UIScrollView+IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+IGListKit.h"; sourceTree = "<group>"; };
+		A7EDF4CB9612A8A0FE0972862063E753 /* Constants.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Constants.html; path = docs/Constants.html; sourceTree = "<group>"; };
+		A9A2515017382C1E17D3F0226CE017BB /* modeling-and-binding.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "modeling-and-binding.html"; path = "docs/modeling-and-binding.html"; sourceTree = "<group>"; };
+		AA5B59B126584D9FBFB4B2225A442960 /* installation.html */ = {isa = PBXFileReference; includeInIndex = 1; name = installation.html; path = docs/installation.html; sourceTree = "<group>"; };
+		AE45701181220FC066F21669CDC35EED /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSingleSectionController.h; path = Source/IGListSingleSectionController.h; sourceTree = "<group>"; };
+		B15BD5FCD0BE86A85B7522C2F3F9201A /* badge.svg */ = {isa = PBXFileReference; includeInIndex = 1; name = badge.svg; path = docs/badge.svg; sourceTree = "<group>"; };
+		B251F53F7135E93A7A3FE4ACDE0E6E6C /* IGListBatchUpdates.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdates.h; sourceTree = "<group>"; };
+		B2C630024D74FDC76E0009BFD6FDF427 /* IGListSupplementaryViewSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSupplementaryViewSource.html; path = docs/Protocols/IGListSupplementaryViewSource.html; sourceTree = "<group>"; };
+		B2D6949DF6B5D2CC431EDDDF11918FFD /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
+		B2E92037D172FBA797EC96E20D2F748E /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSectionController.h; path = Source/IGListSectionController.h; sourceTree = "<group>"; };
+		B33C79CC157FEA65CBDDFBB8751AB38C /* IGListBindingSectionControllerSelectionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerSelectionDelegate.h; path = Source/IGListBindingSectionControllerSelectionDelegate.h; sourceTree = "<group>"; };
+		B403368AE910AE7650DCDD8E6656F872 /* IGListDiffOption.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffOption.html; path = docs/Enums/IGListDiffOption.html; sourceTree = "<group>"; };
+		B63E0E9A01385088DC950A9958EBDB03 /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
+		B79957879200DD8A6E97B1206EC58C0E /* Guides.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Guides.html; path = docs/Guides.html; sourceTree = "<group>"; };
 		B845FC43DEE845CB174C686B3498240D /* Pods-IGListKitMessageExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitMessageExample-acknowledgements.plist"; sourceTree = "<group>"; };
-		B90310BFDEB792C0693CC5ADB8B59E3A /* IGListKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "IGListKit-Info.plist"; sourceTree = "<group>"; };
-		B9299B332C7D9358DD8BDAF68049CED2 /* Constants.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Constants.html; path = docs/Constants.html; sourceTree = "<group>"; };
+		B9E43982239A67489C2488B574521620 /* IGListIndexPathResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexPathResult.html; path = docs/Classes/IGListIndexPathResult.html; sourceTree = "<group>"; };
+		BAD2E8CDCA43740CC5C6A0AA76BFF324 /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListWorkingRangeDelegate.h; path = Source/IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
 		BBEA5A4553C9BE16813DB47818485E2E /* Pods-IGListKitExamples-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitExamples-Info.plist"; sourceTree = "<group>"; };
-		BE726AF43888DF0C7F7C1D8C6866E3B9 /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
+		BBF89AEC1335E8560EBD7A889AC1BD80 /* vision.html */ = {isa = PBXFileReference; includeInIndex = 1; name = vision.html; path = docs/vision.html; sourceTree = "<group>"; };
+		BEF2D5AF7527A2EEA2CB61D3B93318E9 /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
+		BF5745ADA8B8D456D74C9AA282FAFDA1 /* IGListMoveIndex.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndex.html; path = docs/Classes/IGListMoveIndex.html; sourceTree = "<group>"; };
 		BFBAFA87E33B9C739D564E3052DC419E /* Pods-IGListKitExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		C0525529DA2B84B1F3CD5C39968556C7 /* IGListKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListKit-dummy.m"; sourceTree = "<group>"; };
+		C0E08CEACF3457FD3AE697E20C9C78ED /* IGListAdapterUpdater.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdater.html; path = docs/Classes/IGListAdapterUpdater.html; sourceTree = "<group>"; };
 		C1676DC9B2B58BB164B5770AE4A1AA3B /* Pods-IGListKitMessageExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-IGListKitMessageExample.modulemap"; sourceTree = "<group>"; };
-		C1A99101B7FD0FB345799178314AE0CB /* IGListKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-prefix.pch"; sourceTree = "<group>"; };
-		C1DE4721BE340A6DDF89DBEA95046820 /* IGListAdapter.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapter.html; path = docs/Classes/IGListAdapter.html; sourceTree = "<group>"; };
-		C2267D810839A15755F5E28197B069E3 /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
+		C1ED33F61FEC5AAAF032B8C0F5574ABB /* IGListAdapterUpdater+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapterUpdater+DebugDescription.h"; sourceTree = "<group>"; };
 		C29A09B219DE2EED9EDF0036A53C3A32 /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitExamples.framework; path = "Pods-IGListKitExamples.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C332230FF765F424C3F1AD6F27D82474 /* IGListSupplementaryViewSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSupplementaryViewSource.html; path = docs/Protocols/IGListSupplementaryViewSource.html; sourceTree = "<group>"; };
-		C3E48B6C09DB4B87AB8F2523A79B1D6B /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapter.m; path = Source/IGListAdapter.m; sourceTree = "<group>"; };
-		C420FE671C4EFB6345F7882E71E5E4DA /* IGListAdapterMoveDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterMoveDelegate.h; path = Source/IGListAdapterMoveDelegate.h; sourceTree = "<group>"; };
-		C7C6F0859B45281DE2F20F302A29ED68 /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
-		C7F3DDBC4E623739466845B9A9F0FE8C /* IGListAdapterPerformanceDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterPerformanceDelegate.h; path = Source/IGListAdapterPerformanceDelegate.h; sourceTree = "<group>"; };
-		C9012F307058EE4ABCF2B2FB5D3574DC /* IGListAdapterUpdater.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdater.html; path = docs/Classes/IGListAdapterUpdater.html; sourceTree = "<group>"; };
-		CA37B2EEC914A0785E29D2047C0FD1E9 /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSingleSectionController.h; path = Source/IGListSingleSectionController.h; sourceTree = "<group>"; };
-		CE3008F480B4309F09B0259B66C07597 /* modeling-and-binding.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "modeling-and-binding.html"; path = "docs/modeling-and-binding.html"; sourceTree = "<group>"; };
-		CE77CFD6A72590901219325F80A7D9B7 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
-		CF28E4393C715BB0FC81A5CFB00D6ACD /* IGListStackedSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionControllerInternal.h; sourceTree = "<group>"; };
-		CFDC84B590BEDD3F0CDC316945839372 /* working-with-core-data.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-core-data.html"; path = "docs/working-with-core-data.html"; sourceTree = "<group>"; };
-		CFF408C087E56123D872C50FCFA40AFA /* IGListCollectionViewLayoutCompatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayoutCompatible.h; path = Source/IGListCollectionViewLayoutCompatible.h; sourceTree = "<group>"; };
-		D14D732D3CEBF3AA264AA1B8148B1BDF /* badge.svg */ = {isa = PBXFileReference; includeInIndex = 1; name = badge.svg; path = docs/badge.svg; sourceTree = "<group>"; };
-		D1506F96A7CBC596094F7B2A33ACD435 /* IGListSectionMap+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListSectionMap+DebugDescription.h"; sourceTree = "<group>"; };
-		D1C74FFB6B4579E2C45F3AB95BC283C3 /* IGListDebuggingUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebuggingUtilities.m; sourceTree = "<group>"; };
-		D33ECCD2445C78902BF2608067222F91 /* IGListSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSectionController.html; path = docs/Classes/IGListSectionController.html; sourceTree = "<group>"; };
+		C2C98958388A5D10B6A6F8653FC324C8 /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapter.m; path = Source/IGListAdapter.m; sourceTree = "<group>"; };
+		C46720A53A5175FFF5858F9184B0B377 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
+		C52D3728817A5D029C6DB61E4DA9FBD8 /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
+		C536C62EC1F5CCE91F3BCDF37C9C347E /* IGListCollectionViewDelegateLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewDelegateLayout.h; path = Source/IGListCollectionViewDelegateLayout.h; sourceTree = "<group>"; };
+		C5F187AC8488CF9E490F2C4200CFA292 /* IGListBatchUpdateState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateState.h; sourceTree = "<group>"; };
+		C6E4FC2BCE1CEA686E09FB1DE6AF1D1F /* Enums.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Enums.html; path = docs/Enums.html; sourceTree = "<group>"; };
+		C7DD0A25CCB7775738D04DD0553DE010 /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListReloadDataUpdater.m; path = Source/IGListReloadDataUpdater.m; sourceTree = "<group>"; };
+		C807FA89C7533AA66C5F09CA80356D9F /* IGListExperiment.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListExperiment.html; path = docs/Enums/IGListExperiment.html; sourceTree = "<group>"; };
+		C88734A4CEB37D3DEE450C9DB8633296 /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSupplementaryViewSource.h; path = Source/IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
+		CB1316BC6A395B155E1F497445AC8112 /* IGListCollectionView.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionView.html; path = docs/Classes/IGListCollectionView.html; sourceTree = "<group>"; };
+		CBD7DB84695BF777CC376FE0B4C6E0DC /* IGListAdapterUpdateListener.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdateListener.h; path = Source/IGListAdapterUpdateListener.h; sourceTree = "<group>"; };
+		CC11094D70EBA0125ADB725C5814E8BD /* IGListKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-prefix.pch"; sourceTree = "<group>"; };
+		D0AEC9D3C7F018C772C2994836AD3555 /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
+		D0C4A37D30725BCC1CBD2795A7E79BFB /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayout.h; path = Source/IGListCollectionViewLayout.h; sourceTree = "<group>"; };
+		D0CA665052C5446A2BB26EE0066DC427 /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		D16B36F2C78B68C15C9B30BC770265D4 /* IGListDebugger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebugger.m; sourceTree = "<group>"; };
+		D187C0E5DB27F1AE8701ED1644D57506 /* IGListCollectionViewLayoutCompatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayoutCompatible.h; path = Source/IGListCollectionViewLayoutCompatible.h; sourceTree = "<group>"; };
+		D3B50C9C20677607D48A07C2E38E5F34 /* IGListDebuggingUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebuggingUtilities.m; sourceTree = "<group>"; };
 		D77D965BFCDDDD13E3099D899B536201 /* Pods-IGListKitTodayExample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitTodayExample-dummy.m"; sourceTree = "<group>"; };
 		D7A363B477B31B91C9136FCAC2A9FA9B /* Pods-IGListKitExamples-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitExamples-umbrella.h"; sourceTree = "<group>"; };
-		D952A047D5FB197406B63B5ADA927302 /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
-		DA546B8ADF45E9C49AE21793AF908FC2 /* IGListBindingSectionControllerDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerDataSource.h; path = Source/IGListBindingSectionControllerDataSource.h; sourceTree = "<group>"; };
-		DB617B3AD6B0D099C0066F294361AC40 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.js; path = docs/js/jazzy.js; sourceTree = "<group>"; };
-		DBE0909C45B4B4F12E2F68766E666043 /* IGListArrayUtilsInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListArrayUtilsInternal.h; sourceTree = "<group>"; };
+		DA952D32E01044CED53295436E89D88B /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
+		DC61EFBCDE4460EE8D51971199FE4C4A /* IGListBatchUpdates.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListBatchUpdates.m; sourceTree = "<group>"; };
 		DD11FA4F4D747228292F39CDD7808F85 /* Pods-IGListKitMessageExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitMessageExample-umbrella.h"; sourceTree = "<group>"; };
-		DE9BBF67B3ADDABCF919D37C121CF8C3 /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSupplementaryViewSource.h; path = Source/IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
 		DED9369B12236529C64756DDD159A5FB /* Pods-IGListKitExamples-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitExamples-dummy.m"; sourceTree = "<group>"; };
-		E09C30D85E9DDEB527C77C9AFE8D6B76 /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
-		E238DB9C7E52E19405D95073716D8357 /* IGListAdapterUpdaterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdaterDelegate.html; path = docs/Protocols/IGListAdapterUpdaterDelegate.html; sourceTree = "<group>"; };
-		E309AE66E886B34FA6C73F9729951CA5 /* IGListBatchUpdates.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListBatchUpdates.m; sourceTree = "<group>"; };
-		E45EDD691FF311B8A3B3DA94C707AAF0 /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
-		E5C0CB8E49DF4232A3CF7156C6511BB7 /* IGListAdapterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDelegate.html; path = docs/Protocols/IGListAdapterDelegate.html; sourceTree = "<group>"; };
-		E67111D8D93D71589496E6771FE543AE /* Classes.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Classes.html; path = docs/Classes.html; sourceTree = "<group>"; };
-		E833589E26237AA174C0E9EA6465FEB3 /* IGListAdapterUpdater+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapterUpdater+DebugDescription.m"; sourceTree = "<group>"; };
-		E9372831718C06100C6AFA0397DFDBC9 /* IGListCollectionView.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionView.html; path = docs/Classes/IGListCollectionView.html; sourceTree = "<group>"; };
-		E9D67F2AF1177C61845A3BBEE77A5D38 /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
-		EA5F1CAD4062FDA7678FCEA53EACE33D /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
-		EBDE258CA74FF5078A77584C74EDBDC2 /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; name = index.html; path = docs/index.html; sourceTree = "<group>"; };
-		ECB918404917AD4FDCBAA810A7DFF624 /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
+		DF0888A9BC07FFD5D749A3503B7425C9 /* IGListBindingSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionController.html; path = docs/Classes/IGListBindingSectionController.html; sourceTree = "<group>"; };
+		DF0974E1FC25B9A25FFCE4C76A54DCBE /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
+		DF0E1BA43692A529F41C26BE0C278EFF /* IGListBindingSectionControllerSelectionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerSelectionDelegate.html; path = docs/Protocols/IGListBindingSectionControllerSelectionDelegate.html; sourceTree = "<group>"; };
+		E12138C62489CFAF670C584626B6A8CF /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDelegate.h; path = Source/IGListAdapterDelegate.h; sourceTree = "<group>"; };
+		E50F213F33008C31CFB8F78A5F46D893 /* IGListCollectionViewDelegateLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewDelegateLayout.html; path = docs/Protocols/IGListCollectionViewDelegateLayout.html; sourceTree = "<group>"; };
+		E8AAD1FA644F47540FEE5E2DE2C2C009 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.js; path = docs/js/jazzy.js; sourceTree = "<group>"; };
+		E9C97D5A25B37D88574660E311BBF291 /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListKit.h; path = Source/IGListKit.h; sourceTree = "<group>"; };
+		EAF37BDA9B692B58A75658B98B04D7F2 /* IGListDisplayDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDisplayDelegate.html; path = docs/Protocols/IGListDisplayDelegate.html; sourceTree = "<group>"; };
+		EBB996C88B4D76F0A2A3F0E0D3F6EA5E /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
 		ECF2A2B0720AE923C22BED3192888BE0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		EDBA59A2AA390CCA5E5597773A48DD51 /* IGListGenericSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListGenericSectionController.html; path = docs/Classes/IGListGenericSectionController.html; sourceTree = "<group>"; };
-		EDD27A8476E8722E951B2DA4445E7A2F /* UICollectionView+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+DebugDescription.m"; sourceTree = "<group>"; };
-		EDDBBEDD1758F2A7AF127E049902C46A /* generating-your-models.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "generating-your-models.html"; path = "docs/generating-your-models.html"; sourceTree = "<group>"; };
-		F1B830E3D3F859A4D05A6EC4B93431F4 /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
-		F3B589E41CFF0D2CFCEC848E2A5D5BAC /* IGListTransitionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListTransitionDelegate.h; path = Source/IGListTransitionDelegate.h; sourceTree = "<group>"; };
-		F96F6A0856664D181DD81B5EF2A48172 /* IGListCollectionViewLayoutInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayoutInternal.h; sourceTree = "<group>"; };
+		EFF7CC987D1C5138F502D14214368771 /* IGListBindingSectionControllerDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerDataSource.h; path = Source/IGListBindingSectionControllerDataSource.h; sourceTree = "<group>"; };
+		F0949488A81E86CFA1CD1B92CE084E42 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
+		F20B6A958066540F4B5523C3E48B9F12 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSectionController.m; path = Source/IGListSectionController.m; sourceTree = "<group>"; };
+		F3739218A19D5E056E29E85AFAB750D8 /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListUpdatingDelegate.h; path = Source/IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		F5EC716FD2106CEA5A413425306D3050 /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
+		F6F632BA2C517D3BC6CBF4433D61E094 /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdater.h; path = Source/IGListAdapterUpdater.h; sourceTree = "<group>"; };
+		F8148402E66986003F6673D9E412A99C /* IGListBindable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindable.h; path = Source/IGListBindable.h; sourceTree = "<group>"; };
+		F81ADB79D91726B72485F4EB07189680 /* best-practices-and-faq.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "best-practices-and-faq.html"; path = "docs/best-practices-and-faq.html"; sourceTree = "<group>"; };
+		F9096A156E32C6DDE6F4897C0A69871C /* IGListArrayUtilsInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListArrayUtilsInternal.h; sourceTree = "<group>"; };
 		F9E36173A6C879C3E3E834CBEAB85609 /* Pods-IGListKitTodayExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitTodayExample-acknowledgements.plist"; sourceTree = "<group>"; };
-		FAFEDA48F1A640BC56553F6BE4447058 /* getting-started.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "getting-started.html"; path = "docs/getting-started.html"; sourceTree = "<group>"; };
-		FB6422637E1B4DC6603EC538CA47F177 /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapter.h; path = Source/IGListAdapter.h; sourceTree = "<group>"; };
-		FBE985E43CE368AA737BFE297FFFF930 /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListReloadDataUpdater.h; path = Source/IGListReloadDataUpdater.h; sourceTree = "<group>"; };
-		FC796A62B892E50A529ACDCC7667F086 /* UIScrollView+IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+IGListKit.h"; sourceTree = "<group>"; };
-		FDF5D9B5791BC8D09BF19CAE1F9006D8 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
-		FE65F47FFB5E1C128EEA82FE06EB9247 /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; name = highlight.css; path = docs/css/highlight.css; sourceTree = "<group>"; };
-		FF5339A45BE6C21D683BDA9ED79DCE06 /* IGListDiffOption.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffOption.html; path = docs/Enums/IGListDiffOption.html; sourceTree = "<group>"; };
+		FAD9792F950A1182316E1A99C9F72342 /* IGListGenericSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListGenericSectionController.html; path = docs/Classes/IGListGenericSectionController.html; sourceTree = "<group>"; };
+		FBD424E50E3FDAA66D2D09EACF0E498F /* IGListReloadIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadIndexPath.h; sourceTree = "<group>"; };
+		FFC642AB792B9AE3319E13ECEBD88B4D /* undocumented.json */ = {isa = PBXFileReference; includeInIndex = 1; name = undocumented.json; path = docs/undocumented.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -403,29 +397,90 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C780C0D7293D61AF9802BB06C18CDFAF /* Frameworks */ = {
+		F30BF0A691E2CFCE72F8CA3B4519B95E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26EA0A48BB89E5440059AECCEB46A14F /* Foundation.framework in Frameworks */,
-				5DBA9B53681CF227C9411BCA2020BD6E /* UIKit.framework in Frameworks */,
+				F4E4600D6EDFF3B1A79E23ECEA796186 /* Foundation.framework in Frameworks */,
+				F9F8DAB415C72F2ACE0C77FCF6A891B7 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		12DEC4618E3744346F019A43B40C005A /* Internal */ = {
+		1129A39009AFD6118B71B7316A7F8084 /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				DBE0909C45B4B4F12E2F68766E666043 /* IGListArrayUtilsInternal.h */,
-				0F2D8C2174EEB190F934FE496A7DFFBD /* IGListIndexPathResultInternal.h */,
-				8153098818861F304A24806868095861 /* IGListIndexSetResultInternal.h */,
-				472224FBB7A3B56A05FC530CB0167EF2 /* IGListMoveIndexInternal.h */,
-				EA5F1CAD4062FDA7678FCEA53EACE33D /* IGListMoveIndexPathInternal.h */,
+				B15BD5FCD0BE86A85B7522C2F3F9201A /* badge.svg */,
+				F81ADB79D91726B72485F4EB07189680 /* best-practices-and-faq.html */,
+				467AFE05CB3A1F8DA52EB49487AC6AD7 /* carat.png */,
+				3B9384CB37292879DF0B7EF59807FB68 /* Classes.html */,
+				A7EDF4CB9612A8A0FE0972862063E753 /* Constants.html */,
+				0945AF09BF9D60192B8D5FCCFE4979D0 /* dash.png */,
+				C6E4FC2BCE1CEA686E09FB1DE6AF1D1F /* Enums.html */,
+				1D7BE3AB5968D829FC7FCA8F26AE9375 /* Functions.html */,
+				3791CC242750A8F4B0C14A469468BDBF /* generating-your-models.html */,
+				42D9B0C949975C67157B981125D5A87E /* getting-started.html */,
+				83ABB67F6B46E509EDD59E671A84C614 /* gh.png */,
+				B79957879200DD8A6E97B1206EC58C0E /* Guides.html */,
+				7DD6C706C7826AADAC31A84BEEB458FC /* highlight.css */,
+				395BB0B42D829322A7AF0C44A9063062 /* IGListAdapter.html */,
+				97C2B26F441E28E533217E3C03697616 /* IGListAdapterDataSource.html */,
+				98173EEA7D8C33730B1F33BE63C9AA09 /* IGListAdapterDelegate.html */,
+				4E95D758C8E7D7F9D1B5C6AC9AEF00F4 /* IGListAdapterMoveDelegate.html */,
+				24F2376EFBD9C1C408C89E2B094DAA4F /* IGListAdapterUpdateListener.html */,
+				C0E08CEACF3457FD3AE697E20C9C78ED /* IGListAdapterUpdater.html */,
+				0A474A78E15DAFA304A953A3FBD6A4C6 /* IGListAdapterUpdaterDelegate.html */,
+				726E9F22C7F35CCABBA5C3DC0F464425 /* IGListAdapterUpdateType.html */,
+				26F52B05C2E7ABB97E721E8B32631396 /* IGListBatchContext.html */,
+				6301C379D70453401D6568EA54FC2CEF /* IGListBatchUpdateData.html */,
+				7878C27766439441462BD57C3C1E99A7 /* IGListBindable.html */,
+				DF0888A9BC07FFD5D749A3503B7425C9 /* IGListBindingSectionController.html */,
+				50331FD388EB8F1FE1E20A4BB4E1220D /* IGListBindingSectionControllerDataSource.html */,
+				DF0E1BA43692A529F41C26BE0C278EFF /* IGListBindingSectionControllerSelectionDelegate.html */,
+				A313396A1949030A4D6F748F4BF86A9A /* IGListCollectionContext.html */,
+				CB1316BC6A395B155E1F497445AC8112 /* IGListCollectionView.html */,
+				E50F213F33008C31CFB8F78A5F46D893 /* IGListCollectionViewDelegateLayout.html */,
+				2911EA29C22A6FAF5526EB699584F3D2 /* IGListCollectionViewLayout.html */,
+				009674E801ED42DA88E2A7E17B464694 /* IGListDiffable.html */,
+				59C22462AD117D30DE0A755213954765 /* iglistdiffable-and-equality.html */,
+				B403368AE910AE7650DCDD8E6656F872 /* IGListDiffOption.html */,
+				EAF37BDA9B692B58A75658B98B04D7F2 /* IGListDisplayDelegate.html */,
+				C807FA89C7533AA66C5F09CA80356D9F /* IGListExperiment.html */,
+				FAD9792F950A1182316E1A99C9F72342 /* IGListGenericSectionController.html */,
+				B9E43982239A67489C2488B574521620 /* IGListIndexPathResult.html */,
+				3F417F895C267FC58F619284C73E15D4 /* IGListIndexSetResult.html */,
+				5E0846871994F31B9C0A2775DCFF4C86 /* IGListKit.podspec */,
+				BF5745ADA8B8D456D74C9AA282FAFDA1 /* IGListMoveIndex.html */,
+				8FD448F150946AEA5A8F422D15207E40 /* IGListMoveIndexPath.html */,
+				3302914E2CA9E19D6778CB6C051C1A49 /* IGListScrollDelegate.html */,
+				59B5055F68D6BDDACA5AFA9312F8D462 /* IGListSectionController.html */,
+				34B6D9A34471548301BDB3993FA9528F /* IGListSingleSectionController.html */,
+				490E2370BB09C802D69D5E62060F5CB9 /* IGListSingleSectionControllerDelegate.html */,
+				409B74D2D8B125E57D47D5BAFF83AEE2 /* IGListStackedSectionController.html */,
+				B2C630024D74FDC76E0009BFD6FDF427 /* IGListSupplementaryViewSource.html */,
+				089FF2A854F52C96BCC1D01A9442C11E /* IGListTransitionDelegate.html */,
+				7593379DF002548C7A41CF74A1316543 /* IGListUpdatingDelegate.html */,
+				8BEEA4D1495834AD797B585E28AB2B43 /* IGListWorkingRangeDelegate.html */,
+				A2B2882030226183EA50205324149F52 /* index.html */,
+				AA5B59B126584D9FBFB4B2225A442960 /* installation.html */,
+				96C35CD69BD0F69865F1E4DDE236074A /* jazzy.css */,
+				E8AAD1FA644F47540FEE5E2DE2C2C009 /* jazzy.js */,
+				5019AEFA6A4686D98190A81B26242344 /* jquery.min.js */,
+				5973AAAEACF20A24793A9E8BE1E38769 /* LICENSE.md */,
+				64B5714ED21DE4FCCAE13B42FE88EAB4 /* migration.html */,
+				A9A2515017382C1E17D3F0226CE017BB /* modeling-and-binding.html */,
+				16168A6EEF34A8A1EAD3D0C6500C94D5 /* Protocols.html */,
+				91769718316CC21FE82BBDC422AEA87B /* README.md */,
+				351B73556627AFF478B894B1B0B8334E /* search.json */,
+				560C673AF5C711F3689CEE41244B364D /* Type Definitions.html */,
+				FFC642AB792B9AE3319E13ECEBD88B4D /* undocumented.json */,
+				BBF89AEC1335E8560EBD7A889AC1BD80 /* vision.html */,
+				3F1B2DF23B5B4F797C037C61F75F104D /* working-with-core-data.html */,
+				1CB7C84EEF54FEE734C2BBAAAC2A6ADB /* working-with-uicollectionview.html */,
 			);
-			name = Internal;
-			path = Internal;
+			name = Pod;
 			sourceTree = "<group>";
 		};
 		1628BF05B4CAFDCC3549A101F5A10A17 /* Frameworks */ = {
@@ -464,6 +519,19 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		245A38633B0C6DEC617F2A68BD8FF6EC /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				F9096A156E32C6DDE6F4897C0A69871C /* IGListArrayUtilsInternal.h */,
+				7EE4B06CE8B9AD78FC7EA9B08B555F77 /* IGListIndexPathResultInternal.h */,
+				B63E0E9A01385088DC950A9958EBDB03 /* IGListIndexSetResultInternal.h */,
+				81733DEBAC61ED8C226AA787201F4AA6 /* IGListMoveIndexInternal.h */,
+				62486C1A8C8ABBE1D22AEACA3CE0E675 /* IGListMoveIndexPathInternal.h */,
+			);
+			name = Internal;
+			path = Internal;
+			sourceTree = "<group>";
+		};
 		2645FE348EFE1212BBF8271E985E2100 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -490,252 +558,124 @@
 			path = "Target Support Files/Pods-IGListKitMessageExample";
 			sourceTree = "<group>";
 		};
-		3B063CC53D6231A12DA0244AAA81FA4F /* IGListKit */ = {
+		484E5E7655E8DB135B4A210F60637686 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				9E5AE2EAA98C56AAD472AB7E18A2F9FD /* Default */,
-				A7D9E7EAAC7F5AD41393D8BCFB9C517E /* Diffing */,
-				BD51129607E5D90031382581A5D0D5CD /* Pod */,
-				ACC670CC92DD0BACA33C74CE77CA8F29 /* Support Files */,
-			);
-			name = IGListKit;
-			path = ../../..;
-			sourceTree = "<group>";
-		};
-		426FE7C368D4E4110F5F06E68C0DC2F0 /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				6FDEDAD33401B1C42CC43C96F2328C25 /* IGListAssert.h */,
-				30DBEF45C2E728D1090A961614EE47E6 /* IGListBatchUpdateData.h */,
-				2315909B6F12DA63EE28E3FE987E8908 /* IGListBatchUpdateData.mm */,
-				F1B830E3D3F859A4D05A6EC4B93431F4 /* IGListCompatibility.h */,
-				7DFD4F2B2D29AB4A18B5120452176853 /* IGListDiff.h */,
-				C2267D810839A15755F5E28197B069E3 /* IGListDiff.mm */,
-				A273F1EDF2D368DFE57EB7B6C2CAA4F7 /* IGListDiffable.h */,
-				62CBBC4894F382BC5AF8D2C38BBA0F32 /* IGListDiffKit.h */,
-				044FCE0682D64C46BD87A96F0E3DBF7B /* IGListExperiments.h */,
-				E9D67F2AF1177C61845A3BBEE77A5D38 /* IGListIndexPathResult.h */,
-				7E87589679047DFEA4C0CF7F76D19965 /* IGListIndexPathResult.m */,
-				07A79365D845D6146F294238A9CD843F /* IGListIndexSetResult.h */,
-				FDF5D9B5791BC8D09BF19CAE1F9006D8 /* IGListIndexSetResult.m */,
-				92F4552DDE17BE53E61F1886DCDE7B70 /* IGListMacros.h */,
-				90DA75A42732723728B7EC12D9DAAAF9 /* IGListMoveIndex.h */,
-				BE726AF43888DF0C7F7C1D8C6866E3B9 /* IGListMoveIndex.m */,
-				E09C30D85E9DDEB527C77C9AFE8D6B76 /* IGListMoveIndexPath.h */,
-				6A159BFCD8301C03E679149E499C1E6B /* IGListMoveIndexPath.m */,
-				674E727C976C2FB76C9D4A4689ADE85F /* NSNumber+IGListDiffable.h */,
-				7E0CCC606FB1769C523803BD2F809E7D /* NSNumber+IGListDiffable.m */,
-				E45EDD691FF311B8A3B3DA94C707AAF0 /* NSString+IGListDiffable.h */,
-				2EEA22BAE075D9E81B2A849ED64BF95D /* NSString+IGListDiffable.m */,
-				12DEC4618E3744346F019A43B40C005A /* Internal */,
-			);
-			name = Common;
-			path = Source/Common;
-			sourceTree = "<group>";
-		};
-		687E31D44AF41B23BE69084C193D6B18 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				3B063CC53D6231A12DA0244AAA81FA4F /* IGListKit */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		9E5AE2EAA98C56AAD472AB7E18A2F9FD /* Default */ = {
-			isa = PBXGroup;
-			children = (
-				FB6422637E1B4DC6603EC538CA47F177 /* IGListAdapter.h */,
-				C3E48B6C09DB4B87AB8F2523A79B1D6B /* IGListAdapter.m */,
-				03DC4A19E3A79A7E24ACAC28C702E4CD /* IGListAdapterDataSource.h */,
-				066B551EEA2FA468D3E99C1880375E35 /* IGListAdapterDelegate.h */,
-				C420FE671C4EFB6345F7882E71E5E4DA /* IGListAdapterMoveDelegate.h */,
-				C7F3DDBC4E623739466845B9A9F0FE8C /* IGListAdapterPerformanceDelegate.h */,
-				34D1309F73A540453DCD26645B813697 /* IGListAdapterUpdateListener.h */,
-				8D3F2B108AFE983D69E84996ED566057 /* IGListAdapterUpdater.h */,
-				87D90284ADC918AE3C5A00FB90A38707 /* IGListAdapterUpdater.m */,
-				98D31AD0C93848779245330326E657A4 /* IGListAdapterUpdaterDelegate.h */,
-				89C7396F7915F4497DFFBCB46D1B33B1 /* IGListBatchContext.h */,
-				8AC78C46C87E838A6509F554738EB8EE /* IGListBindable.h */,
-				3954471B291B5095C6676EC5FBA2A8B9 /* IGListBindingSectionController.h */,
-				5F5AA1D844489BAA60ADE9B02C921B6D /* IGListBindingSectionController.m */,
-				DA546B8ADF45E9C49AE21793AF908FC2 /* IGListBindingSectionControllerDataSource.h */,
-				440E3FF7AC26E6111E65519935642573 /* IGListBindingSectionControllerSelectionDelegate.h */,
-				64B2C0C25765F7F31D3CA044F2F86C3E /* IGListCollectionContext.h */,
-				389848B46317660EF32A43516ECCCA03 /* IGListCollectionScrollingTraits.h */,
-				05D3F2BA94861E7615792CDA068A4CF2 /* IGListCollectionView.h */,
-				74F7FBDA249198E78AD1871D9160C88D /* IGListCollectionView.m */,
-				371F3D6B1997EAA65386CD36258CFDAA /* IGListCollectionViewDelegateLayout.h */,
-				9D30D598272340D656FE6EA38F0B7B7E /* IGListCollectionViewLayout.h */,
-				1A9022CD0D4E43FA62B9F30CAE92CA69 /* IGListCollectionViewLayout.mm */,
-				CFF408C087E56123D872C50FCFA40AFA /* IGListCollectionViewLayoutCompatible.h */,
-				9612085D18B7AF158EBEDF462F481763 /* IGListDisplayDelegate.h */,
-				0383D34B2EE0202A75A7D5FDDDE43E55 /* IGListGenericSectionController.h */,
-				4F48717FE518B8DE09365412671B917A /* IGListGenericSectionController.m */,
-				0D8A4F47558918ACF83FD1EB0FA758D0 /* IGListKit.h */,
-				FBE985E43CE368AA737BFE297FFFF930 /* IGListReloadDataUpdater.h */,
-				365225A14D2009FDF38E6B2C044533AF /* IGListReloadDataUpdater.m */,
-				593AB20FE2F62DCCF55CC8C621A87A13 /* IGListScrollDelegate.h */,
-				2ED46836AFB8D88B1D96399D09F978EA /* IGListSectionController.h */,
-				4F793EC4F27EB18E43481C8411FA2729 /* IGListSectionController.m */,
-				CA37B2EEC914A0785E29D2047C0FD1E9 /* IGListSingleSectionController.h */,
-				A20E8B1E857182C050621491326DEC24 /* IGListSingleSectionController.m */,
-				1B786CE2B90C71EF0828B4448AEE3BE6 /* IGListStackedSectionController.h */,
-				970A241B1B809D2A10F86A7127FD5581 /* IGListStackedSectionController.m */,
-				DE9BBF67B3ADDABCF919D37C121CF8C3 /* IGListSupplementaryViewSource.h */,
-				F3B589E41CFF0D2CFCEC848E2A5D5BAC /* IGListTransitionDelegate.h */,
-				5A03A8B550799920D1B3E989D1335998 /* IGListUpdatingDelegate.h */,
-				2B1D71CBC7B01980F106DF1EE3F9F9BE /* IGListWorkingRangeDelegate.h */,
-				426FE7C368D4E4110F5F06E68C0DC2F0 /* Common */,
-				A15DA26586F8A5233F5F6999279CE80A /* Internal */,
-			);
-			name = Default;
-			sourceTree = "<group>";
-		};
-		A15DA26586F8A5233F5F6999279CE80A /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				3B377708F6EE994BC1010B6BD38A3886 /* IGListAdapter+DebugDescription.h */,
-				1CA143C1A19EDA1CBBFE996AC7222DFD /* IGListAdapter+DebugDescription.m */,
-				0A8725312F557AB63A46D940FDA5F35A /* IGListAdapter+UICollectionView.h */,
-				3EE5A843C04930DC9339D6AA1082C72C /* IGListAdapter+UICollectionView.m */,
-				692D718E1FB846F471F1E238A8073509 /* IGListAdapterInternal.h */,
-				0AF4B55C8C1668B91FA680D052072D6A /* IGListAdapterProxy.h */,
-				D952A047D5FB197406B63B5ADA927302 /* IGListAdapterProxy.m */,
-				211F7C53AD1EA83FFE09E9444F559E8A /* IGListAdapterUpdater+DebugDescription.h */,
-				E833589E26237AA174C0E9EA6465FEB3 /* IGListAdapterUpdater+DebugDescription.m */,
-				77C12F2A7ABA79BCC15AD7CDDFEBB09F /* IGListAdapterUpdaterInternal.h */,
-				9B82F9610386A9EFA9762299B844AF90 /* IGListBatchUpdateData+DebugDescription.h */,
-				67AE8CAAEBAFEE2A970AE7375EEFF9A9 /* IGListBatchUpdateData+DebugDescription.m */,
-				2D7D84E512916E93A503CBF6F88524D6 /* IGListBatchUpdates.h */,
-				E309AE66E886B34FA6C73F9729951CA5 /* IGListBatchUpdates.m */,
-				420B83CB934E78E8B8A75F7C8AA173F4 /* IGListBatchUpdateState.h */,
-				1A89A7D5D864313B7254DA66F8E90249 /* IGListBindingSectionController+DebugDescription.h */,
-				61F8D7D92B91C024F2066C168321AA92 /* IGListBindingSectionController+DebugDescription.m */,
-				F96F6A0856664D181DD81B5EF2A48172 /* IGListCollectionViewLayoutInternal.h */,
-				42D4500DB4DC33B1253A4883F8411E64 /* IGListDebugger.h */,
-				0A794A13E30ED1A1B1117EC695A24CDB /* IGListDebugger.m */,
-				2DC1C637F9C0AE29D72685C77819220E /* IGListDebuggingUtilities.h */,
-				D1C74FFB6B4579E2C45F3AB95BC283C3 /* IGListDebuggingUtilities.m */,
-				6F285B85787EB2EBAA85D53861B22942 /* IGListDisplayHandler.h */,
-				8A9F5E70A8B4308AB52FC695A00EE707 /* IGListDisplayHandler.m */,
-				3882A6E3B7945735D6D90090096760E7 /* IGListReloadIndexPath.h */,
-				9B0687400523ED7A1194B47E87FB9526 /* IGListReloadIndexPath.m */,
-				C7C6F0859B45281DE2F20F302A29ED68 /* IGListSectionControllerInternal.h */,
-				37BEAFA0459AAB1874E601F51BC110D1 /* IGListSectionMap.h */,
-				92F335A785084C07099C58BC3A93E574 /* IGListSectionMap.m */,
-				D1506F96A7CBC596094F7B2A33ACD435 /* IGListSectionMap+DebugDescription.h */,
-				7FFB3F2020528EE055DD35388C7D7C87 /* IGListSectionMap+DebugDescription.m */,
-				CF28E4393C715BB0FC81A5CFB00D6ACD /* IGListStackedSectionControllerInternal.h */,
-				CE77CFD6A72590901219325F80A7D9B7 /* IGListWorkingRangeHandler.h */,
-				7B97C6FC6D3C89142CAF905A5E8A9790 /* IGListWorkingRangeHandler.mm */,
-				69937996A99F521B10DD3272B5CCBB0B /* IGSystemVersion.h */,
-				67832F3519DB4B210CDF5A5860353925 /* IGSystemVersion.m */,
-				0C07BE03D8DEC89C003163AC23C43A4F /* UICollectionView+DebugDescription.h */,
-				EDD27A8476E8722E951B2DA4445E7A2F /* UICollectionView+DebugDescription.m */,
-				ECB918404917AD4FDCBAA810A7DFF624 /* UICollectionView+IGListBatchUpdateData.h */,
-				8696286ED5A79E4AF1AFA2D44920C90B /* UICollectionView+IGListBatchUpdateData.m */,
-				63A47D737C4BD54D40504B4EE5F809E9 /* UICollectionViewLayout+InteractiveReordering.h */,
-				8A886B504C19BA83BB5179DFA3C7074B /* UICollectionViewLayout+InteractiveReordering.m */,
-				FC796A62B892E50A529ACDCC7667F086 /* UIScrollView+IGListKit.h */,
-				3FEFC6C17288EDA681F2DA7AA9931B7C /* UIScrollView+IGListKit.m */,
-			);
-			name = Internal;
-			path = Source/Internal;
-			sourceTree = "<group>";
-		};
-		A7D9E7EAAC7F5AD41393D8BCFB9C517E /* Diffing */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Diffing;
-			sourceTree = "<group>";
-		};
-		ACC670CC92DD0BACA33C74CE77CA8F29 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				18D96B30D2A3A2F6F0FE3EEF1774CAC5 /* IGListKit.modulemap */,
-				22B293012506ACB2C3B45678B518F484 /* IGListKit.xcconfig */,
-				C0525529DA2B84B1F3CD5C39968556C7 /* IGListKit-dummy.m */,
-				B90310BFDEB792C0693CC5ADB8B59E3A /* IGListKit-Info.plist */,
-				C1A99101B7FD0FB345799178314AE0CB /* IGListKit-prefix.pch */,
-				1411C6EFE7A6CAAE16FE65EBD2D55890 /* IGListKit-umbrella.h */,
+				18F5774A460120CA1A7E6AA8686F56B7 /* IGListKit.modulemap */,
+				5648C76FD3F37647CA0368C4CB65FE49 /* IGListKit.xcconfig */,
+				44C8F823D204055646A63EE044B5656D /* IGListKit-dummy.m */,
+				15D914ED60DBD308D0AC8BD035FA2247 /* IGListKit-Info.plist */,
+				CC11094D70EBA0125ADB725C5814E8BD /* IGListKit-prefix.pch */,
+				744A5E861F2D9316E0458C3F0408C123 /* IGListKit-umbrella.h */,
 			);
 			name = "Support Files";
 			path = "Examples/Examples-iOS/Pods/Target Support Files/IGListKit";
 			sourceTree = "<group>";
 		};
-		BD51129607E5D90031382581A5D0D5CD /* Pod */ = {
+		687E31D44AF41B23BE69084C193D6B18 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D14D732D3CEBF3AA264AA1B8148B1BDF /* badge.svg */,
-				3AA060DDCDAA5270488259126A847E6E /* best-practices-and-faq.html */,
-				7F59E34855A27D2382355F64059CB3E7 /* carat.png */,
-				E67111D8D93D71589496E6771FE543AE /* Classes.html */,
-				B9299B332C7D9358DD8BDAF68049CED2 /* Constants.html */,
-				6E443F767BF22D0CDB1998518D50F4E2 /* dash.png */,
-				8119818F252591E5B1CCD7009B67FC92 /* Enums.html */,
-				5F78C2BDDE88CACE848F107C875BD986 /* Functions.html */,
-				EDDBBEDD1758F2A7AF127E049902C46A /* generating-your-models.html */,
-				FAFEDA48F1A640BC56553F6BE4447058 /* getting-started.html */,
-				AB796D0CAB4048AF7FC98EBBF4917723 /* gh.png */,
-				9019EE7B092696DF05B3BDC321A07833 /* Guides.html */,
-				FE65F47FFB5E1C128EEA82FE06EB9247 /* highlight.css */,
-				C1DE4721BE340A6DDF89DBEA95046820 /* IGListAdapter.html */,
-				639E982B1958907B824A6568ADD32EF3 /* IGListAdapterDataSource.html */,
-				E5C0CB8E49DF4232A3CF7156C6511BB7 /* IGListAdapterDelegate.html */,
-				31A7A42011C196C3CDF1AD81D38FE86C /* IGListAdapterMoveDelegate.html */,
-				23EBEFE61B8B248618693FD011E1CEE0 /* IGListAdapterUpdateListener.html */,
-				C9012F307058EE4ABCF2B2FB5D3574DC /* IGListAdapterUpdater.html */,
-				E238DB9C7E52E19405D95073716D8357 /* IGListAdapterUpdaterDelegate.html */,
-				8DFE07B690FEFECB7A8F905715E66254 /* IGListAdapterUpdateType.html */,
-				92D47D16C4CFAE67F015643F7510C084 /* IGListBatchContext.html */,
-				AC900FECC58A646F4B1790A8457854CC /* IGListBatchUpdateData.html */,
-				3EB8531CEB83B8AEC812345FA390180F /* IGListBindable.html */,
-				8CC3824F2A3EC593EF4B54B9EC914FC1 /* IGListBindingSectionController.html */,
-				02CCE4EC31039FE9608A03FAF2CF8D34 /* IGListBindingSectionControllerDataSource.html */,
-				5436E630F35AEB6EEA0604E60680261D /* IGListBindingSectionControllerSelectionDelegate.html */,
-				A5D764AD481EBE76DA25BF5BB4C7AD0D /* IGListCollectionContext.html */,
-				E9372831718C06100C6AFA0397DFDBC9 /* IGListCollectionView.html */,
-				797A2FE675EBCEBB8A6228FB6E63F28F /* IGListCollectionViewDelegateLayout.html */,
-				403CCAEBD2A66F06F9192886315B108B /* IGListCollectionViewLayout.html */,
-				6FF6DD132F04866BE8D01F15E7AA656C /* IGListDiffable.html */,
-				3427C6194DEF85513980D8D53F1DA3C5 /* iglistdiffable-and-equality.html */,
-				FF5339A45BE6C21D683BDA9ED79DCE06 /* IGListDiffOption.html */,
-				B56084A88F0BC291A6880E34E328C7BC /* IGListDisplayDelegate.html */,
-				804AF2931D217E1708961001108574D5 /* IGListExperiment.html */,
-				EDBA59A2AA390CCA5E5597773A48DD51 /* IGListGenericSectionController.html */,
-				87D08C9EFF4873483EC004BA363EE0C3 /* IGListIndexPathResult.html */,
-				A6A7903FB9DFBA3BA30EF026FCC2DF9D /* IGListIndexSetResult.html */,
-				370B9601EB583565F97117E9BC072ED1 /* IGListKit.podspec */,
-				4EDC7D950B56ABC34AC29691AA21774D /* IGListMoveIndex.html */,
-				8794F31CBD1686730DEA031E7727054A /* IGListMoveIndexPath.html */,
-				7DA9982D4A447DCFDEC6BC8373AFD90A /* IGListScrollDelegate.html */,
-				D33ECCD2445C78902BF2608067222F91 /* IGListSectionController.html */,
-				1925B17DBA76D8F40C9AF6C3D9C94A1C /* IGListSingleSectionController.html */,
-				43727BA21BE0954130910417C151DA7C /* IGListSingleSectionControllerDelegate.html */,
-				22742EF0B6DE8261AB1B378987151EDD /* IGListStackedSectionController.html */,
-				C332230FF765F424C3F1AD6F27D82474 /* IGListSupplementaryViewSource.html */,
-				3DDEA6E6559142DCD014E5C226253368 /* IGListTransitionDelegate.html */,
-				B542DB33EAAFB9AFC94CAC082FED0286 /* IGListUpdatingDelegate.html */,
-				36E67F21E86A610819B6CA1E18795F40 /* IGListWorkingRangeDelegate.html */,
-				EBDE258CA74FF5078A77584C74EDBDC2 /* index.html */,
-				07B3DE78C6980BB6995E7C6ADF5EFA9C /* installation.html */,
-				867C7513C719378D50D129144163DF43 /* jazzy.css */,
-				DB617B3AD6B0D099C0066F294361AC40 /* jazzy.js */,
-				1594390C09EC59E43B1F638396EEEA2A /* jquery.min.js */,
-				0BC5635A74E73EDFE4E276EC7737EE67 /* LICENSE.md */,
-				4A16647937945685F1D9E31020CB7B63 /* migration.html */,
-				CE3008F480B4309F09B0259B66C07597 /* modeling-and-binding.html */,
-				AB62E1C6DA9E14B68122D3D4DB6E968B /* Protocols.html */,
-				29F39249FF9402BF48F4E050FD49AF48 /* README.md */,
-				805DD65287244E65D8FE988C5544C264 /* search.json */,
-				6F996AC3C81FF26AB9D7C06F73C95F1E /* Type Definitions.html */,
-				2629974FAAACF45FA8B2310E5DAF982F /* undocumented.json */,
-				380947FA77199189124E703DC1C0CF75 /* vision.html */,
-				CFDC84B590BEDD3F0CDC316945839372 /* working-with-core-data.html */,
-				9EF1992B9850A9877FA806094D9AB0FE /* working-with-uicollectionview.html */,
+				B9028097ECF302993876C64AE4E1A3B0 /* IGListKit */,
 			);
-			name = Pod;
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		7D0CFB62F18FEDE87E0B6FFC82539077 /* Default */ = {
+			isa = PBXGroup;
+			children = (
+				2D17F1144C7FADAC5C843161AE4563B3 /* IGListAdapter.h */,
+				C2C98958388A5D10B6A6F8653FC324C8 /* IGListAdapter.m */,
+				01D64D6A05BB4F6E57D4315BD8B500FE /* IGListAdapterDataSource.h */,
+				E12138C62489CFAF670C584626B6A8CF /* IGListAdapterDelegate.h */,
+				5DB15E81008571D85246D9DD43A9C176 /* IGListAdapterMoveDelegate.h */,
+				1C406DC1E4D3C6B18F012C04608B8DBE /* IGListAdapterPerformanceDelegate.h */,
+				CBD7DB84695BF777CC376FE0B4C6E0DC /* IGListAdapterUpdateListener.h */,
+				F6F632BA2C517D3BC6CBF4433D61E094 /* IGListAdapterUpdater.h */,
+				1017DFA89762EF68154C9E85645E54D3 /* IGListAdapterUpdater.m */,
+				441D39CA85B2D166D8B80F8A56F7C8BA /* IGListAdapterUpdaterDelegate.h */,
+				77561C468BC2B1F1F01CD942A77A5895 /* IGListBatchContext.h */,
+				F8148402E66986003F6673D9E412A99C /* IGListBindable.h */,
+				4325D4F044E926B1FA04C7627F239E82 /* IGListBindingSectionController.h */,
+				0B90E49E53717C10ACE475A6F47E6C19 /* IGListBindingSectionController.m */,
+				EFF7CC987D1C5138F502D14214368771 /* IGListBindingSectionControllerDataSource.h */,
+				B33C79CC157FEA65CBDDFBB8751AB38C /* IGListBindingSectionControllerSelectionDelegate.h */,
+				6E5527C92FCC72200F4FEC95EAA18AD3 /* IGListCollectionContext.h */,
+				8F9E145973E0C159BF76941D9009E3B4 /* IGListCollectionScrollingTraits.h */,
+				2211947B53C9C1733D2FA851AC8CD9B2 /* IGListCollectionView.h */,
+				2776F2557F1B9AB75979FF8A420E484B /* IGListCollectionView.m */,
+				C536C62EC1F5CCE91F3BCDF37C9C347E /* IGListCollectionViewDelegateLayout.h */,
+				D0C4A37D30725BCC1CBD2795A7E79BFB /* IGListCollectionViewLayout.h */,
+				4A012974BA15CE66B6582B2C7FD68665 /* IGListCollectionViewLayout.mm */,
+				D187C0E5DB27F1AE8701ED1644D57506 /* IGListCollectionViewLayoutCompatible.h */,
+				701851857ED864923D686B19C1F130ED /* IGListDisplayDelegate.h */,
+				614A557F6569A1145F876B51D590AE61 /* IGListGenericSectionController.h */,
+				5B90C679A42A6521974D50D15EE81A6E /* IGListGenericSectionController.m */,
+				E9C97D5A25B37D88574660E311BBF291 /* IGListKit.h */,
+				8AA8A1C3856DE7F7B8E4E2E34C682509 /* IGListReloadDataUpdater.h */,
+				C7DD0A25CCB7775738D04DD0553DE010 /* IGListReloadDataUpdater.m */,
+				82D9B57140A46A523A476A8C988DA6ED /* IGListScrollDelegate.h */,
+				B2E92037D172FBA797EC96E20D2F748E /* IGListSectionController.h */,
+				F20B6A958066540F4B5523C3E48B9F12 /* IGListSectionController.m */,
+				AE45701181220FC066F21669CDC35EED /* IGListSingleSectionController.h */,
+				6E593D64A5E553F6D8C4C9072A7F02C9 /* IGListSingleSectionController.m */,
+				C88734A4CEB37D3DEE450C9DB8633296 /* IGListSupplementaryViewSource.h */,
+				74E9D33F9DEBE578466CF8D08D60D3CB /* IGListTransitionDelegate.h */,
+				F3739218A19D5E056E29E85AFAB750D8 /* IGListUpdatingDelegate.h */,
+				BAD2E8CDCA43740CC5C6A0AA76BFF324 /* IGListWorkingRangeDelegate.h */,
+				B6360EA4F4150606624608F1DC7481A3 /* Common */,
+				D3668C8417C50DC931C99962B6D47613 /* Internal */,
+			);
+			name = Default;
+			sourceTree = "<group>";
+		};
+		B6360EA4F4150606624608F1DC7481A3 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				805DC02CD9DFA67ABACEE7D83C1FBC3E /* IGListAssert.h */,
+				C46720A53A5175FFF5858F9184B0B377 /* IGListBatchUpdateData.h */,
+				0A0E48D597836337EF70C29E49E57634 /* IGListBatchUpdateData.mm */,
+				DA952D32E01044CED53295436E89D88B /* IGListCompatibility.h */,
+				C52D3728817A5D029C6DB61E4DA9FBD8 /* IGListDiff.h */,
+				66749052BF9812D222F45DA1D65C0AC2 /* IGListDiff.mm */,
+				72813F0A42ABCB57CC7FDDD48D6525CB /* IGListDiffable.h */,
+				EBB996C88B4D76F0A2A3F0E0D3F6EA5E /* IGListDiffKit.h */,
+				4B35F8F140F5687C2CBB2B18E492F0CC /* IGListExperiments.h */,
+				811398241EF7EF12BDAF0E2F2257C18E /* IGListIndexPathResult.h */,
+				D0AEC9D3C7F018C772C2994836AD3555 /* IGListIndexPathResult.m */,
+				2F2A4059963DF52C6EC18223E51B96C4 /* IGListIndexSetResult.h */,
+				10E2B7E0666B218A43B24AB03E869FE4 /* IGListIndexSetResult.m */,
+				7EDF72970B37AA776A8291F8928739C0 /* IGListMacros.h */,
+				F5EC716FD2106CEA5A413425306D3050 /* IGListMoveIndex.h */,
+				DF0974E1FC25B9A25FFCE4C76A54DCBE /* IGListMoveIndex.m */,
+				41006E0540A00C0AA37FF6E8488171D3 /* IGListMoveIndexPath.h */,
+				3ED072E8B6EF370BD02525AC0C66DF5D /* IGListMoveIndexPath.m */,
+				3365241B64D1A5B0CC65B5942328C88D /* NSNumber+IGListDiffable.h */,
+				22B2104FE3B310C2ACC9EA50D39DABA7 /* NSNumber+IGListDiffable.m */,
+				80B5F0BFE12986E9CC6F8E23DB5DBAD7 /* NSString+IGListDiffable.h */,
+				BEF2D5AF7527A2EEA2CB61D3B93318E9 /* NSString+IGListDiffable.m */,
+				245A38633B0C6DEC617F2A68BD8FF6EC /* Internal */,
+			);
+			name = Common;
+			path = Source/Common;
+			sourceTree = "<group>";
+		};
+		B9028097ECF302993876C64AE4E1A3B0 /* IGListKit */ = {
+			isa = PBXGroup;
+			children = (
+				7D0CFB62F18FEDE87E0B6FFC82539077 /* Default */,
+				BEACB3D08264CAA4EC57D213D4C570F0 /* Diffing */,
+				1129A39009AFD6118B71B7316A7F8084 /* Pod */,
+				484E5E7655E8DB135B4A210F60637686 /* Support Files */,
+			);
+			name = IGListKit;
+			path = ../../..;
+			sourceTree = "<group>";
+		};
+		BEACB3D08264CAA4EC57D213D4C570F0 /* Diffing */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Diffing;
 			sourceTree = "<group>";
 		};
 		CF1408CF629C7361332E53B88F7BD30C = {
@@ -747,6 +687,57 @@
 				205EFBAD19016B9F5C005000B341EB97 /* Products */,
 				2645FE348EFE1212BBF8271E985E2100 /* Targets Support Files */,
 			);
+			sourceTree = "<group>";
+		};
+		D3668C8417C50DC931C99962B6D47613 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				9752CAC78ECDDAD7EBC30468E07B3675 /* IGListAdapter+DebugDescription.h */,
+				993C1BC004AC4BC65B9A3B052E39F9E0 /* IGListAdapter+DebugDescription.m */,
+				854ECCEE735014C5D9C30E8105C10E94 /* IGListAdapter+UICollectionView.h */,
+				0706B22AA2831FE881AF3A3089E9CF8B /* IGListAdapter+UICollectionView.m */,
+				0C118026309C2B39D3DD29B7649911E7 /* IGListAdapterInternal.h */,
+				9B119D3CD073B6AA1D33D5C80E926EC8 /* IGListAdapterProxy.h */,
+				55C4C0A2D93C9CF65908D7E7EC1D339A /* IGListAdapterProxy.m */,
+				C1ED33F61FEC5AAAF032B8C0F5574ABB /* IGListAdapterUpdater+DebugDescription.h */,
+				3FC2F856D00467B0D1788FFE6149787B /* IGListAdapterUpdater+DebugDescription.m */,
+				D0CA665052C5446A2BB26EE0066DC427 /* IGListAdapterUpdaterInternal.h */,
+				3F2A430DE0506907558C17D55F9C4708 /* IGListBatchUpdateData+DebugDescription.h */,
+				2D10370D2A7ACBA4B732EE229BF52FA1 /* IGListBatchUpdateData+DebugDescription.m */,
+				B251F53F7135E93A7A3FE4ACDE0E6E6C /* IGListBatchUpdates.h */,
+				DC61EFBCDE4460EE8D51971199FE4C4A /* IGListBatchUpdates.m */,
+				C5F187AC8488CF9E490F2C4200CFA292 /* IGListBatchUpdateState.h */,
+				876ACA760F9A1500014557081A588CF2 /* IGListBindingSectionController+DebugDescription.h */,
+				6643BED0640FDC23F264B6E30762B99F /* IGListBindingSectionController+DebugDescription.m */,
+				A33E8B1DA72B5B88794B3F3F1DCF7328 /* IGListCollectionViewLayoutInternal.h */,
+				298BE78BD8B2ED70E3A67B1508ED63B3 /* IGListDebugger.h */,
+				D16B36F2C78B68C15C9B30BC770265D4 /* IGListDebugger.m */,
+				878AF2F118E2CCA640970F33A07C73B8 /* IGListDebuggingUtilities.h */,
+				D3B50C9C20677607D48A07C2E38E5F34 /* IGListDebuggingUtilities.m */,
+				76F8DB4CA32E315073C5AF2F5964BDA1 /* IGListDisplayHandler.h */,
+				46EA5FAFA4C1C031D2CBEECD2A50FE34 /* IGListDisplayHandler.m */,
+				FBD424E50E3FDAA66D2D09EACF0E498F /* IGListReloadIndexPath.h */,
+				A1F08F237941A456565584EC6342BD28 /* IGListReloadIndexPath.m */,
+				B2D6949DF6B5D2CC431EDDDF11918FFD /* IGListSectionControllerInternal.h */,
+				1430048F0DC6C8CB7000F61F3AB84DE1 /* IGListSectionMap.h */,
+				5BE925F92B712604FCE780CA91550C5B /* IGListSectionMap.m */,
+				3E124A5D40B16D8B177697C053F6CC2B /* IGListSectionMap+DebugDescription.h */,
+				6B7B482F0D9FC2FBD5EB6A16F9E67C6F /* IGListSectionMap+DebugDescription.m */,
+				F0949488A81E86CFA1CD1B92CE084E42 /* IGListWorkingRangeHandler.h */,
+				9A3C79F564AA50DDB644338C95A6DC5A /* IGListWorkingRangeHandler.mm */,
+				75429017957DF51361DBC74F40F2F21A /* IGSystemVersion.h */,
+				8E12F60BE657ECDC2B431C6BE8096001 /* IGSystemVersion.m */,
+				21DD4062A25AF8B16D5602BE3B603577 /* UICollectionView+DebugDescription.h */,
+				64BC4005A78CE1E91774D507CACD1564 /* UICollectionView+DebugDescription.m */,
+				4FDB300A5525F994AC561F71C5D828D8 /* UICollectionView+IGListBatchUpdateData.h */,
+				9E3327FB501A44D2B9DF8AA2FBDFF7F6 /* UICollectionView+IGListBatchUpdateData.m */,
+				5653B6F57FD69B70F0280EE456DE9B71 /* UICollectionViewLayout+InteractiveReordering.h */,
+				28CDC9AC99FB2C69EE4B400136D05E45 /* UICollectionViewLayout+InteractiveReordering.m */,
+				A6795F66FBAB470CE23EDA7241825D05 /* UIScrollView+IGListKit.h */,
+				5A8AF835DC4362F43842DA5E46471231 /* UIScrollView+IGListKit.m */,
+			);
+			name = Internal;
+			path = Source/Internal;
 			sourceTree = "<group>";
 		};
 		E169A450ED27AC725DF52953F66D11E0 /* iOS */ = {
@@ -777,6 +768,87 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		79D111E9C4E749D733B9F6253B7D48C1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				921B146558C8ABF2838644BE0995FE9D /* IGListAdapter+DebugDescription.h in Headers */,
+				1282117007BC677B95A4CF52D2257565 /* IGListAdapter+UICollectionView.h in Headers */,
+				91B9729085E3DFFF6A2493C75D946344 /* IGListAdapter.h in Headers */,
+				543E895A12B5E4989593120AC9272064 /* IGListAdapterDataSource.h in Headers */,
+				FD8AD5D12D11003C2A062BE079937D79 /* IGListAdapterDelegate.h in Headers */,
+				ECDC0BB3D3F98877AF8562A597899A35 /* IGListAdapterInternal.h in Headers */,
+				B5FBE3FD9252B5AB8A13AE29BA9F7735 /* IGListAdapterMoveDelegate.h in Headers */,
+				EC480E1CF76B2A831A24F0B9EA07DA85 /* IGListAdapterPerformanceDelegate.h in Headers */,
+				39E96236BA4786C17E251772B00FC9D5 /* IGListAdapterProxy.h in Headers */,
+				FCE38CF740B20F9C36A8F74665226E45 /* IGListAdapterUpdateListener.h in Headers */,
+				F20FD96E6EBAF2BCE079A1B391EB6605 /* IGListAdapterUpdater+DebugDescription.h in Headers */,
+				72CCC85E803626A6E85AE3249A918510 /* IGListAdapterUpdater.h in Headers */,
+				9B6A75415BEF5385B5C3D382B1763A0B /* IGListAdapterUpdaterDelegate.h in Headers */,
+				050CB37AEE76ECE3542C348937096F72 /* IGListAdapterUpdaterInternal.h in Headers */,
+				F1344FCB2E4119A707F82DCF02B1AAFF /* IGListArrayUtilsInternal.h in Headers */,
+				F2568F0CB73D4BDCA314C8125D36F364 /* IGListAssert.h in Headers */,
+				DFBAE4FD38CA5B58A0C156DED6D1C701 /* IGListBatchContext.h in Headers */,
+				F80F75C42FD5B327999F711986A2851F /* IGListBatchUpdateData+DebugDescription.h in Headers */,
+				407343653DCC836D08B1A2FB99194E07 /* IGListBatchUpdateData.h in Headers */,
+				5C1B34C156605E407A0F6DE20FD9AE9E /* IGListBatchUpdates.h in Headers */,
+				5938F6A23F345135DB251AC12D2C9CB0 /* IGListBatchUpdateState.h in Headers */,
+				FA49227F4FF92FB7205D8ED3984DAE2C /* IGListBindable.h in Headers */,
+				E870D65E97CFAEB3539758BB9FA0E21E /* IGListBindingSectionController+DebugDescription.h in Headers */,
+				A9E893D7A41C4582B1D87D1B03671A2B /* IGListBindingSectionController.h in Headers */,
+				3713990BA33D5B668C51C9BC030FFAF2 /* IGListBindingSectionControllerDataSource.h in Headers */,
+				C92D69E1A5C840EFA261D5BE92D0B665 /* IGListBindingSectionControllerSelectionDelegate.h in Headers */,
+				0927D0B030275F5F0AA4D5BFC98C5C24 /* IGListCollectionContext.h in Headers */,
+				3E2924EBCF6D645982DD9872C75329C3 /* IGListCollectionScrollingTraits.h in Headers */,
+				A6F4826056A25D8BA1510E4F9C145841 /* IGListCollectionView.h in Headers */,
+				EFBDE12C77935B722442BB23A4DDDB75 /* IGListCollectionViewDelegateLayout.h in Headers */,
+				835F8A26E9D9ED7B28B1A5A8E720D8A5 /* IGListCollectionViewLayout.h in Headers */,
+				D5C431990C04DDD62B11DDA8E66B824C /* IGListCollectionViewLayoutCompatible.h in Headers */,
+				6DD73C34CC787C0D145CA6E408EF42F1 /* IGListCollectionViewLayoutInternal.h in Headers */,
+				D075D5B1D729FBD5D467B9247B36EAD7 /* IGListCompatibility.h in Headers */,
+				842C3167B5F677583A4EB995A0AB9144 /* IGListDebugger.h in Headers */,
+				4B62113EF5872F1B7752C955DEF03E35 /* IGListDebuggingUtilities.h in Headers */,
+				9D28FB3BC158D10F2D39688D02EB8DD2 /* IGListDiff.h in Headers */,
+				B6430BBDD033522F9563BF53B299937B /* IGListDiffable.h in Headers */,
+				87703E311264E96792C69BA3B11A7A8D /* IGListDiffKit.h in Headers */,
+				B25C040E31E7B1BF90B87B1152A19D0C /* IGListDisplayDelegate.h in Headers */,
+				8C381DB929831D42ADFA58031B0111CD /* IGListDisplayHandler.h in Headers */,
+				940829814B26541CB202AF8F1BE1F6DA /* IGListExperiments.h in Headers */,
+				479781E2935028998C7016CFEBBC37C3 /* IGListGenericSectionController.h in Headers */,
+				65D8D6778D494967E8D1857E33EB06B2 /* IGListIndexPathResult.h in Headers */,
+				B0BA766330939CD91E034BD23BA0F030 /* IGListIndexPathResultInternal.h in Headers */,
+				E588EB6372FB13A5CA9B6ACD668E6935 /* IGListIndexSetResult.h in Headers */,
+				436DE67F0C1A1EE7ADD1A104D19783DC /* IGListIndexSetResultInternal.h in Headers */,
+				4A86719B3012A63F47DD316DFA63D67B /* IGListKit-umbrella.h in Headers */,
+				60C252DEA16FA0201AE31B7A516DA2D7 /* IGListKit.h in Headers */,
+				328119A6B5C29D0E167DD4BB2D4B8815 /* IGListMacros.h in Headers */,
+				D976B548E97A8472DD03C110D5840C87 /* IGListMoveIndex.h in Headers */,
+				369C7F203DAF3C82297169F7A76F2898 /* IGListMoveIndexInternal.h in Headers */,
+				0140E79E9A78DCC82A9E0499D6D505A4 /* IGListMoveIndexPath.h in Headers */,
+				66F3C1A0EA3BB9007A18C3671A707474 /* IGListMoveIndexPathInternal.h in Headers */,
+				4C04FC1C6AA89AB03E1703184E79245F /* IGListReloadDataUpdater.h in Headers */,
+				786E49A8F53ED48AEB69D807A208853B /* IGListReloadIndexPath.h in Headers */,
+				565010349B072FD721B750E287779F29 /* IGListScrollDelegate.h in Headers */,
+				9AE5EFDE583ACD4786CF07074474B00D /* IGListSectionController.h in Headers */,
+				50202E0D9BA01738C86218DE29F79FB2 /* IGListSectionControllerInternal.h in Headers */,
+				4DA167EA9BD179605B00005E81582825 /* IGListSectionMap+DebugDescription.h in Headers */,
+				7080F30B82C53E9D621D85B78B0B465C /* IGListSectionMap.h in Headers */,
+				C171FDB4097450BEDF90D08A275628E3 /* IGListSingleSectionController.h in Headers */,
+				BCEFC1DC0089468111DD45674FA6CF38 /* IGListSupplementaryViewSource.h in Headers */,
+				837263F72812458D17329664715B9E00 /* IGListTransitionDelegate.h in Headers */,
+				BDC091D1C2757D68D3AB5A323A4AFD8E /* IGListUpdatingDelegate.h in Headers */,
+				385487A89C4A821AEEC11A3ECFC021A3 /* IGListWorkingRangeDelegate.h in Headers */,
+				0094D67D82CF064A7A4598D2B1458C42 /* IGListWorkingRangeHandler.h in Headers */,
+				159144DE9AB96730A5314BA992AA7D8A /* IGSystemVersion.h in Headers */,
+				170E95301CA7DE703CAAC56EE0061081 /* NSNumber+IGListDiffable.h in Headers */,
+				2A09094BFB39A6184C10B74746FF7A78 /* NSString+IGListDiffable.h in Headers */,
+				96F95E57CF553C5BBEEEAED9B91B2FAB /* UICollectionView+DebugDescription.h in Headers */,
+				20785A08B96FE648530D7BDFEB0AE7C4 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
+				0CDD22A418A269BE2CF27654D0DDF4A4 /* UICollectionViewLayout+InteractiveReordering.h in Headers */,
+				CB9636D8302B605D7F331306729AFD63 /* UIScrollView+IGListKit.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CC87A5863729939B9033345EE454B341 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -790,89 +862,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8DF20D300CF0694BCF3AB1FD0A3ADF3F /* Pods-IGListKitTodayExample-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F7C0172DC4609B819C483A59E0927771 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B46B92DA6C28CB6F5322747DA7FA9259 /* IGListAdapter+DebugDescription.h in Headers */,
-				C53C3D9ADC9FF6A72B758299182BF2EF /* IGListAdapter+UICollectionView.h in Headers */,
-				69C18F1791460A078F2E7503DF52D3A9 /* IGListAdapter.h in Headers */,
-				083707D4DFB99E435B8AB9E765D21F01 /* IGListAdapterDataSource.h in Headers */,
-				52DE97F84FF8E239C11E6946678B3752 /* IGListAdapterDelegate.h in Headers */,
-				078EE7F0A6C0C05D4ADC51A649E71D8A /* IGListAdapterInternal.h in Headers */,
-				BD9BCBC78D070DFF8403401E12EFD09B /* IGListAdapterMoveDelegate.h in Headers */,
-				CF552B2C48B9493D33F1C7FEB4852AAC /* IGListAdapterPerformanceDelegate.h in Headers */,
-				43BFAA66A206E8A6F9D8301F70B0AE4D /* IGListAdapterProxy.h in Headers */,
-				E8BFE6C8932B728BADACF1C377CC232C /* IGListAdapterUpdateListener.h in Headers */,
-				1E7429F48A1A2FD6C378A301CBC97251 /* IGListAdapterUpdater+DebugDescription.h in Headers */,
-				42F62DDD9364FC4702EABDE4FB168626 /* IGListAdapterUpdater.h in Headers */,
-				CCB60B65002D2605C230376170062394 /* IGListAdapterUpdaterDelegate.h in Headers */,
-				AB3D3CF8A734B837A488538B52411004 /* IGListAdapterUpdaterInternal.h in Headers */,
-				7C29839EB19D7F709F28FED9CB32402D /* IGListArrayUtilsInternal.h in Headers */,
-				A9A9279564936FE0EAF95F89EB0B8AAD /* IGListAssert.h in Headers */,
-				426248B7E67B3A847AF1B1BD2A19A103 /* IGListBatchContext.h in Headers */,
-				7B356E78CB42542D40440815A32AC0D0 /* IGListBatchUpdateData+DebugDescription.h in Headers */,
-				8C567AD1964B194962A00D3E5AD25E27 /* IGListBatchUpdateData.h in Headers */,
-				85360445E5C3E9174495212901A7490D /* IGListBatchUpdates.h in Headers */,
-				558A1592B706959921A3548BF42088F4 /* IGListBatchUpdateState.h in Headers */,
-				2BC5A51D82B86957A3BFC7B16F988040 /* IGListBindable.h in Headers */,
-				D2E724C95E02C007C0C65791B11865FB /* IGListBindingSectionController+DebugDescription.h in Headers */,
-				63BDFADF7142DE39365962DCFDF68E5F /* IGListBindingSectionController.h in Headers */,
-				076D3C5F732E7060BFD8115BE93C5504 /* IGListBindingSectionControllerDataSource.h in Headers */,
-				332DF287144C586ED4D9CE3C2297656B /* IGListBindingSectionControllerSelectionDelegate.h in Headers */,
-				D2198FE4B115B262C08ED2B1164838DA /* IGListCollectionContext.h in Headers */,
-				6B074FAE1C973F3B2FD5A329D8400CF5 /* IGListCollectionScrollingTraits.h in Headers */,
-				E5F12B8EFEBBC571F67F578DC427BF82 /* IGListCollectionView.h in Headers */,
-				08C84BEE894A14E5766B5C50E23274FC /* IGListCollectionViewDelegateLayout.h in Headers */,
-				73E9A9FDB94FB973A3582D675BAF95FF /* IGListCollectionViewLayout.h in Headers */,
-				3A94977553916C52A0235B48111926ED /* IGListCollectionViewLayoutCompatible.h in Headers */,
-				78CAAB972EBDE8B6D7E8EA4C8950177A /* IGListCollectionViewLayoutInternal.h in Headers */,
-				3D1D111DEF3B0541CC0715B8F070075F /* IGListCompatibility.h in Headers */,
-				17DEE94EE7607E6C31C347D1872A83C4 /* IGListDebugger.h in Headers */,
-				2AD3B0BF6A79019B8C6814F242C804D1 /* IGListDebuggingUtilities.h in Headers */,
-				25D85AC1A76829D45B602529486E1703 /* IGListDiff.h in Headers */,
-				92A0098963EEABBCE7891AEF2BBEFEB9 /* IGListDiffable.h in Headers */,
-				369279995C112E3620C3DFF8675BA23B /* IGListDiffKit.h in Headers */,
-				1F1B534348B5B6583D691176D3FA980C /* IGListDisplayDelegate.h in Headers */,
-				C61723062C613D10AE505D7D3C851A3F /* IGListDisplayHandler.h in Headers */,
-				89C9164445EBBEE72A39B233293B1DAC /* IGListExperiments.h in Headers */,
-				216E86A5811F0D2957308B2985C906A1 /* IGListGenericSectionController.h in Headers */,
-				4783C07C11C07427C43BBCC93AC5143C /* IGListIndexPathResult.h in Headers */,
-				3F8CF4DE5BAEBEE19C08579E38BB776C /* IGListIndexPathResultInternal.h in Headers */,
-				EEA0D92EB192DB986DB66AA5371AA45D /* IGListIndexSetResult.h in Headers */,
-				E7F66F981EF91FC8B590E7B75487053B /* IGListIndexSetResultInternal.h in Headers */,
-				6D1F1EC22DF9780694EF665E670E5D1A /* IGListKit-umbrella.h in Headers */,
-				10CF8697DC9BF0D2014652FC30C3DDDC /* IGListKit.h in Headers */,
-				281DEA132034220BBC681103A1AF5CE1 /* IGListMacros.h in Headers */,
-				AE0BD12CEAA45873317AE6718BC8506D /* IGListMoveIndex.h in Headers */,
-				FD153EA9B5A2B8D878F3DEF858A6A3A0 /* IGListMoveIndexInternal.h in Headers */,
-				C4D746E4DD31BF495BAD1E424D3E67CA /* IGListMoveIndexPath.h in Headers */,
-				22D3785E32AAA7E050355166AB53F34E /* IGListMoveIndexPathInternal.h in Headers */,
-				CDCE0F8949FCDA85DCC07A91EA102106 /* IGListReloadDataUpdater.h in Headers */,
-				1F20AAB4355466D60A46BDA391AB86EE /* IGListReloadIndexPath.h in Headers */,
-				B15652D58487B23119F5CD952287BF46 /* IGListScrollDelegate.h in Headers */,
-				3876E9EB11373F8E2EF342CB3691BAED /* IGListSectionController.h in Headers */,
-				B5C62515D6137F11E5EE5A150FA4EEA5 /* IGListSectionControllerInternal.h in Headers */,
-				55D072F3C077B3BF47C2A71295522BD9 /* IGListSectionMap+DebugDescription.h in Headers */,
-				775D3EA9ACADCB1061579432AF46A03A /* IGListSectionMap.h in Headers */,
-				6F0CC3FFAF4600EB5B32D2F997FE9661 /* IGListSingleSectionController.h in Headers */,
-				3FE2AF8CFFF1CBCF2EA692B01FDD7AE1 /* IGListStackedSectionController.h in Headers */,
-				E0F57C7DBAC24D7DC63160DA5812C370 /* IGListStackedSectionControllerInternal.h in Headers */,
-				267F7A5F03290F54BCEFDBF866970EE5 /* IGListSupplementaryViewSource.h in Headers */,
-				B32CD5CBE9F25F88399132223D39EA98 /* IGListTransitionDelegate.h in Headers */,
-				913D28466D2B34E687DC0D9702062054 /* IGListUpdatingDelegate.h in Headers */,
-				FF7E567E457135B97BD182D8C67F75F4 /* IGListWorkingRangeDelegate.h in Headers */,
-				ED5C65077D8311258083BF27DAEDCEC8 /* IGListWorkingRangeHandler.h in Headers */,
-				5C3085AEB7ECFA44C0CBCC574C814C22 /* IGSystemVersion.h in Headers */,
-				512468176AE53D4E243476E371CA6384 /* NSNumber+IGListDiffable.h in Headers */,
-				98FDEA8D5C95BB0DFFDA1B059141FB8E /* NSString+IGListDiffable.h in Headers */,
-				7C3A33BD13E4E4BDBBA2A94219AA452D /* UICollectionView+DebugDescription.h in Headers */,
-				8AA91E8D505AAA0E8B448ABF59CD2E95 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
-				ACBC251FDC68254A12F7D7B8C763095D /* UICollectionViewLayout+InteractiveReordering.h in Headers */,
-				D75260F59B10CAEA2E52C2206EE7B0D3 /* UIScrollView+IGListKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -925,24 +914,6 @@
 			productReference = 84A2CC04EEE310D61FC6E3D34F9C3BD6 /* Pods_IGListKitTodayExample.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C366647750138040A1FC88EBB5DD09AC /* Build configuration list for PBXNativeTarget "IGListKit" */;
-			buildPhases = (
-				F7C0172DC4609B819C483A59E0927771 /* Headers */,
-				ABBF128F194B2FB4D8A05C5ABB597CF1 /* Sources */,
-				C780C0D7293D61AF9802BB06C18CDFAF /* Frameworks */,
-				6E9F3806F5D0148F67879F883C5B86E0 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = IGListKit;
-			productName = IGListKit;
-			productReference = 68037F304CD34327A2ABDB9CBE2FD6A8 /* IGListKit.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		93611D31191964DA2D2AA183EB449C82 /* Pods-IGListKitExamples */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2127B2F15D7575477322E01FD7178098 /* Build configuration list for PBXNativeTarget "Pods-IGListKitExamples" */;
@@ -960,6 +931,24 @@
 			name = "Pods-IGListKitExamples";
 			productName = "Pods-IGListKitExamples";
 			productReference = C29A09B219DE2EED9EDF0036A53C3A32 /* Pods_IGListKitExamples.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 21C367A2A521329E861976AAA8493412 /* Build configuration list for PBXNativeTarget "IGListKit" */;
+			buildPhases = (
+				79D111E9C4E749D733B9F6253B7D48C1 /* Headers */,
+				EE3CBB4D5A202233ACC8C018D87344BC /* Sources */,
+				F30BF0A691E2CFCE72F8CA3B4519B95E /* Frameworks */,
+				871823166F14553A3F7C762DF7008934 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IGListKit;
+			productName = IGListKit;
+			productReference = 68037F304CD34327A2ABDB9CBE2FD6A8 /* IGListKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -983,7 +972,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */,
+				D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */,
 				93611D31191964DA2D2AA183EB449C82 /* Pods-IGListKitExamples */,
 				26D45536448EFA4F707F190447F44A08 /* Pods-IGListKitMessageExample */,
 				7C3EAD0D7BF6995CD855AEE51E566A69 /* Pods-IGListKitTodayExample */,
@@ -1013,7 +1002,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6E9F3806F5D0148F67879F883C5B86E0 /* Resources */ = {
+		871823166F14553A3F7C762DF7008934 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1047,48 +1036,47 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ABBF128F194B2FB4D8A05C5ABB597CF1 /* Sources */ = {
+		EE3CBB4D5A202233ACC8C018D87344BC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C330A515296CBE24A82292B534CECD32 /* IGListAdapter+DebugDescription.m in Sources */,
-				CCF21C54492902F6AB5756105A55777F /* IGListAdapter+UICollectionView.m in Sources */,
-				46C8A5977F015698E3F8441FD78B3815 /* IGListAdapter.m in Sources */,
-				EDFE97C739D7C27EB5DF573623146AE0 /* IGListAdapterProxy.m in Sources */,
-				894295A77D2FE6D08956E31F5E4BEA90 /* IGListAdapterUpdater+DebugDescription.m in Sources */,
-				EB9DE9CECB4E21D81D66C5F80C2D6209 /* IGListAdapterUpdater.m in Sources */,
-				860968484A55F57A2E0160414C601EFC /* IGListBatchUpdateData+DebugDescription.m in Sources */,
-				8ECF5C6225FE112FFBB5E5C0767BE421 /* IGListBatchUpdateData.mm in Sources */,
-				7C9CDAA99E50763C7A7993D6013C3D82 /* IGListBatchUpdates.m in Sources */,
-				AB14E01885528EF9C1895FA1FDCCA52A /* IGListBindingSectionController+DebugDescription.m in Sources */,
-				639D19E840CEE47B8A8CDAE0DD96AD76 /* IGListBindingSectionController.m in Sources */,
-				71AA970A0AB7DF31644D77F84231EEBF /* IGListCollectionView.m in Sources */,
-				35A6013FD8BDA2148972A36AB0ABB8C5 /* IGListCollectionViewLayout.mm in Sources */,
-				AFF9372D26BC23508C305031EF5BD98A /* IGListDebugger.m in Sources */,
-				40E56342CF63845B458EAFCBD66CD14A /* IGListDebuggingUtilities.m in Sources */,
-				78D3337F28EB0D85D3C227CCA1CAC487 /* IGListDiff.mm in Sources */,
-				5D8602CAA6AE82D1560BA27DB004A614 /* IGListDisplayHandler.m in Sources */,
-				194775034FF52A1FF3EE93459DD1AAA8 /* IGListGenericSectionController.m in Sources */,
-				C3B987D343F39BD8AAD53F80B48CC011 /* IGListIndexPathResult.m in Sources */,
-				8A407059D7A86F31421960855E58D4F9 /* IGListIndexSetResult.m in Sources */,
-				FB2987DAC40437D72958533E7B955EF5 /* IGListKit-dummy.m in Sources */,
-				60B47D935CBB717BC0D1E8B47887CD7D /* IGListMoveIndex.m in Sources */,
-				D350E679B53B363E68753893E2ABEA93 /* IGListMoveIndexPath.m in Sources */,
-				E9D5623481C8CB91D32BDE1D78ED40ED /* IGListReloadDataUpdater.m in Sources */,
-				3F9AC999133EF04647D1A660FD61955D /* IGListReloadIndexPath.m in Sources */,
-				339DE064A51B93D31F00ADD08D65232D /* IGListSectionController.m in Sources */,
-				8DDEB77D26E101539FBC32073BCC91BC /* IGListSectionMap+DebugDescription.m in Sources */,
-				CEBECDD6178C3F768D2FF4BD80405BDE /* IGListSectionMap.m in Sources */,
-				81F8452E9117587E205091DE73A80B76 /* IGListSingleSectionController.m in Sources */,
-				D408771CF05B12485C14D5A819D04B43 /* IGListStackedSectionController.m in Sources */,
-				1BA5D4302BBB5DC62D2CF4587FB5D3BE /* IGListWorkingRangeHandler.mm in Sources */,
-				85893A0F1D8732D0D28035E406DAEF5F /* IGSystemVersion.m in Sources */,
-				798199A75C4A7C31E97B38AA4B037C96 /* NSNumber+IGListDiffable.m in Sources */,
-				E06A01FAC1C0F8053DB7F7D5110B1E9E /* NSString+IGListDiffable.m in Sources */,
-				D709E3D33001D8C64533654DFD7A627D /* UICollectionView+DebugDescription.m in Sources */,
-				D6B9D0372AFCFDB89F5B18A96A9CD0B2 /* UICollectionView+IGListBatchUpdateData.m in Sources */,
-				B3D57B439E9CA31E04FD392FEA45209B /* UICollectionViewLayout+InteractiveReordering.m in Sources */,
-				1F327C2BF81FD3A44F3C928E0A2790B4 /* UIScrollView+IGListKit.m in Sources */,
+				8E8B4C9FA06F091842EB606AE8499CCE /* IGListAdapter+DebugDescription.m in Sources */,
+				502EE857A881018E5FD387A6E23A38F0 /* IGListAdapter+UICollectionView.m in Sources */,
+				120E8310162E61C5E350C905BBD0642F /* IGListAdapter.m in Sources */,
+				89EF06907B308D35A992588930244256 /* IGListAdapterProxy.m in Sources */,
+				09FE869D7DF75AED14C5ECBC9BBE0E77 /* IGListAdapterUpdater+DebugDescription.m in Sources */,
+				2EB99C6459645C76EAEDB614B96E8A7F /* IGListAdapterUpdater.m in Sources */,
+				4D5FC94F0F38840B4F4EF0125C28C073 /* IGListBatchUpdateData+DebugDescription.m in Sources */,
+				9010A8434B660C2264AA992949930C32 /* IGListBatchUpdateData.mm in Sources */,
+				2A3BCB64AA8A37F9D5739904743287A8 /* IGListBatchUpdates.m in Sources */,
+				8DEB6A80425E81F141AFA892B539A17A /* IGListBindingSectionController+DebugDescription.m in Sources */,
+				82DB51EE154C7EACF2ECAEA4ACAB7C71 /* IGListBindingSectionController.m in Sources */,
+				9F2A844A340283F45D94389D884EB8C2 /* IGListCollectionView.m in Sources */,
+				B0B9AC8BB0CDE9B87FBB7E2DE4723A06 /* IGListCollectionViewLayout.mm in Sources */,
+				D7F710D485982645AE922C5D6839901F /* IGListDebugger.m in Sources */,
+				44A1CBBE52A752A925DC49D95C78DB10 /* IGListDebuggingUtilities.m in Sources */,
+				304B559EB0E2155CF01FCD80F852CA08 /* IGListDiff.mm in Sources */,
+				1137E7A3F0AE912B05C6C75267B22948 /* IGListDisplayHandler.m in Sources */,
+				359CF0381AF5C7F81C800A6174A2F5A7 /* IGListGenericSectionController.m in Sources */,
+				7337162978A882C23723096E5F4A0E75 /* IGListIndexPathResult.m in Sources */,
+				EAEC3F09A8484F35F7FE3672321E2361 /* IGListIndexSetResult.m in Sources */,
+				924CBB03106BFF159DE0DEC543355B9E /* IGListKit-dummy.m in Sources */,
+				72E4DF6E435AAED14B9C27571DC08FA0 /* IGListMoveIndex.m in Sources */,
+				CEEC931F251E36D412DBFDB798D60F94 /* IGListMoveIndexPath.m in Sources */,
+				1397AE7BC9FA504F98363C065FBC834B /* IGListReloadDataUpdater.m in Sources */,
+				6A1EFB64B94A1F9BB4616092D761C9AF /* IGListReloadIndexPath.m in Sources */,
+				84EDB91D8FEC7B4F430E9483AE203741 /* IGListSectionController.m in Sources */,
+				07BD381C9D8D8AE0B30B9A2497AF58C3 /* IGListSectionMap+DebugDescription.m in Sources */,
+				6D89FDE6F52F9C3191B616E9B0E05DD5 /* IGListSectionMap.m in Sources */,
+				94D1B6BA3DA2B691BB3C07A95A011F01 /* IGListSingleSectionController.m in Sources */,
+				4E3B217C44E988031BF24FAD15FCEDEF /* IGListWorkingRangeHandler.mm in Sources */,
+				02BF2B7603D611AAACC331E2352B590C /* IGSystemVersion.m in Sources */,
+				07B148F761AF9AC40BBC3A463A21ACAF /* NSNumber+IGListDiffable.m in Sources */,
+				6026AC58E181E1A3411CE6E99F01E136 /* NSString+IGListDiffable.m in Sources */,
+				6C62504ABCCD830B5CCB0701657BAAAF /* UICollectionView+DebugDescription.m in Sources */,
+				80C765861733FEB163A4689F40D889E7 /* UICollectionView+IGListBatchUpdateData.m in Sources */,
+				386AD898815E39BB26F3ED97D5F52A0B /* UICollectionViewLayout+InteractiveReordering.m in Sources */,
+				B56F1064287CC0E3B444CE9A3B8EEE70 /* UIScrollView+IGListKit.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1098,19 +1086,19 @@
 		67063A68B34CA90D4E65782EB6E07855 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */;
+			target = D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */;
 			targetProxy = 3CB146CADA5C19602C8D12DDC7D38BDB /* PBXContainerItemProxy */;
 		};
 		9D7A83CCBE42DC893E21B50607D0A5B6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */;
+			target = D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */;
 			targetProxy = ECFCADAB141C83EEB8CC1527E24DFABD /* PBXContainerItemProxy */;
 		};
 		F1D6E5FCA32C05A047D9C46247A845F3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */;
+			target = D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */;
 			targetProxy = 57CA669B239472F35B1A8FB80D4C1B4A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -1210,6 +1198,38 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		27826FC1E0AF264DAE221A672A5EDC85 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5648C76FD3F37647CA0368C4CB65FE49 /* IGListKit.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
+				PRODUCT_MODULE_NAME = IGListKit;
+				PRODUCT_NAME = IGListKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		421ECB1396280A8D83853C3DDBED1700 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1343,39 +1363,6 @@
 			};
 			name = Debug;
 		};
-		6F865FAAD59BF0D1B09FCA07324FB94F /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 22B293012506ACB2C3B45678B518F484 /* IGListKit.xcconfig */;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				PRODUCT_MODULE_NAME = IGListKit;
-				PRODUCT_NAME = IGListKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		83024940D935C1376A0A22C3009B325D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5B2A9D84CA0388C9B26C3475B05ADCD2 /* Pods-IGListKitTodayExample.debug.xcconfig */;
@@ -1444,38 +1431,6 @@
 			};
 			name = Release;
 		};
-		C8444E0098395D2EB4084AA961DC0E13 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 22B293012506ACB2C3B45678B518F484 /* IGListKit.xcconfig */;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				PRODUCT_MODULE_NAME = IGListKit;
-				PRODUCT_NAME = IGListKit;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		F41930C0876A51AE0E90A3B9A70AC765 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5C87C061377DD9791EBC94A0E43BE899 /* Pods-IGListKitMessageExample.debug.xcconfig */;
@@ -1510,6 +1465,39 @@
 			};
 			name = Debug;
 		};
+		FDBC3ADF0F71016CD58DDD5B7A0A692D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5648C76FD3F37647CA0368C4CB65FE49 /* IGListKit.xcconfig */;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
+				PRODUCT_MODULE_NAME = IGListKit;
+				PRODUCT_NAME = IGListKit;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1518,6 +1506,15 @@
 			buildConfigurations = (
 				6F17EA4C8EE160E1A4B126FB8736D0B0 /* Debug */,
 				8E9CA75E73BEAA6EF5BD1F48CCAA0340 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		21C367A2A521329E861976AAA8493412 /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				27826FC1E0AF264DAE221A672A5EDC85 /* Debug */,
+				FDBC3ADF0F71016CD58DDD5B7A0A692D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1536,15 +1533,6 @@
 			buildConfigurations = (
 				83024940D935C1376A0A22C3009B325D /* Debug */,
 				6DF41F0E19EA1A3CD77147B87734E7C0 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		C366647750138040A1FC88EBB5DD09AC /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C8444E0098395D2EB4084AA961DC0E13 /* Debug */,
-				6F865FAAD59BF0D1B09FCA07324FB94F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/Examples-iOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
+++ b/Examples/Examples-iOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
@@ -50,7 +50,6 @@
 #import "IGListScrollDelegate.h"
 #import "IGListSectionController.h"
 #import "IGListSingleSectionController.h"
-#import "IGListStackedSectionController.h"
 #import "IGListSupplementaryViewSource.h"
 #import "IGListTransitionDelegate.h"
 #import "IGListUpdatingDelegate.h"

--- a/Examples/Examples-tvOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Examples/Examples-tvOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,125 +7,122 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		076D3C5F732E7060BFD8115BE93C5504 /* IGListBindingSectionControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AA5FD6A83C251EE1811A9255A497697 /* IGListBindingSectionControllerDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		078EE7F0A6C0C05D4ADC51A649E71D8A /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EE371FDA07F4634A9B1BDB60F935F4 /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		083707D4DFB99E435B8AB9E765D21F01 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A3DCE9B5057E863E71ADAB91B5EA88B /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		08C84BEE894A14E5766B5C50E23274FC /* IGListCollectionViewDelegateLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 574C0496D80A99F9405D469520056267 /* IGListCollectionViewDelegateLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		10CF8697DC9BF0D2014652FC30C3DDDC /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 563DB9FB0110ABD5F4C87BFB3A9C0CA0 /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		17DEE94EE7607E6C31C347D1872A83C4 /* IGListDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = 11F595B6FDC08A260C3FA66A953E514D /* IGListDebugger.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		194775034FF52A1FF3EE93459DD1AAA8 /* IGListGenericSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = B4DFDC546D6C9201470E212F6FEC2D53 /* IGListGenericSectionController.m */; };
-		1BA5D4302BBB5DC62D2CF4587FB5D3BE /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 686854EC36F333525958DAF35D34BAF3 /* IGListWorkingRangeHandler.mm */; };
-		1E7429F48A1A2FD6C378A301CBC97251 /* IGListAdapterUpdater+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E1528C973DD8B2333BD588E38DF9447A /* IGListAdapterUpdater+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1F1B534348B5B6583D691176D3FA980C /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EC7416DD068D1BD076ABFD8DD732577 /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1F20AAB4355466D60A46BDA391AB86EE /* IGListReloadIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = FB11653964C304B24481B1DEFF9879DD /* IGListReloadIndexPath.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		1F327C2BF81FD3A44F3C928E0A2790B4 /* UIScrollView+IGListKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CB2F85056C4C607B6B6E7EC98DB9E84 /* UIScrollView+IGListKit.m */; };
-		216E86A5811F0D2957308B2985C906A1 /* IGListGenericSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 97DBAAAB328E840C239E4BE42CEBE8ED /* IGListGenericSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		22D3785E32AAA7E050355166AB53F34E /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0E48D9F7D3895D5EAF562BAD2DECB4 /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2358C208FD129715EA0D37F93601F9B3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A82C1E897A8CE3E9036D129552382C7 /* Foundation.framework */; };
-		25D85AC1A76829D45B602529486E1703 /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = B70328A2E0A3F72BA82672881851B80B /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		267F7A5F03290F54BCEFDBF866970EE5 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A91B591449672B70EFC34E5DC7FC2DE /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		281DEA132034220BBC681103A1AF5CE1 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E260A0FB8163D90890C8EDCA45255300 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2AD3B0BF6A79019B8C6814F242C804D1 /* IGListDebuggingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 149B4939E2C5274272E5C166A4864E0A /* IGListDebuggingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		2BC5A51D82B86957A3BFC7B16F988040 /* IGListBindable.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A8315EF72DC73C7AB140FD2231C5215 /* IGListBindable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		332DF287144C586ED4D9CE3C2297656B /* IGListBindingSectionControllerSelectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D1460B5DFF0A80A4D7EEFCBE64677FDB /* IGListBindingSectionControllerSelectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		339DE064A51B93D31F00ADD08D65232D /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D4584ED339BB369CAD0DA8FAD40C04 /* IGListSectionController.m */; };
-		35A6013FD8BDA2148972A36AB0ABB8C5 /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3631514648B3D2E10ADD3BBF4C0D9CF7 /* IGListCollectionViewLayout.mm */; };
-		369279995C112E3620C3DFF8675BA23B /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B087726B793A58C6C933D64E562A32D /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3876E9EB11373F8E2EF342CB3691BAED /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = D1C8DDF5BA982C10F975BA827D12F430 /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A94977553916C52A0235B48111926ED /* IGListCollectionViewLayoutCompatible.h in Headers */ = {isa = PBXBuildFile; fileRef = DC60C4B845BC59AE0C874BBC4736F161 /* IGListCollectionViewLayoutCompatible.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3D1D111DEF3B0541CC0715B8F070075F /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 32E967142A67AC34858D39AC29313CCD /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3F8CF4DE5BAEBEE19C08579E38BB776C /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E417CC7E63825AD82FFC0A046DE113C /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		3F9AC999133EF04647D1A660FD61955D /* IGListReloadIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA67A0FFFB778AB24D4DC905BF4CC32 /* IGListReloadIndexPath.m */; };
-		3FE2AF8CFFF1CBCF2EA692B01FDD7AE1 /* IGListStackedSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EAF0CDC4F7D519F26BF3B9567967E13 /* IGListStackedSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40E56342CF63845B458EAFCBD66CD14A /* IGListDebuggingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 36D0FE4A81CF9AA5B8D3D54D66E76780 /* IGListDebuggingUtilities.m */; };
-		426248B7E67B3A847AF1B1BD2A19A103 /* IGListBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = C69FDA626A5D4AAB26BF806565E138D1 /* IGListBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		42F62DDD9364FC4702EABDE4FB168626 /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 26C78D8E281288D5585AA3A4FB5AC507 /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43BFAA66A206E8A6F9D8301F70B0AE4D /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5979137B9E523F7C3E8CE418F45740F2 /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		46C8A5977F015698E3F8441FD78B3815 /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D2637E8C35C5982C271EC7753E0B648 /* IGListAdapter.m */; };
-		4783C07C11C07427C43BBCC93AC5143C /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 0570D4B23B361A7D9CD610DBE3EB4B90 /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		512468176AE53D4E243476E371CA6384 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 82ED09E1C96818B56F1098DB0AC949A8 /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		52DE97F84FF8E239C11E6946678B3752 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E790A45A397CAC4AD5FD6D403F6AAAD /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		558A1592B706959921A3548BF42088F4 /* IGListBatchUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = B7C194B0F679AAC42180BAB3B6EA175C /* IGListBatchUpdateState.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		55D072F3C077B3BF47C2A71295522BD9 /* IGListSectionMap+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EB707861AB65F4AC265978084BFBF17 /* IGListSectionMap+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5C3085AEB7ECFA44C0CBCC574C814C22 /* IGSystemVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 69A3121145912B37F42400B9368F3C64 /* IGSystemVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		5D8602CAA6AE82D1560BA27DB004A614 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = A1D7E38A7D2088C4862F42F97C853C9E /* IGListDisplayHandler.m */; };
-		60B47D935CBB717BC0D1E8B47887CD7D /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = BA324DBA4D116701215F00F1D442031E /* IGListMoveIndex.m */; };
-		639D19E840CEE47B8A8CDAE0DD96AD76 /* IGListBindingSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = DFD0F67723798B582076129F6566AA6C /* IGListBindingSectionController.m */; };
-		63BDFADF7142DE39365962DCFDF68E5F /* IGListBindingSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 883A820D9F5DBA472227193B19842D13 /* IGListBindingSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		64A69C2F83921103D2159FA323209EE3 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05F171BFF248A0DC7ECF84240D012266 /* UIKit.framework */; };
-		69C18F1791460A078F2E7503DF52D3A9 /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 43E27A2AF52114A34151624E40F01224 /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6B074FAE1C973F3B2FD5A329D8400CF5 /* IGListCollectionScrollingTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 41ECAE5C3A5838272DE3E6050568CF75 /* IGListCollectionScrollingTraits.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D1F1EC22DF9780694EF665E670E5D1A /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2420CE41964AFD3450CEEB4EC6AFDF86 /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6F0CC3FFAF4600EB5B32D2F997FE9661 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A5F144990E42E7E7F98054A3BD913C /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		71AA970A0AB7DF31644D77F84231EEBF /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AFADD9F5188146104C26AC277B8994D /* IGListCollectionView.m */; };
-		73E9A9FDB94FB973A3582D675BAF95FF /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = 83279AD01B1A458091ED0813A6955E94 /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		775D3EA9ACADCB1061579432AF46A03A /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 01A8E0CE6A5FEDF0D5397E9D892D4BB4 /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		78CAAB972EBDE8B6D7E8EA4C8950177A /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B80EE0AB5DBEB727B920BB3C6F57759 /* IGListCollectionViewLayoutInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		78D3337F28EB0D85D3C227CCA1CAC487 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = B512206520F88C251E446BA93F7EE7FF /* IGListDiff.mm */; };
-		798199A75C4A7C31E97B38AA4B037C96 /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 35DD6A7BFAD9E6B98EAD5076384F9081 /* NSNumber+IGListDiffable.m */; };
-		7B356E78CB42542D40440815A32AC0D0 /* IGListBatchUpdateData+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = E0B0E3300CB46F0E146E93C537AE6763 /* IGListBatchUpdateData+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7C29839EB19D7F709F28FED9CB32402D /* IGListArrayUtilsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F3CDC354267668792E43CBED92D2D80F /* IGListArrayUtilsInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7C3A33BD13E4E4BDBBA2A94219AA452D /* UICollectionView+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 62694290E98BA20397F838188E9EF8A6 /* UICollectionView+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		7C9CDAA99E50763C7A7993D6013C3D82 /* IGListBatchUpdates.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C46504759494FD1C69FC7D25DBCAA74 /* IGListBatchUpdates.m */; };
-		81F8452E9117587E205091DE73A80B76 /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = F95771ACD4A92ADD45F2C7007212A805 /* IGListSingleSectionController.m */; };
-		85360445E5C3E9174495212901A7490D /* IGListBatchUpdates.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F3751B73FEB5E127AA62659AE62B93E /* IGListBatchUpdates.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		85893A0F1D8732D0D28035E406DAEF5F /* IGSystemVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 23DCD2B28629A40D0D57AD92F7636F19 /* IGSystemVersion.m */; };
-		860968484A55F57A2E0160414C601EFC /* IGListBatchUpdateData+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E14008BBAC83E53CA444F44989DB052 /* IGListBatchUpdateData+DebugDescription.m */; };
-		894295A77D2FE6D08956E31F5E4BEA90 /* IGListAdapterUpdater+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B17BB62A86153D50181B3AABB05895 /* IGListAdapterUpdater+DebugDescription.m */; };
-		89C9164445EBBEE72A39B233293B1DAC /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AD55BAAC438E3FDE5AF6BFE90EFE713 /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8A407059D7A86F31421960855E58D4F9 /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EAFB73895317F9A670C6DEAA39E2EB8 /* IGListIndexSetResult.m */; };
-		8AA91E8D505AAA0E8B448ABF59CD2E95 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD51DEB8E118A7ABBB4A895A47798A5 /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		8C567AD1964B194962A00D3E5AD25E27 /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = 62C291DAA7F2B9D281E999B4878BC582 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8DDEB77D26E101539FBC32073BCC91BC /* IGListSectionMap+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF5955A637E241EA5C4876D38D58C2A /* IGListSectionMap+DebugDescription.m */; };
-		8ECF5C6225FE112FFBB5E5C0767BE421 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = FEB4BCCAC44453E24732E5EF11DCAF7D /* IGListBatchUpdateData.mm */; };
-		913D28466D2B34E687DC0D9702062054 /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A60A116EF7A80CCF65D693A01AA64E9 /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		92A0098963EEABBCE7891AEF2BBEFEB9 /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E9E077E7E1A733778A42E0E0CCC0A45 /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		98FDEA8D5C95BB0DFFDA1B059141FB8E /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 033080E7DAE490140BABD859A77CD09D /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A9A9279564936FE0EAF95F89EB0B8AAD /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = B33A467275A5EE43F8C330E9185FBA6D /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB14E01885528EF9C1895FA1FDCCA52A /* IGListBindingSectionController+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = E8D916232B7570E68F8F5C12982E9041 /* IGListBindingSectionController+DebugDescription.m */; };
-		AB3D3CF8A734B837A488538B52411004 /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3122453D86AC5041C5F290B1DE9E7F /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		ACBC251FDC68254A12F7D7B8C763095D /* UICollectionViewLayout+InteractiveReordering.h in Headers */ = {isa = PBXBuildFile; fileRef = 24C30F79A131EEFB0194BE5C976F593C /* UICollectionViewLayout+InteractiveReordering.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		AE0BD12CEAA45873317AE6718BC8506D /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E9BB6D359B6DECF013E01A04A18FAE4 /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AFF9372D26BC23508C305031EF5BD98A /* IGListDebugger.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B90263B5A843B3DC09B13569F3CF91 /* IGListDebugger.m */; };
-		B15652D58487B23119F5CD952287BF46 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = BFBCBB4200399BD318EF408096C885EB /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B32CD5CBE9F25F88399132223D39EA98 /* IGListTransitionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FB64D7270DB5AA0DD15A428602BA72B /* IGListTransitionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B3D57B439E9CA31E04FD392FEA45209B /* UICollectionViewLayout+InteractiveReordering.m in Sources */ = {isa = PBXBuildFile; fileRef = D46C8AB1244310CBF9D05EA5C7254514 /* UICollectionViewLayout+InteractiveReordering.m */; };
-		B46B92DA6C28CB6F5322747DA7FA9259 /* IGListAdapter+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8629172752FCE2589FB8572BAA7314 /* IGListAdapter+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		B5C62515D6137F11E5EE5A150FA4EEA5 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 743FE50E582F13629065E9E3D173F5B1 /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		BD9BCBC78D070DFF8403401E12EFD09B /* IGListAdapterMoveDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 23DCBFCE667AB8405F67973A03E4480E /* IGListAdapterMoveDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C330A515296CBE24A82292B534CECD32 /* IGListAdapter+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DC19D5B3BAE9CC18FF49A7D5C8B6702 /* IGListAdapter+DebugDescription.m */; };
-		C3B987D343F39BD8AAD53F80B48CC011 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F4DECCF61780200270778DF515EC496A /* IGListIndexPathResult.m */; };
-		C4D746E4DD31BF495BAD1E424D3E67CA /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 489D58E145A8814DCFC8193EA5C2E876 /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C53C3D9ADC9FF6A72B758299182BF2EF /* IGListAdapter+UICollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CA8ED4A030F88933A2F29E8C38B96A0 /* IGListAdapter+UICollectionView.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		C61723062C613D10AE505D7D3C851A3F /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C5CA2A546B17646539BCD8DFB4938F7 /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		CCB60B65002D2605C230376170062394 /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 008E078085E5CBACBF071FC95E37A05B /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CCF21C54492902F6AB5756105A55777F /* IGListAdapter+UICollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BA4C6C4059F3CBF35BE7786CE660F1B /* IGListAdapter+UICollectionView.m */; };
-		CDCE0F8949FCDA85DCC07A91EA102106 /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 3425853BBD44F3961F19B71D7B8B6C79 /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CEBECDD6178C3F768D2FF4BD80405BDE /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C1A62CC27BF00BA7B6959F7C6AD01C1 /* IGListSectionMap.m */; };
-		CF552B2C48B9493D33F1C7FEB4852AAC /* IGListAdapterPerformanceDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 23D8B546152A3EC32AF19CA7D5D07B8A /* IGListAdapterPerformanceDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D2198FE4B115B262C08ED2B1164838DA /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F9036766D2AE85DD0A0A7A0D2323CB09 /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D2E724C95E02C007C0C65791B11865FB /* IGListBindingSectionController+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 415174E37372C679DCAA9449AD7B7256 /* IGListBindingSectionController+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		D350E679B53B363E68753893E2ABEA93 /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CCED269E2E7BC03D5CD1D53573DDDDB /* IGListMoveIndexPath.m */; };
-		D408771CF05B12485C14D5A819D04B43 /* IGListStackedSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 26952F184BB0B349D3CA073AA7B22FD7 /* IGListStackedSectionController.m */; };
-		D6B9D0372AFCFDB89F5B18A96A9CD0B2 /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = 2636800EBE1C3FB2ED2270629F17685A /* UICollectionView+IGListBatchUpdateData.m */; };
-		D709E3D33001D8C64533654DFD7A627D /* UICollectionView+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A941D2316F957BD7FE9D0C602768F1 /* UICollectionView+DebugDescription.m */; };
-		D75260F59B10CAEA2E52C2206EE7B0D3 /* UIScrollView+IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 68A7E11525116AE5E46B9D018450447C /* UIScrollView+IGListKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0094D67D82CF064A7A4598D2B1458C42 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C978E2D79271335866B7D0DD0582F1 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0140E79E9A78DCC82A9E0499D6D505A4 /* IGListMoveIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 868BF8C95FF47E5C246B00599DF42516 /* IGListMoveIndexPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		02BF2B7603D611AAACC331E2352B590C /* IGSystemVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = B0FFAA09371EBE42012FDE64C925C73A /* IGSystemVersion.m */; };
+		050CB37AEE76ECE3542C348937096F72 /* IGListAdapterUpdaterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A8FF58A75C0FC925FB853C2EB6AAD781 /* IGListAdapterUpdaterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07B148F761AF9AC40BBC3A463A21ACAF /* NSNumber+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F9E4628465A178BBD0D363303492D76 /* NSNumber+IGListDiffable.m */; };
+		07BD381C9D8D8AE0B30B9A2497AF58C3 /* IGListSectionMap+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = DB895118AD753C2EFCDD6A73FD4A745A /* IGListSectionMap+DebugDescription.m */; };
+		0927D0B030275F5F0AA4D5BFC98C5C24 /* IGListCollectionContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 29F4E9770C067D926E6339A319F1BC13 /* IGListCollectionContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		09FE869D7DF75AED14C5ECBC9BBE0E77 /* IGListAdapterUpdater+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 7610BD2A59929BFCE2043AC2CD3CE1D8 /* IGListAdapterUpdater+DebugDescription.m */; };
+		0CDD22A418A269BE2CF27654D0DDF4A4 /* UICollectionViewLayout+InteractiveReordering.h in Headers */ = {isa = PBXBuildFile; fileRef = F9D07B7E789DE06B7A7AA4A9F45A975E /* UICollectionViewLayout+InteractiveReordering.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1137E7A3F0AE912B05C6C75267B22948 /* IGListDisplayHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = F773D18ABAE135A6E1D5D76A698EA10D /* IGListDisplayHandler.m */; };
+		120E8310162E61C5E350C905BBD0642F /* IGListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 752E3E997F94B90A778D42712A3F2E81 /* IGListAdapter.m */; };
+		1282117007BC677B95A4CF52D2257565 /* IGListAdapter+UICollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F105B8CF11E614C103B34A54D9E51F3 /* IGListAdapter+UICollectionView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1397AE7BC9FA504F98363C065FBC834B /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 16C154D66B7A4B1B7BD647A97E5ADB91 /* IGListReloadDataUpdater.m */; };
+		159144DE9AB96730A5314BA992AA7D8A /* IGSystemVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D5879AF5DFBA075134C34FA0BE32085 /* IGSystemVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		170E95301CA7DE703CAAC56EE0061081 /* NSNumber+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FAB28975EFFE2099E46F6F6B54C1C76 /* NSNumber+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		20785A08B96FE648530D7BDFEB0AE7C4 /* UICollectionView+IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = FDE51513C020EFFAD2A183A146732FBC /* UICollectionView+IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A09094BFB39A6184C10B74746FF7A78 /* NSString+IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E31CDC469669B8E02481E1B11FFBFFF /* NSString+IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2A3BCB64AA8A37F9D5739904743287A8 /* IGListBatchUpdates.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F9FDCCADB974D16C0188511D9299907 /* IGListBatchUpdates.m */; };
+		2EB99C6459645C76EAEDB614B96E8A7F /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC2095FF630C62E3CDC81ADDE44AA2D /* IGListAdapterUpdater.m */; };
+		304B559EB0E2155CF01FCD80F852CA08 /* IGListDiff.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6669E8CF240CABC4EF87825FC327953F /* IGListDiff.mm */; };
+		328119A6B5C29D0E167DD4BB2D4B8815 /* IGListMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = DC04ED9FAC8E1E1434224647DC5C4720 /* IGListMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		359CF0381AF5C7F81C800A6174A2F5A7 /* IGListGenericSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = BA17F8C5B6E033DAFA1F70CF53CCA68B /* IGListGenericSectionController.m */; };
+		369C7F203DAF3C82297169F7A76F2898 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D838450F8E0D164349A3470C9346DF90 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3713990BA33D5B668C51C9BC030FFAF2 /* IGListBindingSectionControllerDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = FBC96DA29603138BAEBE8AF60B8F48F9 /* IGListBindingSectionControllerDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		385487A89C4A821AEEC11A3ECFC021A3 /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D70EE9B7CECF23985B790A3823D98355 /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		386AD898815E39BB26F3ED97D5F52A0B /* UICollectionViewLayout+InteractiveReordering.m in Sources */ = {isa = PBXBuildFile; fileRef = D6940BBB133FD96832217E7DC50F5CD8 /* UICollectionViewLayout+InteractiveReordering.m */; };
+		39E96236BA4786C17E251772B00FC9D5 /* IGListAdapterProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5259ADD1BE816E14314F2FECB0BC5894 /* IGListAdapterProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3E2924EBCF6D645982DD9872C75329C3 /* IGListCollectionScrollingTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = FF7643D43E87E259550779FD70DD2797 /* IGListCollectionScrollingTraits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		407343653DCC836D08B1A2FB99194E07 /* IGListBatchUpdateData.h in Headers */ = {isa = PBXBuildFile; fileRef = EB01BBE6A6391233013E1108EFDF78B9 /* IGListBatchUpdateData.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		414D775738722A317B00BD8546A4C593 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05F171BFF248A0DC7ECF84240D012266 /* UIKit.framework */; };
+		436DE67F0C1A1EE7ADD1A104D19783DC /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 37B4EF0DB0FFA8A36C8B575B3B927920 /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		44A1CBBE52A752A925DC49D95C78DB10 /* IGListDebuggingUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = C610821FDDA6D2231D085843FC6DC242 /* IGListDebuggingUtilities.m */; };
+		479781E2935028998C7016CFEBBC37C3 /* IGListGenericSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B5EC58E30A22BC07F49E583FF13DC38 /* IGListGenericSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4A86719B3012A63F47DD316DFA63D67B /* IGListKit-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C8BE0DE56665816514B7B4714532123 /* IGListKit-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4B62113EF5872F1B7752C955DEF03E35 /* IGListDebuggingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = E5CCCBBF2E6F6EF9FCFB67E955E7C68B /* IGListDebuggingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4C04FC1C6AA89AB03E1703184E79245F /* IGListReloadDataUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F8A668E9712C40062603117B03A22EE /* IGListReloadDataUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D5FC94F0F38840B4F4EF0125C28C073 /* IGListBatchUpdateData+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 71AD5B51808292764E22529D74D7318B /* IGListBatchUpdateData+DebugDescription.m */; };
+		4DA167EA9BD179605B00005E81582825 /* IGListSectionMap+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 729FFC51BA0A0B13C6F1A9FDC0D4C343 /* IGListSectionMap+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4E3B217C44E988031BF24FAD15FCEDEF /* IGListWorkingRangeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0C2D1A66F9E1F55FD874F70560B0D8DF /* IGListWorkingRangeHandler.mm */; };
+		50202E0D9BA01738C86218DE29F79FB2 /* IGListSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 860541A2716D9453C1A7EEEA2A131B31 /* IGListSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		502EE857A881018E5FD387A6E23A38F0 /* IGListAdapter+UICollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = E73BC32AA0F76C800E8908A6B3C42790 /* IGListAdapter+UICollectionView.m */; };
+		543E895A12B5E4989593120AC9272064 /* IGListAdapterDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = F0D36A5433BCC619E63BE6F74BD13E7D /* IGListAdapterDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		565010349B072FD721B750E287779F29 /* IGListScrollDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B0CF85D82A0634F8DA990F797B18BC33 /* IGListScrollDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5938F6A23F345135DB251AC12D2C9CB0 /* IGListBatchUpdateState.h in Headers */ = {isa = PBXBuildFile; fileRef = 012B3E1C5626CDF6C32CBCA8E14D5FE0 /* IGListBatchUpdateState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		5C1B34C156605E407A0F6DE20FD9AE9E /* IGListBatchUpdates.h in Headers */ = {isa = PBXBuildFile; fileRef = 44C6BA16AEAE34F42C7B57D7090CEBBF /* IGListBatchUpdates.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6026AC58E181E1A3411CE6E99F01E136 /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = C3690084CC7B9A8C0858FC685851FDBE /* NSString+IGListDiffable.m */; };
+		60C252DEA16FA0201AE31B7A516DA2D7 /* IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D8B3B7637451F48B7CD12B966F1A9F1B /* IGListKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60CBAC6C6F4E286D7256D79B1B2AE0C3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A82C1E897A8CE3E9036D129552382C7 /* Foundation.framework */; };
+		65D8D6778D494967E8D1857E33EB06B2 /* IGListIndexPathResult.h in Headers */ = {isa = PBXBuildFile; fileRef = AC663AEDA4088C8FB5BF939E922768B4 /* IGListIndexPathResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		66F3C1A0EA3BB9007A18C3671A707474 /* IGListMoveIndexPathInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EF251C87925E981E746A6B4FD99B0C2E /* IGListMoveIndexPathInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		6A1EFB64B94A1F9BB4616092D761C9AF /* IGListReloadIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ACC254639EE1A7602BF41F25EED9E01 /* IGListReloadIndexPath.m */; };
+		6C62504ABCCD830B5CCB0701657BAAAF /* UICollectionView+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 302A71A00989DD5368033503C0549E02 /* UICollectionView+DebugDescription.m */; };
+		6D89FDE6F52F9C3191B616E9B0E05DD5 /* IGListSectionMap.m in Sources */ = {isa = PBXBuildFile; fileRef = BBAA828E8BFDA9BF14A22C98D2B135FE /* IGListSectionMap.m */; };
+		6DD73C34CC787C0D145CA6E408EF42F1 /* IGListCollectionViewLayoutInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9FA9E9A57FEDD3BD8F51E5116C7555 /* IGListCollectionViewLayoutInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		7080F30B82C53E9D621D85B78B0B465C /* IGListSectionMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 106CA0425A27F3F8C12A3A23317460BF /* IGListSectionMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		72CCC85E803626A6E85AE3249A918510 /* IGListAdapterUpdater.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C11715F41C45CBCE595C680B3994B3A /* IGListAdapterUpdater.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72E4DF6E435AAED14B9C27571DC08FA0 /* IGListMoveIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 30400241FAEEEDF2758E249F39157FB1 /* IGListMoveIndex.m */; };
+		7337162978A882C23723096E5F4A0E75 /* IGListIndexPathResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F6BBABD2DF0B6D7F6092794BD317D27 /* IGListIndexPathResult.m */; };
+		786E49A8F53ED48AEB69D807A208853B /* IGListReloadIndexPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DCAF230EF43E174D67434F83EAFBE02 /* IGListReloadIndexPath.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		80C765861733FEB163A4689F40D889E7 /* UICollectionView+IGListBatchUpdateData.m in Sources */ = {isa = PBXBuildFile; fileRef = 57DD564F20A17DD50E7EBC3A411202F9 /* UICollectionView+IGListBatchUpdateData.m */; };
+		82DB51EE154C7EACF2ECAEA4ACAB7C71 /* IGListBindingSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D4FBF9B44F1D1C527E59932D8CEB24C /* IGListBindingSectionController.m */; };
+		835F8A26E9D9ED7B28B1A5A8E720D8A5 /* IGListCollectionViewLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = A4BEBBE604D583277C35FB3F47AD0A03 /* IGListCollectionViewLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		837263F72812458D17329664715B9E00 /* IGListTransitionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 27C15DF7E700F07C9797E799F2D5FAF0 /* IGListTransitionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		842C3167B5F677583A4EB995A0AB9144 /* IGListDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = EE5E35F9A82E6D39139EC34031D831CD /* IGListDebugger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		84EDB91D8FEC7B4F430E9483AE203741 /* IGListSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = E1EEF85288E2EE4836942CECBB0428A0 /* IGListSectionController.m */; };
+		87703E311264E96792C69BA3B11A7A8D /* IGListDiffKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 378ED14285D196EA7607F251FC48E4D0 /* IGListDiffKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		89EF06907B308D35A992588930244256 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = CD7E1029929FE53C957D372E0BEBE005 /* IGListAdapterProxy.m */; };
+		8C381DB929831D42ADFA58031B0111CD /* IGListDisplayHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 10FA7756E5D4FC447ECBD9B3BDCD08DA /* IGListDisplayHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8DEB6A80425E81F141AFA892B539A17A /* IGListBindingSectionController+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = D4EF7437C981623A3B293E902588C06B /* IGListBindingSectionController+DebugDescription.m */; };
+		8E8B4C9FA06F091842EB606AE8499CCE /* IGListAdapter+DebugDescription.m in Sources */ = {isa = PBXBuildFile; fileRef = 33634685462FB991AB3FD49B80DC454F /* IGListAdapter+DebugDescription.m */; };
+		9010A8434B660C2264AA992949930C32 /* IGListBatchUpdateData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9524B68D686F4353973DFF7F69401316 /* IGListBatchUpdateData.mm */; };
+		91B9729085E3DFFF6A2493C75D946344 /* IGListAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = BFA4624CE7818123F4F26FB1C46D9F3F /* IGListAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		921B146558C8ABF2838644BE0995FE9D /* IGListAdapter+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 1964F22A392BA4DCD1169B3E45451A66 /* IGListAdapter+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		924CBB03106BFF159DE0DEC543355B9E /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F37A7E042B9E7B824C1B2299628EA6D /* IGListKit-dummy.m */; };
+		940829814B26541CB202AF8F1BE1F6DA /* IGListExperiments.h in Headers */ = {isa = PBXBuildFile; fileRef = 7F812141078FAC52E986C6BCD1A92B4F /* IGListExperiments.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94D1B6BA3DA2B691BB3C07A95A011F01 /* IGListSingleSectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 41C2ABF2EC14D10E3DD732632E7317AC /* IGListSingleSectionController.m */; };
+		96F95E57CF553C5BBEEEAED9B91B2FAB /* UICollectionView+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 045A80642FC43FBA50FBC69FF1CDF318 /* UICollectionView+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		9AE5EFDE583ACD4786CF07074474B00D /* IGListSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BA48420AC58C6C0DB94318D18A8E8AF /* IGListSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9B6A75415BEF5385B5C3D382B1763A0B /* IGListAdapterUpdaterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DC901EB33E7C79EF784C4FE484616A92 /* IGListAdapterUpdaterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9D28FB3BC158D10F2D39688D02EB8DD2 /* IGListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = 0771E2085846501017113531E195A21A /* IGListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9F2A844A340283F45D94389D884EB8C2 /* IGListCollectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = DB9F626C5894ADA202AB1DC2DAAB464B /* IGListCollectionView.m */; };
+		A6F4826056A25D8BA1510E4F9C145841 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BA734B0125D1B7290396F40B2800E39 /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A9E893D7A41C4582B1D87D1B03671A2B /* IGListBindingSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FCD809B23AC7F8E26AB4E3021AE84CB /* IGListBindingSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B0B9AC8BB0CDE9B87FBB7E2DE4723A06 /* IGListCollectionViewLayout.mm in Sources */ = {isa = PBXBuildFile; fileRef = C84C85F00F04CBDCB4B88A6AF39815CF /* IGListCollectionViewLayout.mm */; };
+		B0BA766330939CD91E034BD23BA0F030 /* IGListIndexPathResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = BF5C82FE9F82ECABD06498FCDBF2902B /* IGListIndexPathResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B25C040E31E7B1BF90B87B1152A19D0C /* IGListDisplayDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = D22847B3CDED5FB0E35212C5397ABB95 /* IGListDisplayDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B56F1064287CC0E3B444CE9A3B8EEE70 /* UIScrollView+IGListKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 389AD9B267953379243C7F2113074234 /* UIScrollView+IGListKit.m */; };
+		B5FBE3FD9252B5AB8A13AE29BA9F7735 /* IGListAdapterMoveDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 451ED9B182FA7882083A4E0E7697D10E /* IGListAdapterMoveDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B6430BBDD033522F9563BF53B299937B /* IGListDiffable.h in Headers */ = {isa = PBXBuildFile; fileRef = E77509DC901BF91356013B155D5E526E /* IGListDiffable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BCEFC1DC0089468111DD45674FA6CF38 /* IGListSupplementaryViewSource.h in Headers */ = {isa = PBXBuildFile; fileRef = DBDD45BA9A4EEB0980889C51FDAFEC03 /* IGListSupplementaryViewSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BDC091D1C2757D68D3AB5A323A4AFD8E /* IGListUpdatingDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 44B2020520F57C4D260E6C653E5DFFBB /* IGListUpdatingDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C171FDB4097450BEDF90D08A275628E3 /* IGListSingleSectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E611DD892F73D0174581C3D304EBB5 /* IGListSingleSectionController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C92D69E1A5C840EFA261D5BE92D0B665 /* IGListBindingSectionControllerSelectionDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FA51D190E02BCE46AB238C76FD7C7B4 /* IGListBindingSectionControllerSelectionDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB9636D8302B605D7F331306729AFD63 /* UIScrollView+IGListKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A8A3B78D4AB97C97C29414E37A74F24 /* UIScrollView+IGListKit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CEEC931F251E36D412DBFDB798D60F94 /* IGListMoveIndexPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 35ABBAEDC37A4EC6DD0A4E9D2361A744 /* IGListMoveIndexPath.m */; };
+		D075D5B1D729FBD5D467B9247B36EAD7 /* IGListCompatibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 3EC204B851CACE33D675EC91C3A8D84E /* IGListCompatibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D5C431990C04DDD62B11DDA8E66B824C /* IGListCollectionViewLayoutCompatible.h in Headers */ = {isa = PBXBuildFile; fileRef = 3BF9436F51B58C6EEF41CF905A8B9075 /* IGListCollectionViewLayoutCompatible.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D7F710D485982645AE922C5D6839901F /* IGListDebugger.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D21D3A338001C9842D2B1616BDF632 /* IGListDebugger.m */; };
 		D90781179CA274125422700EC52D0C79 /* Pods-IGListKitExamples-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24989CFBCEDBB59574A81E4052A4DC14 /* Pods-IGListKitExamples-dummy.m */; };
+		D976B548E97A8472DD03C110D5840C87 /* IGListMoveIndex.h in Headers */ = {isa = PBXBuildFile; fileRef = 990F7D79A031CB4C220D4B5C547BB059 /* IGListMoveIndex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC490E762CE343241684A362B9D5FDE6 /* Pods-IGListKitExamples-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D2C03B63D2966A9E53EB08E12B34D2A9 /* Pods-IGListKitExamples-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E06A01FAC1C0F8053DB7F7D5110B1E9E /* NSString+IGListDiffable.m in Sources */ = {isa = PBXBuildFile; fileRef = 188D8DE4C52A4752D518B64EE7B26DE7 /* NSString+IGListDiffable.m */; };
-		E0F57C7DBAC24D7DC63160DA5812C370 /* IGListStackedSectionControllerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 79B6F9B2C0B438C85E50BFBEA5396800 /* IGListStackedSectionControllerInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E5F12B8EFEBBC571F67F578DC427BF82 /* IGListCollectionView.h in Headers */ = {isa = PBXBuildFile; fileRef = 860CCB618D514D62DAD8916E53A937E1 /* IGListCollectionView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E7F66F981EF91FC8B590E7B75487053B /* IGListIndexSetResultInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = EB7C63E83A0B28810376DFFD8774AEA4 /* IGListIndexSetResultInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		E8BFE6C8932B728BADACF1C377CC232C /* IGListAdapterUpdateListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BB9E2672FD3F3529F9C80E3642BBD51 /* IGListAdapterUpdateListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E9D5623481C8CB91D32BDE1D78ED40ED /* IGListReloadDataUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = 3248F2BEFAD4A9B5D4607820B7A7417B /* IGListReloadDataUpdater.m */; };
-		EB9DE9CECB4E21D81D66C5F80C2D6209 /* IGListAdapterUpdater.m in Sources */ = {isa = PBXBuildFile; fileRef = C051E1AFD1CC4F94690E2E02A3B394FF /* IGListAdapterUpdater.m */; };
-		ED5C65077D8311258083BF27DAEDCEC8 /* IGListWorkingRangeHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8972E1F0B57B0CC62B46737A66514188 /* IGListWorkingRangeHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		EDFE97C739D7C27EB5DF573623146AE0 /* IGListAdapterProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 756C605CCA981182AF18EF2E9C83313E /* IGListAdapterProxy.m */; };
-		EEA0D92EB192DB986DB66AA5371AA45D /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 798F1F6F8FC5CE54BDDCD8740F3A6E5C /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DFBAE4FD38CA5B58A0C156DED6D1C701 /* IGListBatchContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 97526A171526748F051CBFD68F2EF9B4 /* IGListBatchContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E588EB6372FB13A5CA9B6ACD668E6935 /* IGListIndexSetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 83210F59EEEFBB281964DA57C76D5DC2 /* IGListIndexSetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E870D65E97CFAEB3539758BB9FA0E21E /* IGListBindingSectionController+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = CEBD27C8A40F0A06F44656CA39F0E012 /* IGListBindingSectionController+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EAEC3F09A8484F35F7FE3672321E2361 /* IGListIndexSetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = B22042E362E658FE617639CD3B7C796D /* IGListIndexSetResult.m */; };
+		EC480E1CF76B2A831A24F0B9EA07DA85 /* IGListAdapterPerformanceDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 72AF28C067D1C890CD4152B2B289F637 /* IGListAdapterPerformanceDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ECDC0BB3D3F98877AF8562A597899A35 /* IGListAdapterInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = C188D91462C16F01A3E02F212B08E003 /* IGListAdapterInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EFBDE12C77935B722442BB23A4DDDB75 /* IGListCollectionViewDelegateLayout.h in Headers */ = {isa = PBXBuildFile; fileRef = E5B49DC88986D4C7C6BF583F1629DF54 /* IGListCollectionViewDelegateLayout.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F1344FCB2E4119A707F82DCF02B1AAFF /* IGListArrayUtilsInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 007F0F773689E30244859FE3804C081B /* IGListArrayUtilsInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F20FD96E6EBAF2BCE079A1B391EB6605 /* IGListAdapterUpdater+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = 26089596EEC9E2C7B0581E87FE581733 /* IGListAdapterUpdater+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F2568F0CB73D4BDCA314C8125D36F364 /* IGListAssert.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C53C036466D56700A861DC6AEB03596 /* IGListAssert.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7848580913315C3193E0CADB4BABB9A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A82C1E897A8CE3E9036D129552382C7 /* Foundation.framework */; };
-		FB2987DAC40437D72958533E7B955EF5 /* IGListKit-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B1E20FD3534F921890EC04B5037C00DA /* IGListKit-dummy.m */; };
-		FD153EA9B5A2B8D878F3DEF858A6A3A0 /* IGListMoveIndexInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D96310E4479763D45D35DCF2803D63F4 /* IGListMoveIndexInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FF7E567E457135B97BD182D8C67F75F4 /* IGListWorkingRangeDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AFB8CAB7342FB0B45FC211C8D6BD8AF /* IGListWorkingRangeDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F80F75C42FD5B327999F711986A2851F /* IGListBatchUpdateData+DebugDescription.h in Headers */ = {isa = PBXBuildFile; fileRef = D32926E306D69EB82C2A08352B12C459 /* IGListBatchUpdateData+DebugDescription.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FA49227F4FF92FB7205D8ED3984DAE2C /* IGListBindable.h in Headers */ = {isa = PBXBuildFile; fileRef = AD40AB3041240ECDF54846D942FE9263 /* IGListBindable.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FCE38CF740B20F9C36A8F74665226E45 /* IGListAdapterUpdateListener.h in Headers */ = {isa = PBXBuildFile; fileRef = 557439D3DDB574FCFCBBBB4521FEC778 /* IGListAdapterUpdateListener.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD8AD5D12D11003C2A062BE079937D79 /* IGListAdapterDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = EA6268E165A136247E1C79C1D53A229C /* IGListAdapterDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,211 +130,208 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E744CEE24C044B1DCCAA8DFFBCACB6C;
+			remoteGlobalIDString = D10AD9FAD40B191F43F847DCF504FE0B;
 			remoteInfo = IGListKit;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		008E078085E5CBACBF071FC95E37A05B /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdaterDelegate.h; path = Source/IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
-		0140D92319C66456405A2D25B028C555 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.js; path = docs/js/jazzy.js; sourceTree = "<group>"; };
-		01A8E0CE6A5FEDF0D5397E9D892D4BB4 /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
-		025338DE5F92CD26D21ECBCCCF35F178 /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jquery.min.js; path = docs/js/jquery.min.js; sourceTree = "<group>"; };
-		033080E7DAE490140BABD859A77CD09D /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
-		0570D4B23B361A7D9CD610DBE3EB4B90 /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
+		004B2432EC6AC3D146BDE8BC07DC58CC /* IGListStackedSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListStackedSectionController.html; path = docs/Classes/IGListStackedSectionController.html; sourceTree = "<group>"; };
+		007F0F773689E30244859FE3804C081B /* IGListArrayUtilsInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListArrayUtilsInternal.h; sourceTree = "<group>"; };
+		012B3E1C5626CDF6C32CBCA8E14D5FE0 /* IGListBatchUpdateState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateState.h; sourceTree = "<group>"; };
+		02FB4D57200CA4255A1A27CE46B92CCC /* IGListBindable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindable.html; path = docs/Protocols/IGListBindable.html; sourceTree = "<group>"; };
+		03EFE5BF9C99A7FA7E3E3BDDDDB14E96 /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; name = highlight.css; path = docs/css/highlight.css; sourceTree = "<group>"; };
+		045A80642FC43FBA50FBC69FF1CDF318 /* UICollectionView+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+DebugDescription.h"; sourceTree = "<group>"; };
 		05F171BFF248A0DC7ECF84240D012266 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		0CCED269E2E7BC03D5CD1D53573DDDDB /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
-		0D3D2A70A351A1B27305FFEB26B108AB /* modeling-and-binding.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "modeling-and-binding.html"; path = "docs/modeling-and-binding.html"; sourceTree = "<group>"; };
-		11F595B6FDC08A260C3FA66A953E514D /* IGListDebugger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebugger.h; sourceTree = "<group>"; };
+		0771E2085846501017113531E195A21A /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
+		0A28DEF2D9134159434923A19D2BAD19 /* generating-your-models.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "generating-your-models.html"; path = "docs/generating-your-models.html"; sourceTree = "<group>"; };
+		0A3718D00E137159845EBFA52B9D0B03 /* IGListDiffOption.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffOption.html; path = docs/Enums/IGListDiffOption.html; sourceTree = "<group>"; };
+		0BFD300F4F6699A06155A832AA82700C /* Protocols.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Protocols.html; path = docs/Protocols.html; sourceTree = "<group>"; };
+		0C2D1A66F9E1F55FD874F70560B0D8DF /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
+		0DCAF230EF43E174D67434F83EAFBE02 /* IGListReloadIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadIndexPath.h; sourceTree = "<group>"; };
+		0F105B8CF11E614C103B34A54D9E51F3 /* IGListAdapter+UICollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+UICollectionView.h"; sourceTree = "<group>"; };
+		0F359C0DD6ACC522E2B69F0E46AE0862 /* IGListMoveIndex.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndex.html; path = docs/Classes/IGListMoveIndex.html; sourceTree = "<group>"; };
+		0F73691980A250D56726AD81F4DE4746 /* IGListCollectionView.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionView.html; path = docs/Classes/IGListCollectionView.html; sourceTree = "<group>"; };
+		106CA0425A27F3F8C12A3A23317460BF /* IGListSectionMap.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionMap.h; sourceTree = "<group>"; };
+		10FA7756E5D4FC447ECBD9B3BDCD08DA /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
+		1257ACEB4C79BD9EBF97035FE95C70A8 /* IGListAdapterUpdateType.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateType.html; path = docs/Enums/IGListAdapterUpdateType.html; sourceTree = "<group>"; };
 		13A3412F0C670D4056DC2B0D5BCF07F6 /* Pods-IGListKitExamples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.debug.xcconfig"; sourceTree = "<group>"; };
-		149B4939E2C5274272E5C166A4864E0A /* IGListDebuggingUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebuggingUtilities.h; sourceTree = "<group>"; };
-		15948EF546563F3601C8AD6EBFB61B3A /* installation.html */ = {isa = PBXFileReference; includeInIndex = 1; name = installation.html; path = docs/installation.html; sourceTree = "<group>"; };
+		16C154D66B7A4B1B7BD647A97E5ADB91 /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListReloadDataUpdater.m; path = Source/IGListReloadDataUpdater.m; sourceTree = "<group>"; };
 		16E1E6E12BFF2A3C1D8E7D5105F93870 /* Pods-IGListKitExamples-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitExamples-acknowledgements.plist"; sourceTree = "<group>"; };
-		188D8DE4C52A4752D518B64EE7B26DE7 /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
-		1F3751B73FEB5E127AA62659AE62B93E /* IGListBatchUpdates.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdates.h; sourceTree = "<group>"; };
-		22F2B5651FC5691E88B29E0CEACC894F /* IGListScrollDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListScrollDelegate.html; path = docs/Protocols/IGListScrollDelegate.html; sourceTree = "<group>"; };
-		23D8B546152A3EC32AF19CA7D5D07B8A /* IGListAdapterPerformanceDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterPerformanceDelegate.h; path = Source/IGListAdapterPerformanceDelegate.h; sourceTree = "<group>"; };
-		23DCBFCE667AB8405F67973A03E4480E /* IGListAdapterMoveDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterMoveDelegate.h; path = Source/IGListAdapterMoveDelegate.h; sourceTree = "<group>"; };
-		23DCD2B28629A40D0D57AD92F7636F19 /* IGSystemVersion.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGSystemVersion.m; sourceTree = "<group>"; };
-		2420CE41964AFD3450CEEB4EC6AFDF86 /* IGListKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-umbrella.h"; sourceTree = "<group>"; };
+		17168E12B516FC2D437D953D1D3945CA /* IGListAdapterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDelegate.html; path = docs/Protocols/IGListAdapterDelegate.html; sourceTree = "<group>"; };
+		1964F22A392BA4DCD1169B3E45451A66 /* IGListAdapter+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+DebugDescription.h"; sourceTree = "<group>"; };
+		19E801A5B355BB6709EEBCA0E11F6D61 /* Guides.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Guides.html; path = docs/Guides.html; sourceTree = "<group>"; };
+		1A945075F8DEC4A99B1BC379CE98C3D5 /* IGListAdapter.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapter.html; path = docs/Classes/IGListAdapter.html; sourceTree = "<group>"; };
+		1B2479B244994949F4B8AB48482D235C /* IGListAdapterUpdaterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdaterDelegate.html; path = docs/Protocols/IGListAdapterUpdaterDelegate.html; sourceTree = "<group>"; };
+		1DE2F3501F90CB454B9A54532DAF33CE /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; name = search.json; path = docs/search.json; sourceTree = "<group>"; };
+		1FCD809B23AC7F8E26AB4E3021AE84CB /* IGListBindingSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionController.h; path = Source/IGListBindingSectionController.h; sourceTree = "<group>"; };
+		20733D11D25E38C4FBA3DEBC32EAFAF6 /* IGListKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = IGListKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		20FF0A6862FA86E363C0EC59BE7CBD82 /* Classes.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Classes.html; path = docs/Classes.html; sourceTree = "<group>"; };
+		224CEA50CF837C0AE490645B9A81F531 /* IGListBatchContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchContext.html; path = docs/Protocols/IGListBatchContext.html; sourceTree = "<group>"; };
 		24989CFBCEDBB59574A81E4052A4DC14 /* Pods-IGListKitExamples-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKitExamples-dummy.m"; sourceTree = "<group>"; };
-		249D1B80B319A7966B4B7C15B481D6BE /* vision.html */ = {isa = PBXFileReference; includeInIndex = 1; name = vision.html; path = docs/vision.html; sourceTree = "<group>"; };
-		24C30F79A131EEFB0194BE5C976F593C /* UICollectionViewLayout+InteractiveReordering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionViewLayout+InteractiveReordering.h"; sourceTree = "<group>"; };
-		250CD9CE94FE45466DBABBE78044F096 /* getting-started.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "getting-started.html"; path = "docs/getting-started.html"; sourceTree = "<group>"; };
-		2636800EBE1C3FB2ED2270629F17685A /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
-		26952F184BB0B349D3CA073AA7B22FD7 /* IGListStackedSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListStackedSectionController.m; path = Source/IGListStackedSectionController.m; sourceTree = "<group>"; };
-		26C78D8E281288D5585AA3A4FB5AC507 /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdater.h; path = Source/IGListAdapterUpdater.h; sourceTree = "<group>"; };
+		25B861B5D13C549517BD1B203F97D15E /* IGListKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "IGListKit-Info.plist"; sourceTree = "<group>"; };
+		26089596EEC9E2C7B0581E87FE581733 /* IGListAdapterUpdater+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapterUpdater+DebugDescription.h"; sourceTree = "<group>"; };
 		26D77165167F838AB4A273A56783F08F /* Pods-IGListKitExamples-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-IGListKitExamples-acknowledgements.markdown"; sourceTree = "<group>"; };
-		299BB696E57FD78EF83ACD902DEC7B70 /* IGListCollectionViewDelegateLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewDelegateLayout.html; path = docs/Protocols/IGListCollectionViewDelegateLayout.html; sourceTree = "<group>"; };
-		29B17BB62A86153D50181B3AABB05895 /* IGListAdapterUpdater+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapterUpdater+DebugDescription.m"; sourceTree = "<group>"; };
-		2A0E48D9F7D3895D5EAF562BAD2DECB4 /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
-		2AF5955A637E241EA5C4876D38D58C2A /* IGListSectionMap+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListSectionMap+DebugDescription.m"; sourceTree = "<group>"; };
-		2C1A62CC27BF00BA7B6959F7C6AD01C1 /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
-		2D2637E8C35C5982C271EC7753E0B648 /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapter.m; path = Source/IGListAdapter.m; sourceTree = "<group>"; };
-		2E6C8A986D4AE18A487EDB9DE7B34319 /* best-practices-and-faq.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "best-practices-and-faq.html"; path = "docs/best-practices-and-faq.html"; sourceTree = "<group>"; };
-		2EC7416DD068D1BD076ABFD8DD732577 /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListDisplayDelegate.h; path = Source/IGListDisplayDelegate.h; sourceTree = "<group>"; };
-		2EF8B2416C245DFEFCEF81D07E8497E6 /* IGListBindingSectionControllerDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerDataSource.html; path = docs/Protocols/IGListBindingSectionControllerDataSource.html; sourceTree = "<group>"; };
-		3248F2BEFAD4A9B5D4607820B7A7417B /* IGListReloadDataUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListReloadDataUpdater.m; path = Source/IGListReloadDataUpdater.m; sourceTree = "<group>"; };
-		327071D938A768D568D9459284C91652 /* migration.html */ = {isa = PBXFileReference; includeInIndex = 1; name = migration.html; path = docs/migration.html; sourceTree = "<group>"; };
-		32E967142A67AC34858D39AC29313CCD /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
-		3425853BBD44F3961F19B71D7B8B6C79 /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListReloadDataUpdater.h; path = Source/IGListReloadDataUpdater.h; sourceTree = "<group>"; };
-		347B1DF9984F508AC0B5D4C47C505A4C /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/img/carat.png; sourceTree = "<group>"; };
-		35DD6A7BFAD9E6B98EAD5076384F9081 /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
-		3631514648B3D2E10ADD3BBF4C0D9CF7 /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.mm; path = Source/IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
-		36D0FE4A81CF9AA5B8D3D54D66E76780 /* IGListDebuggingUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebuggingUtilities.m; sourceTree = "<group>"; };
-		3A3DCE9B5057E863E71ADAB91B5EA88B /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDataSource.h; path = Source/IGListAdapterDataSource.h; sourceTree = "<group>"; };
-		3A91B591449672B70EFC34E5DC7FC2DE /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSupplementaryViewSource.h; path = Source/IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
-		3B087726B793A58C6C933D64E562A32D /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
-		3B970D5837C65B7C7AABFB21F7349C7A /* IGListCollectionView.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionView.html; path = docs/Classes/IGListCollectionView.html; sourceTree = "<group>"; };
-		3CB2F85056C4C607B6B6E7EC98DB9E84 /* UIScrollView+IGListKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+IGListKit.m"; sourceTree = "<group>"; };
-		3EAFB73895317F9A670C6DEAA39E2EB8 /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
-		3FB64D7270DB5AA0DD15A428602BA72B /* IGListTransitionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListTransitionDelegate.h; path = Source/IGListTransitionDelegate.h; sourceTree = "<group>"; };
-		415174E37372C679DCAA9449AD7B7256 /* IGListBindingSectionController+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBindingSectionController+DebugDescription.h"; sourceTree = "<group>"; };
-		41ECAE5C3A5838272DE3E6050568CF75 /* IGListCollectionScrollingTraits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionScrollingTraits.h; path = Source/IGListCollectionScrollingTraits.h; sourceTree = "<group>"; };
-		43E27A2AF52114A34151624E40F01224 /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapter.h; path = Source/IGListAdapter.h; sourceTree = "<group>"; };
-		4662CA2365B32D37CBA929352FE567EF /* IGListUpdatingDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListUpdatingDelegate.html; path = docs/Protocols/IGListUpdatingDelegate.html; sourceTree = "<group>"; };
-		489D58E145A8814DCFC8193EA5C2E876 /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
-		4A8315EF72DC73C7AB140FD2231C5215 /* IGListBindable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindable.h; path = Source/IGListBindable.h; sourceTree = "<group>"; };
-		4AA5FD6A83C251EE1811A9255A497697 /* IGListBindingSectionControllerDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerDataSource.h; path = Source/IGListBindingSectionControllerDataSource.h; sourceTree = "<group>"; };
-		4C0BE4506870F583F018A0948E118642 /* IGListMoveIndexPath.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndexPath.html; path = docs/Classes/IGListMoveIndexPath.html; sourceTree = "<group>"; };
-		4E417CC7E63825AD82FFC0A046DE113C /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
-		4E94A701A2C8F645308872A1D1CECC53 /* IGListSingleSectionControllerDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionControllerDelegate.html; path = docs/Protocols/IGListSingleSectionControllerDelegate.html; sourceTree = "<group>"; };
-		534081990B3A69B3A3E6E35D7C6A0A42 /* IGListTransitionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListTransitionDelegate.html; path = docs/Protocols/IGListTransitionDelegate.html; sourceTree = "<group>"; };
-		53629EF923E6638D616BF356F216D0A7 /* Enums.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Enums.html; path = docs/Enums.html; sourceTree = "<group>"; };
-		563DB9FB0110ABD5F4C87BFB3A9C0CA0 /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListKit.h; path = Source/IGListKit.h; sourceTree = "<group>"; };
-		56CBD388A002C794BE073ACA6B24CCEE /* search.json */ = {isa = PBXFileReference; includeInIndex = 1; name = search.json; path = docs/search.json; sourceTree = "<group>"; };
-		574C0496D80A99F9405D469520056267 /* IGListCollectionViewDelegateLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewDelegateLayout.h; path = Source/IGListCollectionViewDelegateLayout.h; sourceTree = "<group>"; };
-		57CDD06CCFE6D5E8B56D1FCCB6EA6F8E /* IGListDiffable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffable.html; path = docs/Protocols/IGListDiffable.html; sourceTree = "<group>"; };
-		58E6337F20AA586DC618479560C61792 /* IGListBindable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindable.html; path = docs/Protocols/IGListBindable.html; sourceTree = "<group>"; };
-		5919EFCC22F7C1399B4720A6CFA95254 /* Protocols.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Protocols.html; path = docs/Protocols.html; sourceTree = "<group>"; };
-		5979137B9E523F7C3E8CE418F45740F2 /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
-		5A60A116EF7A80CCF65D693A01AA64E9 /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListUpdatingDelegate.h; path = Source/IGListUpdatingDelegate.h; sourceTree = "<group>"; };
-		5AEFEACAF9387A355DE5D7B4CBED1C0E /* Functions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Functions.html; path = docs/Functions.html; sourceTree = "<group>"; };
-		5C457D3D4FD7B70069E5F47E6BBCA865 /* generating-your-models.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "generating-your-models.html"; path = "docs/generating-your-models.html"; sourceTree = "<group>"; };
-		5CA8ED4A030F88933A2F29E8C38B96A0 /* IGListAdapter+UICollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+UICollectionView.h"; sourceTree = "<group>"; };
-		5CDFA68B43C6C111AD1B7CA35B525991 /* IGListKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IGListKit.xcconfig; sourceTree = "<group>"; };
-		5DC19D5B3BAE9CC18FF49A7D5C8B6702 /* IGListAdapter+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+DebugDescription.m"; sourceTree = "<group>"; };
+		27C15DF7E700F07C9797E799F2D5FAF0 /* IGListTransitionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListTransitionDelegate.h; path = Source/IGListTransitionDelegate.h; sourceTree = "<group>"; };
+		2830BF4DB98E6D1D5443A19D33852ED9 /* IGListAdapterMoveDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterMoveDelegate.html; path = docs/Protocols/IGListAdapterMoveDelegate.html; sourceTree = "<group>"; };
+		29F4E9770C067D926E6339A319F1BC13 /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionContext.h; path = Source/IGListCollectionContext.h; sourceTree = "<group>"; };
+		2BA734B0125D1B7290396F40B2800E39 /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionView.h; path = Source/IGListCollectionView.h; sourceTree = "<group>"; };
+		2C8CE8FA43765F32479D4BF097AC917A /* Constants.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Constants.html; path = docs/Constants.html; sourceTree = "<group>"; };
+		2D16AF72ED30423E249AB2CFB9984999 /* IGListCollectionContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionContext.html; path = docs/Protocols/IGListCollectionContext.html; sourceTree = "<group>"; };
+		2E4869B037A9B7A01D66EB24642F6184 /* IGListBindingSectionControllerSelectionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerSelectionDelegate.html; path = docs/Protocols/IGListBindingSectionControllerSelectionDelegate.html; sourceTree = "<group>"; };
+		2F8059AF7E79E79C9475C37FCE68B3F8 /* best-practices-and-faq.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "best-practices-and-faq.html"; path = "docs/best-practices-and-faq.html"; sourceTree = "<group>"; };
+		2FAB28975EFFE2099E46F6F6B54C1C76 /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
+		302A71A00989DD5368033503C0549E02 /* UICollectionView+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+DebugDescription.m"; sourceTree = "<group>"; };
+		30400241FAEEEDF2758E249F39157FB1 /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
+		304A7C4D3128540EE5890E8CA437379A /* undocumented.json */ = {isa = PBXFileReference; includeInIndex = 1; name = undocumented.json; path = docs/undocumented.json; sourceTree = "<group>"; };
+		312B77AD67A49B0BD8FFEAB87C3A2763 /* iglistdiffable-and-equality.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "iglistdiffable-and-equality.html"; path = "docs/iglistdiffable-and-equality.html"; sourceTree = "<group>"; };
+		314892D745B03A25D25171B9D57554C3 /* IGListBindingSectionControllerDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerDataSource.html; path = docs/Protocols/IGListBindingSectionControllerDataSource.html; sourceTree = "<group>"; };
+		33634685462FB991AB3FD49B80DC454F /* IGListAdapter+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+DebugDescription.m"; sourceTree = "<group>"; };
+		33B0C97FD46A2A926E41BD7014C41577 /* IGListSupplementaryViewSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSupplementaryViewSource.html; path = docs/Protocols/IGListSupplementaryViewSource.html; sourceTree = "<group>"; };
+		35ABBAEDC37A4EC6DD0A4E9D2361A744 /* IGListMoveIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndexPath.m; sourceTree = "<group>"; };
+		35F62C1A0EF1789EB57097E56C3227F4 /* IGListTransitionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListTransitionDelegate.html; path = docs/Protocols/IGListTransitionDelegate.html; sourceTree = "<group>"; };
+		378ED14285D196EA7607F251FC48E4D0 /* IGListDiffKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffKit.h; sourceTree = "<group>"; };
+		37B4EF0DB0FFA8A36C8B575B3B927920 /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
+		389AD9B267953379243C7F2113074234 /* UIScrollView+IGListKit.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIScrollView+IGListKit.m"; sourceTree = "<group>"; };
+		3B5EC58E30A22BC07F49E583FF13DC38 /* IGListGenericSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListGenericSectionController.h; path = Source/IGListGenericSectionController.h; sourceTree = "<group>"; };
+		3BA48420AC58C6C0DB94318D18A8E8AF /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSectionController.h; path = Source/IGListSectionController.h; sourceTree = "<group>"; };
+		3BF9436F51B58C6EEF41CF905A8B9075 /* IGListCollectionViewLayoutCompatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayoutCompatible.h; path = Source/IGListCollectionViewLayoutCompatible.h; sourceTree = "<group>"; };
+		3EC204B851CACE33D675EC91C3A8D84E /* IGListCompatibility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCompatibility.h; sourceTree = "<group>"; };
+		41C2ABF2EC14D10E3DD732632E7317AC /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSingleSectionController.m; path = Source/IGListSingleSectionController.m; sourceTree = "<group>"; };
+		43C978E2D79271335866B7D0DD0582F1 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
+		44B2020520F57C4D260E6C653E5DFFBB /* IGListUpdatingDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListUpdatingDelegate.h; path = Source/IGListUpdatingDelegate.h; sourceTree = "<group>"; };
+		44C6BA16AEAE34F42C7B57D7090CEBBF /* IGListBatchUpdates.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdates.h; sourceTree = "<group>"; };
+		451ED9B182FA7882083A4E0E7697D10E /* IGListAdapterMoveDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterMoveDelegate.h; path = Source/IGListAdapterMoveDelegate.h; sourceTree = "<group>"; };
+		4580025430C4A44F3305BBEA866AC2E2 /* working-with-uicollectionview.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-uicollectionview.html"; path = "docs/working-with-uicollectionview.html"; sourceTree = "<group>"; };
+		48B66893D0F358DFC6F94A4A7240AEE6 /* IGListExperiment.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListExperiment.html; path = docs/Enums/IGListExperiment.html; sourceTree = "<group>"; };
+		48DF22CBDF2D9AA52DE0986EEF4F2336 /* IGListCollectionViewLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.html; path = docs/Classes/IGListCollectionViewLayout.html; sourceTree = "<group>"; };
+		4F8A668E9712C40062603117B03A22EE /* IGListReloadDataUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListReloadDataUpdater.h; path = Source/IGListReloadDataUpdater.h; sourceTree = "<group>"; };
+		5112340F00F1F4A85D487204BC4D147C /* IGListKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = IGListKit.modulemap; sourceTree = "<group>"; };
+		5259ADD1BE816E14314F2FECB0BC5894 /* IGListAdapterProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterProxy.h; sourceTree = "<group>"; };
+		557439D3DDB574FCFCBBBB4521FEC778 /* IGListAdapterUpdateListener.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdateListener.h; path = Source/IGListAdapterUpdateListener.h; sourceTree = "<group>"; };
+		57DD564F20A17DD50E7EBC3A411202F9 /* UICollectionView+IGListBatchUpdateData.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+IGListBatchUpdateData.m"; sourceTree = "<group>"; };
+		588B448D71BD2E7BFE9D1AE58885A5DF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		58E10324C362A266742BF8BE65FDD635 /* badge.svg */ = {isa = PBXFileReference; includeInIndex = 1; name = badge.svg; path = docs/badge.svg; sourceTree = "<group>"; };
+		5ACC254639EE1A7602BF41F25EED9E01 /* IGListReloadIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadIndexPath.m; sourceTree = "<group>"; };
+		5C53C036466D56700A861DC6AEB03596 /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
 		5E6DA36C457BA385F215258929F44C93 /* Pods-IGListKitExamples.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-IGListKitExamples.modulemap"; sourceTree = "<group>"; };
-		62694290E98BA20397F838188E9EF8A6 /* UICollectionView+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+DebugDescription.h"; sourceTree = "<group>"; };
-		62C291DAA7F2B9D281E999B4878BC582 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
+		5EDC78E548D85BD196F1A2694ECA37F6 /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.css; path = docs/css/jazzy.css; sourceTree = "<group>"; };
 		659DAB79E09D170FB9096949FEA9FA49 /* Pods_IGListKitExamples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_IGListKitExamples.framework; path = "Pods-IGListKitExamples.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		686854EC36F333525958DAF35D34BAF3 /* IGListWorkingRangeHandler.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListWorkingRangeHandler.mm; sourceTree = "<group>"; };
-		68A7E11525116AE5E46B9D018450447C /* UIScrollView+IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+IGListKit.h"; sourceTree = "<group>"; };
-		69A3121145912B37F42400B9368F3C64 /* IGSystemVersion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGSystemVersion.h; sourceTree = "<group>"; };
+		6669E8CF240CABC4EF87825FC327953F /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
 		6A2F53564B1658CD75F959A0934B9496 /* Pods-IGListKitExamples-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKitExamples-frameworks.sh"; sourceTree = "<group>"; };
-		6ACAD7F7A58065174A2601520F6B2483 /* highlight.css */ = {isa = PBXFileReference; includeInIndex = 1; name = highlight.css; path = docs/css/highlight.css; sourceTree = "<group>"; };
-		6B80EE0AB5DBEB727B920BB3C6F57759 /* IGListCollectionViewLayoutInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayoutInternal.h; sourceTree = "<group>"; };
-		6BD61DC6E2371341E420BBB7FE0FC542 /* IGListCollectionViewLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.html; path = docs/Classes/IGListCollectionViewLayout.html; sourceTree = "<group>"; };
+		6A5E9C1015C9EA2186D8D2685FAD7F1C /* IGListDisplayDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDisplayDelegate.html; path = docs/Protocols/IGListDisplayDelegate.html; sourceTree = "<group>"; };
+		6B145588E251C0BF3EA8500BBE138403 /* Functions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Functions.html; path = docs/Functions.html; sourceTree = "<group>"; };
+		6C8BE0DE56665816514B7B4714532123 /* IGListKit-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-umbrella.h"; sourceTree = "<group>"; };
 		6E1F643EADCA4A1EE9BA4C3C9748D21F /* Pods-IGListKitExamples-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitExamples-Info.plist"; sourceTree = "<group>"; };
-		6E9E077E7E1A733778A42E0E0CCC0A45 /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
-		743FE50E582F13629065E9E3D173F5B1 /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
-		756C605CCA981182AF18EF2E9C83313E /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
-		798F1F6F8FC5CE54BDDCD8740F3A6E5C /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
-		79B6F9B2C0B438C85E50BFBEA5396800 /* IGListStackedSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListStackedSectionControllerInternal.h; sourceTree = "<group>"; };
-		7A77E320D9278AEAE76811DD6A623C86 /* IGListBatchContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchContext.html; path = docs/Protocols/IGListBatchContext.html; sourceTree = "<group>"; };
-		7AD55BAAC438E3FDE5AF6BFE90EFE713 /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
-		7BB9E2672FD3F3529F9C80E3642BBD51 /* IGListAdapterUpdateListener.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdateListener.h; path = Source/IGListAdapterUpdateListener.h; sourceTree = "<group>"; };
-		7BD51DEB8E118A7ABBB4A895A47798A5 /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
-		7C07ABB5703D70F5AAD92544668BA846 /* IGListWorkingRangeDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListWorkingRangeDelegate.html; path = docs/Protocols/IGListWorkingRangeDelegate.html; sourceTree = "<group>"; };
-		7C5CA2A546B17646539BCD8DFB4938F7 /* IGListDisplayHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDisplayHandler.h; sourceTree = "<group>"; };
-		7E14008BBAC83E53CA444F44989DB052 /* IGListBatchUpdateData+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBatchUpdateData+DebugDescription.m"; sourceTree = "<group>"; };
-		7EAF0CDC4F7D519F26BF3B9567967E13 /* IGListStackedSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListStackedSectionController.h; path = Source/IGListStackedSectionController.h; sourceTree = "<group>"; };
-		7EB707861AB65F4AC265978084BFBF17 /* IGListSectionMap+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListSectionMap+DebugDescription.h"; sourceTree = "<group>"; };
-		7F142E3021CAFC41168357CAEE857470 /* IGListBindingSectionControllerSelectionDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionControllerSelectionDelegate.html; path = docs/Protocols/IGListBindingSectionControllerSelectionDelegate.html; sourceTree = "<group>"; };
-		82ED09E1C96818B56F1098DB0AC949A8 /* NSNumber+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSNumber+IGListDiffable.h"; sourceTree = "<group>"; };
-		83279AD01B1A458091ED0813A6955E94 /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayout.h; path = Source/IGListCollectionViewLayout.h; sourceTree = "<group>"; };
-		83B34633ACB3B2B949437A4B66640B44 /* undocumented.json */ = {isa = PBXFileReference; includeInIndex = 1; name = undocumented.json; path = docs/undocumented.json; sourceTree = "<group>"; };
-		83E0F6E6C1A818BBB64BA6A068E4DD68 /* Constants.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Constants.html; path = docs/Constants.html; sourceTree = "<group>"; };
-		8488BF3D306A4F98FFE63C0C34A67EB7 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/img/gh.png; sourceTree = "<group>"; };
-		84D4584ED339BB369CAD0DA8FAD40C04 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSectionController.m; path = Source/IGListSectionController.m; sourceTree = "<group>"; };
-		85F5CE0A1105CF699905AEAE503A46DC /* IGListKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = IGListKit.modulemap; sourceTree = "<group>"; };
-		860CCB618D514D62DAD8916E53A937E1 /* IGListCollectionView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionView.h; path = Source/IGListCollectionView.h; sourceTree = "<group>"; };
-		87C673091031357C5311C8103A9F6AE0 /* IGListMoveIndex.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndex.html; path = docs/Classes/IGListMoveIndex.html; sourceTree = "<group>"; };
-		883A820D9F5DBA472227193B19842D13 /* IGListBindingSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionController.h; path = Source/IGListBindingSectionController.h; sourceTree = "<group>"; };
-		8972E1F0B57B0CC62B46737A66514188 /* IGListWorkingRangeHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListWorkingRangeHandler.h; sourceTree = "<group>"; };
-		8AFADD9F5188146104C26AC277B8994D /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListCollectionView.m; path = Source/IGListCollectionView.m; sourceTree = "<group>"; };
+		6E303B2030CAC6CEBFCAEEF61980CAFB /* Type Definitions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "Type Definitions.html"; path = "docs/Type Definitions.html"; sourceTree = "<group>"; };
+		6E31CDC469669B8E02481E1B11FFBFFF /* NSString+IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSString+IGListDiffable.h"; sourceTree = "<group>"; };
+		71AD5B51808292764E22529D74D7318B /* IGListBatchUpdateData+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBatchUpdateData+DebugDescription.m"; sourceTree = "<group>"; };
+		729FFC51BA0A0B13C6F1A9FDC0D4C343 /* IGListSectionMap+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListSectionMap+DebugDescription.h"; sourceTree = "<group>"; };
+		72AF28C067D1C890CD4152B2B289F637 /* IGListAdapterPerformanceDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterPerformanceDelegate.h; path = Source/IGListAdapterPerformanceDelegate.h; sourceTree = "<group>"; };
+		752E3E997F94B90A778D42712A3F2E81 /* IGListAdapter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapter.m; path = Source/IGListAdapter.m; sourceTree = "<group>"; };
+		7610BD2A59929BFCE2043AC2CD3CE1D8 /* IGListAdapterUpdater+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapterUpdater+DebugDescription.m"; sourceTree = "<group>"; };
+		78B234C5E7DEF10B76DCBEA00C838B48 /* jquery.min.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jquery.min.js; path = docs/js/jquery.min.js; sourceTree = "<group>"; };
+		7C11715F41C45CBCE595C680B3994B3A /* IGListAdapterUpdater.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdater.h; path = Source/IGListAdapterUpdater.h; sourceTree = "<group>"; };
+		7D4FBF9B44F1D1C527E59932D8CEB24C /* IGListBindingSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListBindingSectionController.m; path = Source/IGListBindingSectionController.m; sourceTree = "<group>"; };
+		7D5879AF5DFBA075134C34FA0BE32085 /* IGSystemVersion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGSystemVersion.h; sourceTree = "<group>"; };
+		7F37A7E042B9E7B824C1B2299628EA6D /* IGListKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListKit-dummy.m"; sourceTree = "<group>"; };
+		7F456DD4F20ACCA5BB684DE87DE18105 /* IGListMoveIndexPath.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListMoveIndexPath.html; path = docs/Classes/IGListMoveIndexPath.html; sourceTree = "<group>"; };
+		7F6BBABD2DF0B6D7F6092794BD317D27 /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
+		7F812141078FAC52E986C6BCD1A92B4F /* IGListExperiments.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListExperiments.h; sourceTree = "<group>"; };
+		7F9FDCCADB974D16C0188511D9299907 /* IGListBatchUpdates.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListBatchUpdates.m; sourceTree = "<group>"; };
+		7FA51D190E02BCE46AB238C76FD7C7B4 /* IGListBindingSectionControllerSelectionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerSelectionDelegate.h; path = Source/IGListBindingSectionControllerSelectionDelegate.h; sourceTree = "<group>"; };
+		812F3CC66646DA80AF409DD9C99DE524 /* IGListSingleSectionControllerDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionControllerDelegate.html; path = docs/Protocols/IGListSingleSectionControllerDelegate.html; sourceTree = "<group>"; };
+		819B414164D207CC334E0399EDC280A5 /* modeling-and-binding.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "modeling-and-binding.html"; path = "docs/modeling-and-binding.html"; sourceTree = "<group>"; };
+		83210F59EEEFBB281964DA57C76D5DC2 /* IGListIndexSetResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResult.h; sourceTree = "<group>"; };
+		834105A9BE125299CFD399D0AB4688C0 /* IGListAdapterUpdater.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdater.html; path = docs/Classes/IGListAdapterUpdater.html; sourceTree = "<group>"; };
+		860541A2716D9453C1A7EEEA2A131B31 /* IGListSectionControllerInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListSectionControllerInternal.h; sourceTree = "<group>"; };
+		868BF8C95FF47E5C246B00599DF42516 /* IGListMoveIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPath.h; sourceTree = "<group>"; };
+		87F7C66E97DA10342D23CE8DDB9C08E1 /* installation.html */ = {isa = PBXFileReference; includeInIndex = 1; name = installation.html; path = docs/installation.html; sourceTree = "<group>"; };
+		8A9856D52D7B275F82F234C54119F04A /* carat.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = carat.png; path = docs/img/carat.png; sourceTree = "<group>"; };
+		8B174878B8023103E5329A9DD7F704FD /* IGListScrollDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListScrollDelegate.html; path = docs/Protocols/IGListScrollDelegate.html; sourceTree = "<group>"; };
 		8CAEA38BA4119C7D41068C4FDAB7D01E /* IGListKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = IGListKit.framework; path = IGListKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E790A45A397CAC4AD5FD6D403F6AAAD /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDelegate.h; path = Source/IGListAdapterDelegate.h; sourceTree = "<group>"; };
-		8E9BB6D359B6DECF013E01A04A18FAE4 /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
-		8EA67A0FFFB778AB24D4DC905BF4CC32 /* IGListReloadIndexPath.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListReloadIndexPath.m; sourceTree = "<group>"; };
-		8F9E474B3AA7CC7D314FF1D92E174D0D /* IGListAdapter.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapter.html; path = docs/Classes/IGListAdapter.html; sourceTree = "<group>"; };
-		97DBAAAB328E840C239E4BE42CEBE8ED /* IGListGenericSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListGenericSectionController.h; path = Source/IGListGenericSectionController.h; sourceTree = "<group>"; };
-		97E93F460F79F89FCFBE8556C3130773 /* IGListAdapterUpdateListener.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateListener.html; path = docs/Protocols/IGListAdapterUpdateListener.html; sourceTree = "<group>"; };
-		98429D09463111806069C97FFBB4C3B5 /* IGListAdapterMoveDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterMoveDelegate.html; path = docs/Protocols/IGListAdapterMoveDelegate.html; sourceTree = "<group>"; };
+		8E4F8FFADB70D93DF9342AB725E6D73B /* IGListBatchUpdateData.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchUpdateData.html; path = docs/Classes/IGListBatchUpdateData.html; sourceTree = "<group>"; };
+		8F9E4628465A178BBD0D363303492D76 /* NSNumber+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+IGListDiffable.m"; sourceTree = "<group>"; };
+		9524B68D686F4353973DFF7F69401316 /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
+		97526A171526748F051CBFD68F2EF9B4 /* IGListBatchContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBatchContext.h; path = Source/IGListBatchContext.h; sourceTree = "<group>"; };
+		990F7D79A031CB4C220D4B5C547BB059 /* IGListMoveIndex.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndex.h; sourceTree = "<group>"; };
 		9A82C1E897A8CE3E9036D129552382C7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		9AFB8CAB7342FB0B45FC211C8D6BD8AF /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListWorkingRangeDelegate.h; path = Source/IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
-		9BA4C6C4059F3CBF35BE7786CE660F1B /* IGListAdapter+UICollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+UICollectionView.m"; sourceTree = "<group>"; };
-		9C46504759494FD1C69FC7D25DBCAA74 /* IGListBatchUpdates.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListBatchUpdates.m; sourceTree = "<group>"; };
+		9A8A3B78D4AB97C97C29414E37A74F24 /* UIScrollView+IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIScrollView+IGListKit.h"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A07DE671ACEBE4206D3AFBBF594793B1 /* Classes.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Classes.html; path = docs/Classes.html; sourceTree = "<group>"; };
-		A1D7E38A7D2088C4862F42F97C853C9E /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
-		A2A941D2316F957BD7FE9D0C602768F1 /* UICollectionView+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionView+DebugDescription.m"; sourceTree = "<group>"; };
-		A7A5F144990E42E7E7F98054A3BD913C /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSingleSectionController.h; path = Source/IGListSingleSectionController.h; sourceTree = "<group>"; };
-		A7C9BDB2DE00A299CF507C2BAD98964E /* IGListKit-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "IGListKit-Info.plist"; sourceTree = "<group>"; };
-		AAE937562C084DD587F1BF54759F80DC /* LICENSE.md */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE.md; sourceTree = "<group>"; };
-		AC3DC18E81A3DB6A9AF746B1D474877F /* IGListBindingSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionController.html; path = docs/Classes/IGListBindingSectionController.html; sourceTree = "<group>"; };
-		AC6AA87A7B7A3D56217D5F8302EF2EC6 /* IGListSupplementaryViewSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSupplementaryViewSource.html; path = docs/Protocols/IGListSupplementaryViewSource.html; sourceTree = "<group>"; };
-		AC6C75B671CA9379B82DE2E46D2538B9 /* IGListAdapterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDelegate.html; path = docs/Protocols/IGListAdapterDelegate.html; sourceTree = "<group>"; };
-		AD85AE76B370D8DA9FE49B38C579EE9C /* IGListAdapterUpdateType.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateType.html; path = docs/Enums/IGListAdapterUpdateType.html; sourceTree = "<group>"; };
-		ADB5DE04A399436547677B5FA94D89AC /* Guides.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Guides.html; path = docs/Guides.html; sourceTree = "<group>"; };
-		B1E20FD3534F921890EC04B5037C00DA /* IGListKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListKit-dummy.m"; sourceTree = "<group>"; };
-		B33A467275A5EE43F8C330E9185FBA6D /* IGListAssert.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAssert.h; sourceTree = "<group>"; };
-		B4DFDC546D6C9201470E212F6FEC2D53 /* IGListGenericSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListGenericSectionController.m; path = Source/IGListGenericSectionController.m; sourceTree = "<group>"; };
-		B512206520F88C251E446BA93F7EE7FF /* IGListDiff.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListDiff.mm; sourceTree = "<group>"; };
-		B70328A2E0A3F72BA82672881851B80B /* IGListDiff.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiff.h; sourceTree = "<group>"; };
-		B7C194B0F679AAC42180BAB3B6EA175C /* IGListBatchUpdateState.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateState.h; sourceTree = "<group>"; };
-		B84F280A40187163E5678AE7C76D7EB0 /* jazzy.css */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.css; path = docs/css/jazzy.css; sourceTree = "<group>"; };
-		BA324DBA4D116701215F00F1D442031E /* IGListMoveIndex.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListMoveIndex.m; sourceTree = "<group>"; };
-		BC1798F2AAA1C44C0259B22B60DAC12E /* IGListAdapterUpdaterDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdaterDelegate.html; path = docs/Protocols/IGListAdapterUpdaterDelegate.html; sourceTree = "<group>"; };
-		BFBCBB4200399BD318EF408096C885EB /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListScrollDelegate.h; path = Source/IGListScrollDelegate.h; sourceTree = "<group>"; };
-		C051E1AFD1CC4F94690E2E02A3B394FF /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapterUpdater.m; path = Source/IGListAdapterUpdater.m; sourceTree = "<group>"; };
-		C1BA2FD09982FF72B87995903CAE1FD0 /* IGListIndexSetResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexSetResult.html; path = docs/Classes/IGListIndexSetResult.html; sourceTree = "<group>"; };
-		C62BD1911BDD5ED1E8C3C9C9B1AD9124 /* IGListGenericSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListGenericSectionController.html; path = docs/Classes/IGListGenericSectionController.html; sourceTree = "<group>"; };
-		C69FDA626A5D4AAB26BF806565E138D1 /* IGListBatchContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBatchContext.h; path = Source/IGListBatchContext.h; sourceTree = "<group>"; };
-		C8338F04F1DF7C1F900FF59F89EFAC59 /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; name = index.html; path = docs/index.html; sourceTree = "<group>"; };
-		CC5492764E481E05B0F8F7E246530BB8 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
-		CDA11FA38E419A0A6390D00E7C9358C6 /* IGListExperiment.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListExperiment.html; path = docs/Enums/IGListExperiment.html; sourceTree = "<group>"; };
-		CFAEE6376D59A153C4AE6FB7E5097FEC /* IGListStackedSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListStackedSectionController.html; path = docs/Classes/IGListStackedSectionController.html; sourceTree = "<group>"; };
-		D1460B5DFF0A80A4D7EEFCBE64677FDB /* IGListBindingSectionControllerSelectionDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerSelectionDelegate.h; path = Source/IGListBindingSectionControllerSelectionDelegate.h; sourceTree = "<group>"; };
-		D1C8DDF5BA982C10F975BA827D12F430 /* IGListSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSectionController.h; path = Source/IGListSectionController.h; sourceTree = "<group>"; };
+		9ED0E95CA3D89A17E425CC6D6AF114FA /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/img/dash.png; sourceTree = "<group>"; };
+		A130B4E161084BD481263A37BBE7C621 /* IGListKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-prefix.pch"; sourceTree = "<group>"; };
+		A4BEBBE604D583277C35FB3F47AD0A03 /* IGListCollectionViewLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayout.h; path = Source/IGListCollectionViewLayout.h; sourceTree = "<group>"; };
+		A6C3E0349F10F8088F48E35928291511 /* gh.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = gh.png; path = docs/img/gh.png; sourceTree = "<group>"; };
+		A6C3E884ADC8026A2A12139846E90F1B /* IGListDiffable.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffable.html; path = docs/Protocols/IGListDiffable.html; sourceTree = "<group>"; };
+		A8FF58A75C0FC925FB853C2EB6AAD781 /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
+		A920DCE0F3C24C36F41D7C0E4D2959F4 /* IGListKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = IGListKit.xcconfig; sourceTree = "<group>"; };
+		A9574D6393E97469F2446297CBF3B968 /* IGListWorkingRangeDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListWorkingRangeDelegate.html; path = docs/Protocols/IGListWorkingRangeDelegate.html; sourceTree = "<group>"; };
+		AC663AEDA4088C8FB5BF939E922768B4 /* IGListIndexPathResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResult.h; sourceTree = "<group>"; };
+		AD40AB3041240ECDF54846D942FE9263 /* IGListBindable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindable.h; path = Source/IGListBindable.h; sourceTree = "<group>"; };
+		AD8BCAE50DFE55681081BC20B383F96A /* IGListIndexSetResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexSetResult.html; path = docs/Classes/IGListIndexSetResult.html; sourceTree = "<group>"; };
+		B0BB0E7DF7C4BFB310BEC1BD4C2B8FCC /* IGListUpdatingDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListUpdatingDelegate.html; path = docs/Protocols/IGListUpdatingDelegate.html; sourceTree = "<group>"; };
+		B0CF85D82A0634F8DA990F797B18BC33 /* IGListScrollDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListScrollDelegate.h; path = Source/IGListScrollDelegate.h; sourceTree = "<group>"; };
+		B0FFAA09371EBE42012FDE64C925C73A /* IGSystemVersion.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGSystemVersion.m; sourceTree = "<group>"; };
+		B22042E362E658FE617639CD3B7C796D /* IGListIndexSetResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexSetResult.m; sourceTree = "<group>"; };
+		B27C0F59186E63E7362D78634D8F2B69 /* IGListAdapterDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDataSource.html; path = docs/Protocols/IGListAdapterDataSource.html; sourceTree = "<group>"; };
+		B7E611DD892F73D0174581C3D304EBB5 /* IGListSingleSectionController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSingleSectionController.h; path = Source/IGListSingleSectionController.h; sourceTree = "<group>"; };
+		BA17F8C5B6E033DAFA1F70CF53CCA68B /* IGListGenericSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListGenericSectionController.m; path = Source/IGListGenericSectionController.m; sourceTree = "<group>"; };
+		BBAA828E8BFDA9BF14A22C98D2B135FE /* IGListSectionMap.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListSectionMap.m; sourceTree = "<group>"; };
+		BC083790FD4C0AFE69FBDFB2F37C0F7A /* LICENSE.md */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE.md; sourceTree = "<group>"; };
+		BF5C82FE9F82ECABD06498FCDBF2902B /* IGListIndexPathResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexPathResultInternal.h; sourceTree = "<group>"; };
+		BF72C26F2E4F640088FDA2C5FA5D3DE0 /* Enums.html */ = {isa = PBXFileReference; includeInIndex = 1; name = Enums.html; path = docs/Enums.html; sourceTree = "<group>"; };
+		BFA4624CE7818123F4F26FB1C46D9F3F /* IGListAdapter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapter.h; path = Source/IGListAdapter.h; sourceTree = "<group>"; };
+		C03D612CCA85B9502DB9BD7D2C722922 /* IGListAdapterUpdateListener.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdateListener.html; path = docs/Protocols/IGListAdapterUpdateListener.html; sourceTree = "<group>"; };
+		C188D91462C16F01A3E02F212B08E003 /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
+		C3690084CC7B9A8C0858FC685851FDBE /* NSString+IGListDiffable.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSString+IGListDiffable.m"; sourceTree = "<group>"; };
+		C4440EB3C5A1F17E5F9234BB007CC963 /* working-with-core-data.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-core-data.html"; path = "docs/working-with-core-data.html"; sourceTree = "<group>"; };
+		C610821FDDA6D2231D085843FC6DC242 /* IGListDebuggingUtilities.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebuggingUtilities.m; sourceTree = "<group>"; };
+		C84C85F00F04CBDCB4B88A6AF39815CF /* IGListCollectionViewLayout.mm */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewLayout.mm; path = Source/IGListCollectionViewLayout.mm; sourceTree = "<group>"; };
+		C8E06E61E38B9763EC0A58A313AA2BB6 /* vision.html */ = {isa = PBXFileReference; includeInIndex = 1; name = vision.html; path = docs/vision.html; sourceTree = "<group>"; };
+		CD7E1029929FE53C957D372E0BEBE005 /* IGListAdapterProxy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListAdapterProxy.m; sourceTree = "<group>"; };
+		CEBD27C8A40F0A06F44656CA39F0E012 /* IGListBindingSectionController+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBindingSectionController+DebugDescription.h"; sourceTree = "<group>"; };
+		CFEF48AE97A505C40074B0CD4B11A222 /* jazzy.js */ = {isa = PBXFileReference; includeInIndex = 1; name = jazzy.js; path = docs/js/jazzy.js; sourceTree = "<group>"; };
+		D22847B3CDED5FB0E35212C5397ABB95 /* IGListDisplayDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListDisplayDelegate.h; path = Source/IGListDisplayDelegate.h; sourceTree = "<group>"; };
 		D2C03B63D2966A9E53EB08E12B34D2A9 /* Pods-IGListKitExamples-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitExamples-umbrella.h"; sourceTree = "<group>"; };
-		D46C8AB1244310CBF9D05EA5C7254514 /* UICollectionViewLayout+InteractiveReordering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionViewLayout+InteractiveReordering.m"; sourceTree = "<group>"; };
-		D48138098CF97E32ABD630FB7EA21505 /* working-with-uicollectionview.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-uicollectionview.html"; path = "docs/working-with-uicollectionview.html"; sourceTree = "<group>"; };
-		D4B90263B5A843B3DC09B13569F3CF91 /* IGListDebugger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebugger.m; sourceTree = "<group>"; };
-		D532BDC1DEFAD50B99ACE01BBCB61C7E /* iglistdiffable-and-equality.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "iglistdiffable-and-equality.html"; path = "docs/iglistdiffable-and-equality.html"; sourceTree = "<group>"; };
-		D545077F07455288973D1FCAC6A45A93 /* IGListAdapterDataSource.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterDataSource.html; path = docs/Protocols/IGListAdapterDataSource.html; sourceTree = "<group>"; };
-		D6EE371FDA07F4634A9B1BDB60F935F4 /* IGListAdapterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterInternal.h; sourceTree = "<group>"; };
-		D96310E4479763D45D35DCF2803D63F4 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
-		DA8629172752FCE2589FB8572BAA7314 /* IGListAdapter+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapter+DebugDescription.h"; sourceTree = "<group>"; };
-		DC60C4B845BC59AE0C874BBC4736F161 /* IGListCollectionViewLayoutCompatible.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewLayoutCompatible.h; path = Source/IGListCollectionViewLayoutCompatible.h; sourceTree = "<group>"; };
-		DFD0F67723798B582076129F6566AA6C /* IGListBindingSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListBindingSectionController.m; path = Source/IGListBindingSectionController.m; sourceTree = "<group>"; };
-		E0B0E3300CB46F0E146E93C537AE6763 /* IGListBatchUpdateData+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBatchUpdateData+DebugDescription.h"; sourceTree = "<group>"; };
-		E1528C973DD8B2333BD588E38DF9447A /* IGListAdapterUpdater+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListAdapterUpdater+DebugDescription.h"; sourceTree = "<group>"; };
-		E260A0FB8163D90890C8EDCA45255300 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
-		E66E82AA73F5CAFF72970FA02B764E22 /* IGListAdapterUpdater.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListAdapterUpdater.html; path = docs/Classes/IGListAdapterUpdater.html; sourceTree = "<group>"; };
-		E81B3766891DB909524A06CB85F60865 /* IGListCollectionContext.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionContext.html; path = docs/Protocols/IGListCollectionContext.html; sourceTree = "<group>"; };
-		E8D916232B7570E68F8F5C12982E9041 /* IGListBindingSectionController+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBindingSectionController+DebugDescription.m"; sourceTree = "<group>"; };
-		EB7C63E83A0B28810376DFFD8774AEA4 /* IGListIndexSetResultInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListIndexSetResultInternal.h; sourceTree = "<group>"; };
-		EC6B52548405A8709A20E62B16707B4E /* IGListDiffOption.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDiffOption.html; path = docs/Enums/IGListDiffOption.html; sourceTree = "<group>"; };
-		F3343E915A0ACCABD231D51BAB8E1CF9 /* IGListIndexPathResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexPathResult.html; path = docs/Classes/IGListIndexPathResult.html; sourceTree = "<group>"; };
-		F3CDC354267668792E43CBED92D2D80F /* IGListArrayUtilsInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListArrayUtilsInternal.h; sourceTree = "<group>"; };
+		D32926E306D69EB82C2A08352B12C459 /* IGListBatchUpdateData+DebugDescription.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListBatchUpdateData+DebugDescription.h"; sourceTree = "<group>"; };
+		D4EF7437C981623A3B293E902588C06B /* IGListBindingSectionController+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListBindingSectionController+DebugDescription.m"; sourceTree = "<group>"; };
+		D68F3F6EA1657583F1FC965E1E83B7DD /* migration.html */ = {isa = PBXFileReference; includeInIndex = 1; name = migration.html; path = docs/migration.html; sourceTree = "<group>"; };
+		D6940BBB133FD96832217E7DC50F5CD8 /* UICollectionViewLayout+InteractiveReordering.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UICollectionViewLayout+InteractiveReordering.m"; sourceTree = "<group>"; };
+		D70EE9B7CECF23985B790A3823D98355 /* IGListWorkingRangeDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListWorkingRangeDelegate.h; path = Source/IGListWorkingRangeDelegate.h; sourceTree = "<group>"; };
+		D838450F8E0D164349A3470C9346DF90 /* IGListMoveIndexInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexInternal.h; sourceTree = "<group>"; };
+		D8B3B7637451F48B7CD12B966F1A9F1B /* IGListKit.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListKit.h; path = Source/IGListKit.h; sourceTree = "<group>"; };
+		DB895118AD753C2EFCDD6A73FD4A745A /* IGListSectionMap+DebugDescription.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListSectionMap+DebugDescription.m"; sourceTree = "<group>"; };
+		DB9F626C5894ADA202AB1DC2DAAB464B /* IGListCollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListCollectionView.m; path = Source/IGListCollectionView.m; sourceTree = "<group>"; };
+		DBDD45BA9A4EEB0980889C51FDAFEC03 /* IGListSupplementaryViewSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListSupplementaryViewSource.h; path = Source/IGListSupplementaryViewSource.h; sourceTree = "<group>"; };
+		DC04ED9FAC8E1E1434224647DC5C4720 /* IGListMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMacros.h; sourceTree = "<group>"; };
+		DC901EB33E7C79EF784C4FE484616A92 /* IGListAdapterUpdaterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterUpdaterDelegate.h; path = Source/IGListAdapterUpdaterDelegate.h; sourceTree = "<group>"; };
+		E1D21D3A338001C9842D2B1616BDF632 /* IGListDebugger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDebugger.m; sourceTree = "<group>"; };
+		E1EEF85288E2EE4836942CECBB0428A0 /* IGListSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSectionController.m; path = Source/IGListSectionController.m; sourceTree = "<group>"; };
+		E363FD3CA762C92B6F2991B5D869D1A4 /* index.html */ = {isa = PBXFileReference; includeInIndex = 1; name = index.html; path = docs/index.html; sourceTree = "<group>"; };
+		E55484DD0ECF569D60694313347A2BE7 /* IGListSingleSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionController.html; path = docs/Classes/IGListSingleSectionController.html; sourceTree = "<group>"; };
+		E55F03BF675483538AE02DCC9E182A09 /* IGListIndexPathResult.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListIndexPathResult.html; path = docs/Classes/IGListIndexPathResult.html; sourceTree = "<group>"; };
+		E5B49DC88986D4C7C6BF583F1629DF54 /* IGListCollectionViewDelegateLayout.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionViewDelegateLayout.h; path = Source/IGListCollectionViewDelegateLayout.h; sourceTree = "<group>"; };
+		E5CCCBBF2E6F6EF9FCFB67E955E7C68B /* IGListDebuggingUtilities.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebuggingUtilities.h; sourceTree = "<group>"; };
+		E73BC32AA0F76C800E8908A6B3C42790 /* IGListAdapter+UICollectionView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "IGListAdapter+UICollectionView.m"; sourceTree = "<group>"; };
+		E77509DC901BF91356013B155D5E526E /* IGListDiffable.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDiffable.h; sourceTree = "<group>"; };
+		EA5E822DFD101BC0E6EBC8CB5F5D2E51 /* IGListGenericSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListGenericSectionController.html; path = docs/Classes/IGListGenericSectionController.html; sourceTree = "<group>"; };
+		EA6268E165A136247E1C79C1D53A229C /* IGListAdapterDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDelegate.h; path = Source/IGListAdapterDelegate.h; sourceTree = "<group>"; };
+		EB01BBE6A6391233013E1108EFDF78B9 /* IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListBatchUpdateData.h; sourceTree = "<group>"; };
+		EE5E35F9A82E6D39139EC34031D831CD /* IGListDebugger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListDebugger.h; sourceTree = "<group>"; };
+		EEC2095FF630C62E3CDC81ADDE44AA2D /* IGListAdapterUpdater.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListAdapterUpdater.m; path = Source/IGListAdapterUpdater.m; sourceTree = "<group>"; };
+		EF251C87925E981E746A6B4FD99B0C2E /* IGListMoveIndexPathInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListMoveIndexPathInternal.h; sourceTree = "<group>"; };
+		F0D36A5433BCC619E63BE6F74BD13E7D /* IGListAdapterDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListAdapterDataSource.h; path = Source/IGListAdapterDataSource.h; sourceTree = "<group>"; };
+		F1590794D469BB5CA8D02C98A8107537 /* IGListSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSectionController.html; path = docs/Classes/IGListSectionController.html; sourceTree = "<group>"; };
 		F461DC2A68D32B0A19A6CCD26FB3562D /* Pods-IGListKitExamples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-IGListKitExamples.release.xcconfig"; sourceTree = "<group>"; };
-		F4DECCF61780200270778DF515EC496A /* IGListIndexPathResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListIndexPathResult.m; sourceTree = "<group>"; };
-		F7A75809C92FCBEF36E8F5922430B809 /* IGListBatchUpdateData.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBatchUpdateData.html; path = docs/Classes/IGListBatchUpdateData.html; sourceTree = "<group>"; };
-		F9036766D2AE85DD0A0A7A0D2323CB09 /* IGListCollectionContext.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionContext.h; path = Source/IGListCollectionContext.h; sourceTree = "<group>"; };
-		F95771ACD4A92ADD45F2C7007212A805 /* IGListSingleSectionController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = IGListSingleSectionController.m; path = Source/IGListSingleSectionController.m; sourceTree = "<group>"; };
-		F996A1F582BB431F19BFA4C6FE3A8271 /* working-with-core-data.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "working-with-core-data.html"; path = "docs/working-with-core-data.html"; sourceTree = "<group>"; };
-		F9F67BAB249CAB3FE74B50C195BBE7C3 /* IGListDisplayDelegate.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListDisplayDelegate.html; path = docs/Protocols/IGListDisplayDelegate.html; sourceTree = "<group>"; };
-		FA0A5B5EEAF52500FEB10AFBCF21A05A /* IGListKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "IGListKit-prefix.pch"; sourceTree = "<group>"; };
-		FA3122453D86AC5041C5F290B1DE9E7F /* IGListAdapterUpdaterInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListAdapterUpdaterInternal.h; sourceTree = "<group>"; };
-		FAD767559901480BBCDB4DE5AC1F08FC /* IGListKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = IGListKit.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		FB11653964C304B24481B1DEFF9879DD /* IGListReloadIndexPath.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListReloadIndexPath.h; sourceTree = "<group>"; };
-		FB3B346EC139D857E04E3F846D7CFDF5 /* IGListSingleSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSingleSectionController.html; path = docs/Classes/IGListSingleSectionController.html; sourceTree = "<group>"; };
-		FB8C8D8B777CBF48CBB93332A5930BFD /* IGListSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListSectionController.html; path = docs/Classes/IGListSectionController.html; sourceTree = "<group>"; };
-		FC8F200F2B3CFB240FD10DD3B84BBA4F /* badge.svg */ = {isa = PBXFileReference; includeInIndex = 1; name = badge.svg; path = docs/badge.svg; sourceTree = "<group>"; };
-		FCAFC758882C2CDD08475683C973D59B /* Type Definitions.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "Type Definitions.html"; path = "docs/Type Definitions.html"; sourceTree = "<group>"; };
-		FE30AAEECA885B16EBB35AE56A03F8EC /* dash.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; name = dash.png; path = docs/img/dash.png; sourceTree = "<group>"; };
-		FEB4BCCAC44453E24732E5EF11DCAF7D /* IGListBatchUpdateData.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = IGListBatchUpdateData.mm; sourceTree = "<group>"; };
+		F6236916C13176231F363334E738296E /* getting-started.html */ = {isa = PBXFileReference; includeInIndex = 1; name = "getting-started.html"; path = "docs/getting-started.html"; sourceTree = "<group>"; };
+		F6820A7751EDB381703124589782AA0F /* IGListBindingSectionController.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListBindingSectionController.html; path = docs/Classes/IGListBindingSectionController.html; sourceTree = "<group>"; };
+		F773D18ABAE135A6E1D5D76A698EA10D /* IGListDisplayHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = IGListDisplayHandler.m; sourceTree = "<group>"; };
+		F9D07B7E789DE06B7A7AA4A9F45A975E /* UICollectionViewLayout+InteractiveReordering.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionViewLayout+InteractiveReordering.h"; sourceTree = "<group>"; };
+		FBC96DA29603138BAEBE8AF60B8F48F9 /* IGListBindingSectionControllerDataSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListBindingSectionControllerDataSource.h; path = Source/IGListBindingSectionControllerDataSource.h; sourceTree = "<group>"; };
+		FDE51513C020EFFAD2A183A146732FBC /* UICollectionView+IGListBatchUpdateData.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UICollectionView+IGListBatchUpdateData.h"; sourceTree = "<group>"; };
+		FE52E6CDEB93C791408A7B0455305F62 /* IGListCollectionViewDelegateLayout.html */ = {isa = PBXFileReference; includeInIndex = 1; name = IGListCollectionViewDelegateLayout.html; path = docs/Protocols/IGListCollectionViewDelegateLayout.html; sourceTree = "<group>"; };
+		FE9FA9E9A57FEDD3BD8F51E5116C7555 /* IGListCollectionViewLayoutInternal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = IGListCollectionViewLayoutInternal.h; sourceTree = "<group>"; };
+		FF7643D43E87E259550779FD70DD2797 /* IGListCollectionScrollingTraits.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IGListCollectionScrollingTraits.h; path = Source/IGListCollectionScrollingTraits.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -349,94 +343,107 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C780C0D7293D61AF9802BB06C18CDFAF /* Frameworks */ = {
+		F30BF0A691E2CFCE72F8CA3B4519B95E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2358C208FD129715EA0D37F93601F9B3 /* Foundation.framework in Frameworks */,
-				64A69C2F83921103D2159FA323209EE3 /* UIKit.framework in Frameworks */,
+				60CBAC6C6F4E286D7256D79B1B2AE0C3 /* Foundation.framework in Frameworks */,
+				414D775738722A317B00BD8546A4C593 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		069E2C10290294C31BA43D5795A04751 /* IGListKit */ = {
+		104F3608AA9BC3912F599C3511969164 /* IGListKit */ = {
 			isa = PBXGroup;
 			children = (
-				9CD888FA4FF887E90F9C9CA1ACC3F948 /* Default */,
-				53B7413CE8844A8EE7CDFB82BD964C37 /* Diffing */,
-				4E04F373EBAB661D90AB01F823BFDAB1 /* Pod */,
-				2289DE711A934E5C1435FB5562F832F3 /* Support Files */,
+				2CC45263ED78734D41004CF0DD02978D /* Default */,
+				BC1B615BC753F8145F324402330A502C /* Diffing */,
+				9006F9784D82E2087C42D757134B8320 /* Pod */,
+				C0A3DFB6D0A401BE583B994639AB821A /* Support Files */,
 			);
 			name = IGListKit;
 			path = ../../..;
 			sourceTree = "<group>";
 		};
-		0EE36C14988F4B749E2D4DF78A61937D /* Internal */ = {
+		202801649DD0CC1392EB85C46FA82FDF /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				DA8629172752FCE2589FB8572BAA7314 /* IGListAdapter+DebugDescription.h */,
-				5DC19D5B3BAE9CC18FF49A7D5C8B6702 /* IGListAdapter+DebugDescription.m */,
-				5CA8ED4A030F88933A2F29E8C38B96A0 /* IGListAdapter+UICollectionView.h */,
-				9BA4C6C4059F3CBF35BE7786CE660F1B /* IGListAdapter+UICollectionView.m */,
-				D6EE371FDA07F4634A9B1BDB60F935F4 /* IGListAdapterInternal.h */,
-				5979137B9E523F7C3E8CE418F45740F2 /* IGListAdapterProxy.h */,
-				756C605CCA981182AF18EF2E9C83313E /* IGListAdapterProxy.m */,
-				E1528C973DD8B2333BD588E38DF9447A /* IGListAdapterUpdater+DebugDescription.h */,
-				29B17BB62A86153D50181B3AABB05895 /* IGListAdapterUpdater+DebugDescription.m */,
-				FA3122453D86AC5041C5F290B1DE9E7F /* IGListAdapterUpdaterInternal.h */,
-				E0B0E3300CB46F0E146E93C537AE6763 /* IGListBatchUpdateData+DebugDescription.h */,
-				7E14008BBAC83E53CA444F44989DB052 /* IGListBatchUpdateData+DebugDescription.m */,
-				1F3751B73FEB5E127AA62659AE62B93E /* IGListBatchUpdates.h */,
-				9C46504759494FD1C69FC7D25DBCAA74 /* IGListBatchUpdates.m */,
-				B7C194B0F679AAC42180BAB3B6EA175C /* IGListBatchUpdateState.h */,
-				415174E37372C679DCAA9449AD7B7256 /* IGListBindingSectionController+DebugDescription.h */,
-				E8D916232B7570E68F8F5C12982E9041 /* IGListBindingSectionController+DebugDescription.m */,
-				6B80EE0AB5DBEB727B920BB3C6F57759 /* IGListCollectionViewLayoutInternal.h */,
-				11F595B6FDC08A260C3FA66A953E514D /* IGListDebugger.h */,
-				D4B90263B5A843B3DC09B13569F3CF91 /* IGListDebugger.m */,
-				149B4939E2C5274272E5C166A4864E0A /* IGListDebuggingUtilities.h */,
-				36D0FE4A81CF9AA5B8D3D54D66E76780 /* IGListDebuggingUtilities.m */,
-				7C5CA2A546B17646539BCD8DFB4938F7 /* IGListDisplayHandler.h */,
-				A1D7E38A7D2088C4862F42F97C853C9E /* IGListDisplayHandler.m */,
-				FB11653964C304B24481B1DEFF9879DD /* IGListReloadIndexPath.h */,
-				8EA67A0FFFB778AB24D4DC905BF4CC32 /* IGListReloadIndexPath.m */,
-				743FE50E582F13629065E9E3D173F5B1 /* IGListSectionControllerInternal.h */,
-				01A8E0CE6A5FEDF0D5397E9D892D4BB4 /* IGListSectionMap.h */,
-				2C1A62CC27BF00BA7B6959F7C6AD01C1 /* IGListSectionMap.m */,
-				7EB707861AB65F4AC265978084BFBF17 /* IGListSectionMap+DebugDescription.h */,
-				2AF5955A637E241EA5C4876D38D58C2A /* IGListSectionMap+DebugDescription.m */,
-				79B6F9B2C0B438C85E50BFBEA5396800 /* IGListStackedSectionControllerInternal.h */,
-				8972E1F0B57B0CC62B46737A66514188 /* IGListWorkingRangeHandler.h */,
-				686854EC36F333525958DAF35D34BAF3 /* IGListWorkingRangeHandler.mm */,
-				69A3121145912B37F42400B9368F3C64 /* IGSystemVersion.h */,
-				23DCD2B28629A40D0D57AD92F7636F19 /* IGSystemVersion.m */,
-				62694290E98BA20397F838188E9EF8A6 /* UICollectionView+DebugDescription.h */,
-				A2A941D2316F957BD7FE9D0C602768F1 /* UICollectionView+DebugDescription.m */,
-				7BD51DEB8E118A7ABBB4A895A47798A5 /* UICollectionView+IGListBatchUpdateData.h */,
-				2636800EBE1C3FB2ED2270629F17685A /* UICollectionView+IGListBatchUpdateData.m */,
-				24C30F79A131EEFB0194BE5C976F593C /* UICollectionViewLayout+InteractiveReordering.h */,
-				D46C8AB1244310CBF9D05EA5C7254514 /* UICollectionViewLayout+InteractiveReordering.m */,
-				68A7E11525116AE5E46B9D018450447C /* UIScrollView+IGListKit.h */,
-				3CB2F85056C4C607B6B6E7EC98DB9E84 /* UIScrollView+IGListKit.m */,
+				5C53C036466D56700A861DC6AEB03596 /* IGListAssert.h */,
+				EB01BBE6A6391233013E1108EFDF78B9 /* IGListBatchUpdateData.h */,
+				9524B68D686F4353973DFF7F69401316 /* IGListBatchUpdateData.mm */,
+				3EC204B851CACE33D675EC91C3A8D84E /* IGListCompatibility.h */,
+				0771E2085846501017113531E195A21A /* IGListDiff.h */,
+				6669E8CF240CABC4EF87825FC327953F /* IGListDiff.mm */,
+				E77509DC901BF91356013B155D5E526E /* IGListDiffable.h */,
+				378ED14285D196EA7607F251FC48E4D0 /* IGListDiffKit.h */,
+				7F812141078FAC52E986C6BCD1A92B4F /* IGListExperiments.h */,
+				AC663AEDA4088C8FB5BF939E922768B4 /* IGListIndexPathResult.h */,
+				7F6BBABD2DF0B6D7F6092794BD317D27 /* IGListIndexPathResult.m */,
+				83210F59EEEFBB281964DA57C76D5DC2 /* IGListIndexSetResult.h */,
+				B22042E362E658FE617639CD3B7C796D /* IGListIndexSetResult.m */,
+				DC04ED9FAC8E1E1434224647DC5C4720 /* IGListMacros.h */,
+				990F7D79A031CB4C220D4B5C547BB059 /* IGListMoveIndex.h */,
+				30400241FAEEEDF2758E249F39157FB1 /* IGListMoveIndex.m */,
+				868BF8C95FF47E5C246B00599DF42516 /* IGListMoveIndexPath.h */,
+				35ABBAEDC37A4EC6DD0A4E9D2361A744 /* IGListMoveIndexPath.m */,
+				2FAB28975EFFE2099E46F6F6B54C1C76 /* NSNumber+IGListDiffable.h */,
+				8F9E4628465A178BBD0D363303492D76 /* NSNumber+IGListDiffable.m */,
+				6E31CDC469669B8E02481E1B11FFBFFF /* NSString+IGListDiffable.h */,
+				C3690084CC7B9A8C0858FC685851FDBE /* NSString+IGListDiffable.m */,
+				7CA1E477615CA2E04EFDB7800AE2FE47 /* Internal */,
 			);
-			name = Internal;
-			path = Source/Internal;
+			name = Common;
+			path = Source/Common;
 			sourceTree = "<group>";
 		};
-		2289DE711A934E5C1435FB5562F832F3 /* Support Files */ = {
+		2CC45263ED78734D41004CF0DD02978D /* Default */ = {
 			isa = PBXGroup;
 			children = (
-				85F5CE0A1105CF699905AEAE503A46DC /* IGListKit.modulemap */,
-				5CDFA68B43C6C111AD1B7CA35B525991 /* IGListKit.xcconfig */,
-				B1E20FD3534F921890EC04B5037C00DA /* IGListKit-dummy.m */,
-				A7C9BDB2DE00A299CF507C2BAD98964E /* IGListKit-Info.plist */,
-				FA0A5B5EEAF52500FEB10AFBCF21A05A /* IGListKit-prefix.pch */,
-				2420CE41964AFD3450CEEB4EC6AFDF86 /* IGListKit-umbrella.h */,
+				BFA4624CE7818123F4F26FB1C46D9F3F /* IGListAdapter.h */,
+				752E3E997F94B90A778D42712A3F2E81 /* IGListAdapter.m */,
+				F0D36A5433BCC619E63BE6F74BD13E7D /* IGListAdapterDataSource.h */,
+				EA6268E165A136247E1C79C1D53A229C /* IGListAdapterDelegate.h */,
+				451ED9B182FA7882083A4E0E7697D10E /* IGListAdapterMoveDelegate.h */,
+				72AF28C067D1C890CD4152B2B289F637 /* IGListAdapterPerformanceDelegate.h */,
+				557439D3DDB574FCFCBBBB4521FEC778 /* IGListAdapterUpdateListener.h */,
+				7C11715F41C45CBCE595C680B3994B3A /* IGListAdapterUpdater.h */,
+				EEC2095FF630C62E3CDC81ADDE44AA2D /* IGListAdapterUpdater.m */,
+				DC901EB33E7C79EF784C4FE484616A92 /* IGListAdapterUpdaterDelegate.h */,
+				97526A171526748F051CBFD68F2EF9B4 /* IGListBatchContext.h */,
+				AD40AB3041240ECDF54846D942FE9263 /* IGListBindable.h */,
+				1FCD809B23AC7F8E26AB4E3021AE84CB /* IGListBindingSectionController.h */,
+				7D4FBF9B44F1D1C527E59932D8CEB24C /* IGListBindingSectionController.m */,
+				FBC96DA29603138BAEBE8AF60B8F48F9 /* IGListBindingSectionControllerDataSource.h */,
+				7FA51D190E02BCE46AB238C76FD7C7B4 /* IGListBindingSectionControllerSelectionDelegate.h */,
+				29F4E9770C067D926E6339A319F1BC13 /* IGListCollectionContext.h */,
+				FF7643D43E87E259550779FD70DD2797 /* IGListCollectionScrollingTraits.h */,
+				2BA734B0125D1B7290396F40B2800E39 /* IGListCollectionView.h */,
+				DB9F626C5894ADA202AB1DC2DAAB464B /* IGListCollectionView.m */,
+				E5B49DC88986D4C7C6BF583F1629DF54 /* IGListCollectionViewDelegateLayout.h */,
+				A4BEBBE604D583277C35FB3F47AD0A03 /* IGListCollectionViewLayout.h */,
+				C84C85F00F04CBDCB4B88A6AF39815CF /* IGListCollectionViewLayout.mm */,
+				3BF9436F51B58C6EEF41CF905A8B9075 /* IGListCollectionViewLayoutCompatible.h */,
+				D22847B3CDED5FB0E35212C5397ABB95 /* IGListDisplayDelegate.h */,
+				3B5EC58E30A22BC07F49E583FF13DC38 /* IGListGenericSectionController.h */,
+				BA17F8C5B6E033DAFA1F70CF53CCA68B /* IGListGenericSectionController.m */,
+				D8B3B7637451F48B7CD12B966F1A9F1B /* IGListKit.h */,
+				4F8A668E9712C40062603117B03A22EE /* IGListReloadDataUpdater.h */,
+				16C154D66B7A4B1B7BD647A97E5ADB91 /* IGListReloadDataUpdater.m */,
+				B0CF85D82A0634F8DA990F797B18BC33 /* IGListScrollDelegate.h */,
+				3BA48420AC58C6C0DB94318D18A8E8AF /* IGListSectionController.h */,
+				E1EEF85288E2EE4836942CECBB0428A0 /* IGListSectionController.m */,
+				B7E611DD892F73D0174581C3D304EBB5 /* IGListSingleSectionController.h */,
+				41C2ABF2EC14D10E3DD732632E7317AC /* IGListSingleSectionController.m */,
+				DBDD45BA9A4EEB0980889C51FDAFEC03 /* IGListSupplementaryViewSource.h */,
+				27C15DF7E700F07C9797E799F2D5FAF0 /* IGListTransitionDelegate.h */,
+				44B2020520F57C4D260E6C653E5DFFBB /* IGListUpdatingDelegate.h */,
+				D70EE9B7CECF23985B790A3823D98355 /* IGListWorkingRangeDelegate.h */,
+				202801649DD0CC1392EB85C46FA82FDF /* Common */,
+				FEA20A979075128839D49FE318FFADB8 /* Internal */,
 			);
-			name = "Support Files";
-			path = "Examples/Examples-tvOS/Pods/Target Support Files/IGListKit";
+			name = Default;
 			sourceTree = "<group>";
 		};
 		383B90AE68E5D0361DA3D2BCDAA9B912 /* Targets Support Files */ = {
@@ -447,122 +454,10 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		4E04F373EBAB661D90AB01F823BFDAB1 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				FC8F200F2B3CFB240FD10DD3B84BBA4F /* badge.svg */,
-				2E6C8A986D4AE18A487EDB9DE7B34319 /* best-practices-and-faq.html */,
-				347B1DF9984F508AC0B5D4C47C505A4C /* carat.png */,
-				A07DE671ACEBE4206D3AFBBF594793B1 /* Classes.html */,
-				83E0F6E6C1A818BBB64BA6A068E4DD68 /* Constants.html */,
-				FE30AAEECA885B16EBB35AE56A03F8EC /* dash.png */,
-				53629EF923E6638D616BF356F216D0A7 /* Enums.html */,
-				5AEFEACAF9387A355DE5D7B4CBED1C0E /* Functions.html */,
-				5C457D3D4FD7B70069E5F47E6BBCA865 /* generating-your-models.html */,
-				250CD9CE94FE45466DBABBE78044F096 /* getting-started.html */,
-				8488BF3D306A4F98FFE63C0C34A67EB7 /* gh.png */,
-				ADB5DE04A399436547677B5FA94D89AC /* Guides.html */,
-				6ACAD7F7A58065174A2601520F6B2483 /* highlight.css */,
-				8F9E474B3AA7CC7D314FF1D92E174D0D /* IGListAdapter.html */,
-				D545077F07455288973D1FCAC6A45A93 /* IGListAdapterDataSource.html */,
-				AC6C75B671CA9379B82DE2E46D2538B9 /* IGListAdapterDelegate.html */,
-				98429D09463111806069C97FFBB4C3B5 /* IGListAdapterMoveDelegate.html */,
-				97E93F460F79F89FCFBE8556C3130773 /* IGListAdapterUpdateListener.html */,
-				E66E82AA73F5CAFF72970FA02B764E22 /* IGListAdapterUpdater.html */,
-				BC1798F2AAA1C44C0259B22B60DAC12E /* IGListAdapterUpdaterDelegate.html */,
-				AD85AE76B370D8DA9FE49B38C579EE9C /* IGListAdapterUpdateType.html */,
-				7A77E320D9278AEAE76811DD6A623C86 /* IGListBatchContext.html */,
-				F7A75809C92FCBEF36E8F5922430B809 /* IGListBatchUpdateData.html */,
-				58E6337F20AA586DC618479560C61792 /* IGListBindable.html */,
-				AC3DC18E81A3DB6A9AF746B1D474877F /* IGListBindingSectionController.html */,
-				2EF8B2416C245DFEFCEF81D07E8497E6 /* IGListBindingSectionControllerDataSource.html */,
-				7F142E3021CAFC41168357CAEE857470 /* IGListBindingSectionControllerSelectionDelegate.html */,
-				E81B3766891DB909524A06CB85F60865 /* IGListCollectionContext.html */,
-				3B970D5837C65B7C7AABFB21F7349C7A /* IGListCollectionView.html */,
-				299BB696E57FD78EF83ACD902DEC7B70 /* IGListCollectionViewDelegateLayout.html */,
-				6BD61DC6E2371341E420BBB7FE0FC542 /* IGListCollectionViewLayout.html */,
-				57CDD06CCFE6D5E8B56D1FCCB6EA6F8E /* IGListDiffable.html */,
-				D532BDC1DEFAD50B99ACE01BBCB61C7E /* iglistdiffable-and-equality.html */,
-				EC6B52548405A8709A20E62B16707B4E /* IGListDiffOption.html */,
-				F9F67BAB249CAB3FE74B50C195BBE7C3 /* IGListDisplayDelegate.html */,
-				CDA11FA38E419A0A6390D00E7C9358C6 /* IGListExperiment.html */,
-				C62BD1911BDD5ED1E8C3C9C9B1AD9124 /* IGListGenericSectionController.html */,
-				F3343E915A0ACCABD231D51BAB8E1CF9 /* IGListIndexPathResult.html */,
-				C1BA2FD09982FF72B87995903CAE1FD0 /* IGListIndexSetResult.html */,
-				FAD767559901480BBCDB4DE5AC1F08FC /* IGListKit.podspec */,
-				87C673091031357C5311C8103A9F6AE0 /* IGListMoveIndex.html */,
-				4C0BE4506870F583F018A0948E118642 /* IGListMoveIndexPath.html */,
-				22F2B5651FC5691E88B29E0CEACC894F /* IGListScrollDelegate.html */,
-				FB8C8D8B777CBF48CBB93332A5930BFD /* IGListSectionController.html */,
-				FB3B346EC139D857E04E3F846D7CFDF5 /* IGListSingleSectionController.html */,
-				4E94A701A2C8F645308872A1D1CECC53 /* IGListSingleSectionControllerDelegate.html */,
-				CFAEE6376D59A153C4AE6FB7E5097FEC /* IGListStackedSectionController.html */,
-				AC6AA87A7B7A3D56217D5F8302EF2EC6 /* IGListSupplementaryViewSource.html */,
-				534081990B3A69B3A3E6E35D7C6A0A42 /* IGListTransitionDelegate.html */,
-				4662CA2365B32D37CBA929352FE567EF /* IGListUpdatingDelegate.html */,
-				7C07ABB5703D70F5AAD92544668BA846 /* IGListWorkingRangeDelegate.html */,
-				C8338F04F1DF7C1F900FF59F89EFAC59 /* index.html */,
-				15948EF546563F3601C8AD6EBFB61B3A /* installation.html */,
-				B84F280A40187163E5678AE7C76D7EB0 /* jazzy.css */,
-				0140D92319C66456405A2D25B028C555 /* jazzy.js */,
-				025338DE5F92CD26D21ECBCCCF35F178 /* jquery.min.js */,
-				AAE937562C084DD587F1BF54759F80DC /* LICENSE.md */,
-				327071D938A768D568D9459284C91652 /* migration.html */,
-				0D3D2A70A351A1B27305FFEB26B108AB /* modeling-and-binding.html */,
-				5919EFCC22F7C1399B4720A6CFA95254 /* Protocols.html */,
-				CC5492764E481E05B0F8F7E246530BB8 /* README.md */,
-				56CBD388A002C794BE073ACA6B24CCEE /* search.json */,
-				FCAFC758882C2CDD08475683C973D59B /* Type Definitions.html */,
-				83B34633ACB3B2B949437A4B66640B44 /* undocumented.json */,
-				249D1B80B319A7966B4B7C15B481D6BE /* vision.html */,
-				F996A1F582BB431F19BFA4C6FE3A8271 /* working-with-core-data.html */,
-				D48138098CF97E32ABD630FB7EA21505 /* working-with-uicollectionview.html */,
-			);
-			name = Pod;
-			sourceTree = "<group>";
-		};
-		53B7413CE8844A8EE7CDFB82BD964C37 /* Diffing */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Diffing;
-			sourceTree = "<group>";
-		};
-		5946358EF9D80711A66A3084FFEF30FC /* Common */ = {
-			isa = PBXGroup;
-			children = (
-				B33A467275A5EE43F8C330E9185FBA6D /* IGListAssert.h */,
-				62C291DAA7F2B9D281E999B4878BC582 /* IGListBatchUpdateData.h */,
-				FEB4BCCAC44453E24732E5EF11DCAF7D /* IGListBatchUpdateData.mm */,
-				32E967142A67AC34858D39AC29313CCD /* IGListCompatibility.h */,
-				B70328A2E0A3F72BA82672881851B80B /* IGListDiff.h */,
-				B512206520F88C251E446BA93F7EE7FF /* IGListDiff.mm */,
-				6E9E077E7E1A733778A42E0E0CCC0A45 /* IGListDiffable.h */,
-				3B087726B793A58C6C933D64E562A32D /* IGListDiffKit.h */,
-				7AD55BAAC438E3FDE5AF6BFE90EFE713 /* IGListExperiments.h */,
-				0570D4B23B361A7D9CD610DBE3EB4B90 /* IGListIndexPathResult.h */,
-				F4DECCF61780200270778DF515EC496A /* IGListIndexPathResult.m */,
-				798F1F6F8FC5CE54BDDCD8740F3A6E5C /* IGListIndexSetResult.h */,
-				3EAFB73895317F9A670C6DEAA39E2EB8 /* IGListIndexSetResult.m */,
-				E260A0FB8163D90890C8EDCA45255300 /* IGListMacros.h */,
-				8E9BB6D359B6DECF013E01A04A18FAE4 /* IGListMoveIndex.h */,
-				BA324DBA4D116701215F00F1D442031E /* IGListMoveIndex.m */,
-				489D58E145A8814DCFC8193EA5C2E876 /* IGListMoveIndexPath.h */,
-				0CCED269E2E7BC03D5CD1D53573DDDDB /* IGListMoveIndexPath.m */,
-				82ED09E1C96818B56F1098DB0AC949A8 /* NSNumber+IGListDiffable.h */,
-				35DD6A7BFAD9E6B98EAD5076384F9081 /* NSNumber+IGListDiffable.m */,
-				033080E7DAE490140BABD859A77CD09D /* NSString+IGListDiffable.h */,
-				188D8DE4C52A4752D518B64EE7B26DE7 /* NSString+IGListDiffable.m */,
-				E509DB949BA6A2598FA1F66DD814805D /* Internal */,
-			);
-			name = Common;
-			path = Source/Common;
-			sourceTree = "<group>";
-		};
 		687E31D44AF41B23BE69084C193D6B18 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				069E2C10290294C31BA43D5795A04751 /* IGListKit */,
+				104F3608AA9BC3912F599C3511969164 /* IGListKit */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
@@ -584,54 +479,91 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		9CD888FA4FF887E90F9C9CA1ACC3F948 /* Default */ = {
+		7CA1E477615CA2E04EFDB7800AE2FE47 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				43E27A2AF52114A34151624E40F01224 /* IGListAdapter.h */,
-				2D2637E8C35C5982C271EC7753E0B648 /* IGListAdapter.m */,
-				3A3DCE9B5057E863E71ADAB91B5EA88B /* IGListAdapterDataSource.h */,
-				8E790A45A397CAC4AD5FD6D403F6AAAD /* IGListAdapterDelegate.h */,
-				23DCBFCE667AB8405F67973A03E4480E /* IGListAdapterMoveDelegate.h */,
-				23D8B546152A3EC32AF19CA7D5D07B8A /* IGListAdapterPerformanceDelegate.h */,
-				7BB9E2672FD3F3529F9C80E3642BBD51 /* IGListAdapterUpdateListener.h */,
-				26C78D8E281288D5585AA3A4FB5AC507 /* IGListAdapterUpdater.h */,
-				C051E1AFD1CC4F94690E2E02A3B394FF /* IGListAdapterUpdater.m */,
-				008E078085E5CBACBF071FC95E37A05B /* IGListAdapterUpdaterDelegate.h */,
-				C69FDA626A5D4AAB26BF806565E138D1 /* IGListBatchContext.h */,
-				4A8315EF72DC73C7AB140FD2231C5215 /* IGListBindable.h */,
-				883A820D9F5DBA472227193B19842D13 /* IGListBindingSectionController.h */,
-				DFD0F67723798B582076129F6566AA6C /* IGListBindingSectionController.m */,
-				4AA5FD6A83C251EE1811A9255A497697 /* IGListBindingSectionControllerDataSource.h */,
-				D1460B5DFF0A80A4D7EEFCBE64677FDB /* IGListBindingSectionControllerSelectionDelegate.h */,
-				F9036766D2AE85DD0A0A7A0D2323CB09 /* IGListCollectionContext.h */,
-				41ECAE5C3A5838272DE3E6050568CF75 /* IGListCollectionScrollingTraits.h */,
-				860CCB618D514D62DAD8916E53A937E1 /* IGListCollectionView.h */,
-				8AFADD9F5188146104C26AC277B8994D /* IGListCollectionView.m */,
-				574C0496D80A99F9405D469520056267 /* IGListCollectionViewDelegateLayout.h */,
-				83279AD01B1A458091ED0813A6955E94 /* IGListCollectionViewLayout.h */,
-				3631514648B3D2E10ADD3BBF4C0D9CF7 /* IGListCollectionViewLayout.mm */,
-				DC60C4B845BC59AE0C874BBC4736F161 /* IGListCollectionViewLayoutCompatible.h */,
-				2EC7416DD068D1BD076ABFD8DD732577 /* IGListDisplayDelegate.h */,
-				97DBAAAB328E840C239E4BE42CEBE8ED /* IGListGenericSectionController.h */,
-				B4DFDC546D6C9201470E212F6FEC2D53 /* IGListGenericSectionController.m */,
-				563DB9FB0110ABD5F4C87BFB3A9C0CA0 /* IGListKit.h */,
-				3425853BBD44F3961F19B71D7B8B6C79 /* IGListReloadDataUpdater.h */,
-				3248F2BEFAD4A9B5D4607820B7A7417B /* IGListReloadDataUpdater.m */,
-				BFBCBB4200399BD318EF408096C885EB /* IGListScrollDelegate.h */,
-				D1C8DDF5BA982C10F975BA827D12F430 /* IGListSectionController.h */,
-				84D4584ED339BB369CAD0DA8FAD40C04 /* IGListSectionController.m */,
-				A7A5F144990E42E7E7F98054A3BD913C /* IGListSingleSectionController.h */,
-				F95771ACD4A92ADD45F2C7007212A805 /* IGListSingleSectionController.m */,
-				7EAF0CDC4F7D519F26BF3B9567967E13 /* IGListStackedSectionController.h */,
-				26952F184BB0B349D3CA073AA7B22FD7 /* IGListStackedSectionController.m */,
-				3A91B591449672B70EFC34E5DC7FC2DE /* IGListSupplementaryViewSource.h */,
-				3FB64D7270DB5AA0DD15A428602BA72B /* IGListTransitionDelegate.h */,
-				5A60A116EF7A80CCF65D693A01AA64E9 /* IGListUpdatingDelegate.h */,
-				9AFB8CAB7342FB0B45FC211C8D6BD8AF /* IGListWorkingRangeDelegate.h */,
-				5946358EF9D80711A66A3084FFEF30FC /* Common */,
-				0EE36C14988F4B749E2D4DF78A61937D /* Internal */,
+				007F0F773689E30244859FE3804C081B /* IGListArrayUtilsInternal.h */,
+				BF5C82FE9F82ECABD06498FCDBF2902B /* IGListIndexPathResultInternal.h */,
+				37B4EF0DB0FFA8A36C8B575B3B927920 /* IGListIndexSetResultInternal.h */,
+				D838450F8E0D164349A3470C9346DF90 /* IGListMoveIndexInternal.h */,
+				EF251C87925E981E746A6B4FD99B0C2E /* IGListMoveIndexPathInternal.h */,
 			);
-			name = Default;
+			name = Internal;
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		9006F9784D82E2087C42D757134B8320 /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				58E10324C362A266742BF8BE65FDD635 /* badge.svg */,
+				2F8059AF7E79E79C9475C37FCE68B3F8 /* best-practices-and-faq.html */,
+				8A9856D52D7B275F82F234C54119F04A /* carat.png */,
+				20FF0A6862FA86E363C0EC59BE7CBD82 /* Classes.html */,
+				2C8CE8FA43765F32479D4BF097AC917A /* Constants.html */,
+				9ED0E95CA3D89A17E425CC6D6AF114FA /* dash.png */,
+				BF72C26F2E4F640088FDA2C5FA5D3DE0 /* Enums.html */,
+				6B145588E251C0BF3EA8500BBE138403 /* Functions.html */,
+				0A28DEF2D9134159434923A19D2BAD19 /* generating-your-models.html */,
+				F6236916C13176231F363334E738296E /* getting-started.html */,
+				A6C3E0349F10F8088F48E35928291511 /* gh.png */,
+				19E801A5B355BB6709EEBCA0E11F6D61 /* Guides.html */,
+				03EFE5BF9C99A7FA7E3E3BDDDDB14E96 /* highlight.css */,
+				1A945075F8DEC4A99B1BC379CE98C3D5 /* IGListAdapter.html */,
+				B27C0F59186E63E7362D78634D8F2B69 /* IGListAdapterDataSource.html */,
+				17168E12B516FC2D437D953D1D3945CA /* IGListAdapterDelegate.html */,
+				2830BF4DB98E6D1D5443A19D33852ED9 /* IGListAdapterMoveDelegate.html */,
+				C03D612CCA85B9502DB9BD7D2C722922 /* IGListAdapterUpdateListener.html */,
+				834105A9BE125299CFD399D0AB4688C0 /* IGListAdapterUpdater.html */,
+				1B2479B244994949F4B8AB48482D235C /* IGListAdapterUpdaterDelegate.html */,
+				1257ACEB4C79BD9EBF97035FE95C70A8 /* IGListAdapterUpdateType.html */,
+				224CEA50CF837C0AE490645B9A81F531 /* IGListBatchContext.html */,
+				8E4F8FFADB70D93DF9342AB725E6D73B /* IGListBatchUpdateData.html */,
+				02FB4D57200CA4255A1A27CE46B92CCC /* IGListBindable.html */,
+				F6820A7751EDB381703124589782AA0F /* IGListBindingSectionController.html */,
+				314892D745B03A25D25171B9D57554C3 /* IGListBindingSectionControllerDataSource.html */,
+				2E4869B037A9B7A01D66EB24642F6184 /* IGListBindingSectionControllerSelectionDelegate.html */,
+				2D16AF72ED30423E249AB2CFB9984999 /* IGListCollectionContext.html */,
+				0F73691980A250D56726AD81F4DE4746 /* IGListCollectionView.html */,
+				FE52E6CDEB93C791408A7B0455305F62 /* IGListCollectionViewDelegateLayout.html */,
+				48DF22CBDF2D9AA52DE0986EEF4F2336 /* IGListCollectionViewLayout.html */,
+				A6C3E884ADC8026A2A12139846E90F1B /* IGListDiffable.html */,
+				312B77AD67A49B0BD8FFEAB87C3A2763 /* iglistdiffable-and-equality.html */,
+				0A3718D00E137159845EBFA52B9D0B03 /* IGListDiffOption.html */,
+				6A5E9C1015C9EA2186D8D2685FAD7F1C /* IGListDisplayDelegate.html */,
+				48B66893D0F358DFC6F94A4A7240AEE6 /* IGListExperiment.html */,
+				EA5E822DFD101BC0E6EBC8CB5F5D2E51 /* IGListGenericSectionController.html */,
+				E55F03BF675483538AE02DCC9E182A09 /* IGListIndexPathResult.html */,
+				AD8BCAE50DFE55681081BC20B383F96A /* IGListIndexSetResult.html */,
+				20733D11D25E38C4FBA3DEBC32EAFAF6 /* IGListKit.podspec */,
+				0F359C0DD6ACC522E2B69F0E46AE0862 /* IGListMoveIndex.html */,
+				7F456DD4F20ACCA5BB684DE87DE18105 /* IGListMoveIndexPath.html */,
+				8B174878B8023103E5329A9DD7F704FD /* IGListScrollDelegate.html */,
+				F1590794D469BB5CA8D02C98A8107537 /* IGListSectionController.html */,
+				E55484DD0ECF569D60694313347A2BE7 /* IGListSingleSectionController.html */,
+				812F3CC66646DA80AF409DD9C99DE524 /* IGListSingleSectionControllerDelegate.html */,
+				004B2432EC6AC3D146BDE8BC07DC58CC /* IGListStackedSectionController.html */,
+				33B0C97FD46A2A926E41BD7014C41577 /* IGListSupplementaryViewSource.html */,
+				35F62C1A0EF1789EB57097E56C3227F4 /* IGListTransitionDelegate.html */,
+				B0BB0E7DF7C4BFB310BEC1BD4C2B8FCC /* IGListUpdatingDelegate.html */,
+				A9574D6393E97469F2446297CBF3B968 /* IGListWorkingRangeDelegate.html */,
+				E363FD3CA762C92B6F2991B5D869D1A4 /* index.html */,
+				87F7C66E97DA10342D23CE8DDB9C08E1 /* installation.html */,
+				5EDC78E548D85BD196F1A2694ECA37F6 /* jazzy.css */,
+				CFEF48AE97A505C40074B0CD4B11A222 /* jazzy.js */,
+				78B234C5E7DEF10B76DCBEA00C838B48 /* jquery.min.js */,
+				BC083790FD4C0AFE69FBDFB2F37C0F7A /* LICENSE.md */,
+				D68F3F6EA1657583F1FC965E1E83B7DD /* migration.html */,
+				819B414164D207CC334E0399EDC280A5 /* modeling-and-binding.html */,
+				0BFD300F4F6699A06155A832AA82700C /* Protocols.html */,
+				588B448D71BD2E7BFE9D1AE58885A5DF /* README.md */,
+				1DE2F3501F90CB454B9A54532DAF33CE /* search.json */,
+				6E303B2030CAC6CEBFCAEEF61980CAFB /* Type Definitions.html */,
+				304A7C4D3128540EE5890E8CA437379A /* undocumented.json */,
+				C8E06E61E38B9763EC0A58A313AA2BB6 /* vision.html */,
+				C4440EB3C5A1F17E5F9234BB007CC963 /* working-with-core-data.html */,
+				4580025430C4A44F3305BBEA866AC2E2 /* working-with-uicollectionview.html */,
+			);
+			name = Pod;
 			sourceTree = "<group>";
 		};
 		BA0B6F13E5A1E04B5B2DA134DC581D4E /* Pods-IGListKitExamples */ = {
@@ -651,6 +583,27 @@
 			path = "Target Support Files/Pods-IGListKitExamples";
 			sourceTree = "<group>";
 		};
+		BC1B615BC753F8145F324402330A502C /* Diffing */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Diffing;
+			sourceTree = "<group>";
+		};
+		C0A3DFB6D0A401BE583B994639AB821A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				5112340F00F1F4A85D487204BC4D147C /* IGListKit.modulemap */,
+				A920DCE0F3C24C36F41D7C0E4D2959F4 /* IGListKit.xcconfig */,
+				7F37A7E042B9E7B824C1B2299628EA6D /* IGListKit-dummy.m */,
+				25B861B5D13C549517BD1B203F97D15E /* IGListKit-Info.plist */,
+				A130B4E161084BD481263A37BBE7C621 /* IGListKit-prefix.pch */,
+				6C8BE0DE56665816514B7B4714532123 /* IGListKit-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Examples/Examples-tvOS/Pods/Target Support Files/IGListKit";
+			sourceTree = "<group>";
+		};
 		CF1408CF629C7361332E53B88F7BD30C = {
 			isa = PBXGroup;
 			children = (
@@ -662,19 +615,6 @@
 			);
 			sourceTree = "<group>";
 		};
-		E509DB949BA6A2598FA1F66DD814805D /* Internal */ = {
-			isa = PBXGroup;
-			children = (
-				F3CDC354267668792E43CBED92D2D80F /* IGListArrayUtilsInternal.h */,
-				4E417CC7E63825AD82FFC0A046DE113C /* IGListIndexPathResultInternal.h */,
-				EB7C63E83A0B28810376DFFD8774AEA4 /* IGListIndexSetResultInternal.h */,
-				D96310E4479763D45D35DCF2803D63F4 /* IGListMoveIndexInternal.h */,
-				2A0E48D9F7D3895D5EAF562BAD2DECB4 /* IGListMoveIndexPathInternal.h */,
-			);
-			name = Internal;
-			path = Internal;
-			sourceTree = "<group>";
-		};
 		F59DF7C8727D61B1395D8F82863AE4E7 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -684,89 +624,138 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		FEA20A979075128839D49FE318FFADB8 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				1964F22A392BA4DCD1169B3E45451A66 /* IGListAdapter+DebugDescription.h */,
+				33634685462FB991AB3FD49B80DC454F /* IGListAdapter+DebugDescription.m */,
+				0F105B8CF11E614C103B34A54D9E51F3 /* IGListAdapter+UICollectionView.h */,
+				E73BC32AA0F76C800E8908A6B3C42790 /* IGListAdapter+UICollectionView.m */,
+				C188D91462C16F01A3E02F212B08E003 /* IGListAdapterInternal.h */,
+				5259ADD1BE816E14314F2FECB0BC5894 /* IGListAdapterProxy.h */,
+				CD7E1029929FE53C957D372E0BEBE005 /* IGListAdapterProxy.m */,
+				26089596EEC9E2C7B0581E87FE581733 /* IGListAdapterUpdater+DebugDescription.h */,
+				7610BD2A59929BFCE2043AC2CD3CE1D8 /* IGListAdapterUpdater+DebugDescription.m */,
+				A8FF58A75C0FC925FB853C2EB6AAD781 /* IGListAdapterUpdaterInternal.h */,
+				D32926E306D69EB82C2A08352B12C459 /* IGListBatchUpdateData+DebugDescription.h */,
+				71AD5B51808292764E22529D74D7318B /* IGListBatchUpdateData+DebugDescription.m */,
+				44C6BA16AEAE34F42C7B57D7090CEBBF /* IGListBatchUpdates.h */,
+				7F9FDCCADB974D16C0188511D9299907 /* IGListBatchUpdates.m */,
+				012B3E1C5626CDF6C32CBCA8E14D5FE0 /* IGListBatchUpdateState.h */,
+				CEBD27C8A40F0A06F44656CA39F0E012 /* IGListBindingSectionController+DebugDescription.h */,
+				D4EF7437C981623A3B293E902588C06B /* IGListBindingSectionController+DebugDescription.m */,
+				FE9FA9E9A57FEDD3BD8F51E5116C7555 /* IGListCollectionViewLayoutInternal.h */,
+				EE5E35F9A82E6D39139EC34031D831CD /* IGListDebugger.h */,
+				E1D21D3A338001C9842D2B1616BDF632 /* IGListDebugger.m */,
+				E5CCCBBF2E6F6EF9FCFB67E955E7C68B /* IGListDebuggingUtilities.h */,
+				C610821FDDA6D2231D085843FC6DC242 /* IGListDebuggingUtilities.m */,
+				10FA7756E5D4FC447ECBD9B3BDCD08DA /* IGListDisplayHandler.h */,
+				F773D18ABAE135A6E1D5D76A698EA10D /* IGListDisplayHandler.m */,
+				0DCAF230EF43E174D67434F83EAFBE02 /* IGListReloadIndexPath.h */,
+				5ACC254639EE1A7602BF41F25EED9E01 /* IGListReloadIndexPath.m */,
+				860541A2716D9453C1A7EEEA2A131B31 /* IGListSectionControllerInternal.h */,
+				106CA0425A27F3F8C12A3A23317460BF /* IGListSectionMap.h */,
+				BBAA828E8BFDA9BF14A22C98D2B135FE /* IGListSectionMap.m */,
+				729FFC51BA0A0B13C6F1A9FDC0D4C343 /* IGListSectionMap+DebugDescription.h */,
+				DB895118AD753C2EFCDD6A73FD4A745A /* IGListSectionMap+DebugDescription.m */,
+				43C978E2D79271335866B7D0DD0582F1 /* IGListWorkingRangeHandler.h */,
+				0C2D1A66F9E1F55FD874F70560B0D8DF /* IGListWorkingRangeHandler.mm */,
+				7D5879AF5DFBA075134C34FA0BE32085 /* IGSystemVersion.h */,
+				B0FFAA09371EBE42012FDE64C925C73A /* IGSystemVersion.m */,
+				045A80642FC43FBA50FBC69FF1CDF318 /* UICollectionView+DebugDescription.h */,
+				302A71A00989DD5368033503C0549E02 /* UICollectionView+DebugDescription.m */,
+				FDE51513C020EFFAD2A183A146732FBC /* UICollectionView+IGListBatchUpdateData.h */,
+				57DD564F20A17DD50E7EBC3A411202F9 /* UICollectionView+IGListBatchUpdateData.m */,
+				F9D07B7E789DE06B7A7AA4A9F45A975E /* UICollectionViewLayout+InteractiveReordering.h */,
+				D6940BBB133FD96832217E7DC50F5CD8 /* UICollectionViewLayout+InteractiveReordering.m */,
+				9A8A3B78D4AB97C97C29414E37A74F24 /* UIScrollView+IGListKit.h */,
+				389AD9B267953379243C7F2113074234 /* UIScrollView+IGListKit.m */,
+			);
+			name = Internal;
+			path = Source/Internal;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		F7C0172DC4609B819C483A59E0927771 /* Headers */ = {
+		79D111E9C4E749D733B9F6253B7D48C1 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B46B92DA6C28CB6F5322747DA7FA9259 /* IGListAdapter+DebugDescription.h in Headers */,
-				C53C3D9ADC9FF6A72B758299182BF2EF /* IGListAdapter+UICollectionView.h in Headers */,
-				69C18F1791460A078F2E7503DF52D3A9 /* IGListAdapter.h in Headers */,
-				083707D4DFB99E435B8AB9E765D21F01 /* IGListAdapterDataSource.h in Headers */,
-				52DE97F84FF8E239C11E6946678B3752 /* IGListAdapterDelegate.h in Headers */,
-				078EE7F0A6C0C05D4ADC51A649E71D8A /* IGListAdapterInternal.h in Headers */,
-				BD9BCBC78D070DFF8403401E12EFD09B /* IGListAdapterMoveDelegate.h in Headers */,
-				CF552B2C48B9493D33F1C7FEB4852AAC /* IGListAdapterPerformanceDelegate.h in Headers */,
-				43BFAA66A206E8A6F9D8301F70B0AE4D /* IGListAdapterProxy.h in Headers */,
-				E8BFE6C8932B728BADACF1C377CC232C /* IGListAdapterUpdateListener.h in Headers */,
-				1E7429F48A1A2FD6C378A301CBC97251 /* IGListAdapterUpdater+DebugDescription.h in Headers */,
-				42F62DDD9364FC4702EABDE4FB168626 /* IGListAdapterUpdater.h in Headers */,
-				CCB60B65002D2605C230376170062394 /* IGListAdapterUpdaterDelegate.h in Headers */,
-				AB3D3CF8A734B837A488538B52411004 /* IGListAdapterUpdaterInternal.h in Headers */,
-				7C29839EB19D7F709F28FED9CB32402D /* IGListArrayUtilsInternal.h in Headers */,
-				A9A9279564936FE0EAF95F89EB0B8AAD /* IGListAssert.h in Headers */,
-				426248B7E67B3A847AF1B1BD2A19A103 /* IGListBatchContext.h in Headers */,
-				7B356E78CB42542D40440815A32AC0D0 /* IGListBatchUpdateData+DebugDescription.h in Headers */,
-				8C567AD1964B194962A00D3E5AD25E27 /* IGListBatchUpdateData.h in Headers */,
-				85360445E5C3E9174495212901A7490D /* IGListBatchUpdates.h in Headers */,
-				558A1592B706959921A3548BF42088F4 /* IGListBatchUpdateState.h in Headers */,
-				2BC5A51D82B86957A3BFC7B16F988040 /* IGListBindable.h in Headers */,
-				D2E724C95E02C007C0C65791B11865FB /* IGListBindingSectionController+DebugDescription.h in Headers */,
-				63BDFADF7142DE39365962DCFDF68E5F /* IGListBindingSectionController.h in Headers */,
-				076D3C5F732E7060BFD8115BE93C5504 /* IGListBindingSectionControllerDataSource.h in Headers */,
-				332DF287144C586ED4D9CE3C2297656B /* IGListBindingSectionControllerSelectionDelegate.h in Headers */,
-				D2198FE4B115B262C08ED2B1164838DA /* IGListCollectionContext.h in Headers */,
-				6B074FAE1C973F3B2FD5A329D8400CF5 /* IGListCollectionScrollingTraits.h in Headers */,
-				E5F12B8EFEBBC571F67F578DC427BF82 /* IGListCollectionView.h in Headers */,
-				08C84BEE894A14E5766B5C50E23274FC /* IGListCollectionViewDelegateLayout.h in Headers */,
-				73E9A9FDB94FB973A3582D675BAF95FF /* IGListCollectionViewLayout.h in Headers */,
-				3A94977553916C52A0235B48111926ED /* IGListCollectionViewLayoutCompatible.h in Headers */,
-				78CAAB972EBDE8B6D7E8EA4C8950177A /* IGListCollectionViewLayoutInternal.h in Headers */,
-				3D1D111DEF3B0541CC0715B8F070075F /* IGListCompatibility.h in Headers */,
-				17DEE94EE7607E6C31C347D1872A83C4 /* IGListDebugger.h in Headers */,
-				2AD3B0BF6A79019B8C6814F242C804D1 /* IGListDebuggingUtilities.h in Headers */,
-				25D85AC1A76829D45B602529486E1703 /* IGListDiff.h in Headers */,
-				92A0098963EEABBCE7891AEF2BBEFEB9 /* IGListDiffable.h in Headers */,
-				369279995C112E3620C3DFF8675BA23B /* IGListDiffKit.h in Headers */,
-				1F1B534348B5B6583D691176D3FA980C /* IGListDisplayDelegate.h in Headers */,
-				C61723062C613D10AE505D7D3C851A3F /* IGListDisplayHandler.h in Headers */,
-				89C9164445EBBEE72A39B233293B1DAC /* IGListExperiments.h in Headers */,
-				216E86A5811F0D2957308B2985C906A1 /* IGListGenericSectionController.h in Headers */,
-				4783C07C11C07427C43BBCC93AC5143C /* IGListIndexPathResult.h in Headers */,
-				3F8CF4DE5BAEBEE19C08579E38BB776C /* IGListIndexPathResultInternal.h in Headers */,
-				EEA0D92EB192DB986DB66AA5371AA45D /* IGListIndexSetResult.h in Headers */,
-				E7F66F981EF91FC8B590E7B75487053B /* IGListIndexSetResultInternal.h in Headers */,
-				6D1F1EC22DF9780694EF665E670E5D1A /* IGListKit-umbrella.h in Headers */,
-				10CF8697DC9BF0D2014652FC30C3DDDC /* IGListKit.h in Headers */,
-				281DEA132034220BBC681103A1AF5CE1 /* IGListMacros.h in Headers */,
-				AE0BD12CEAA45873317AE6718BC8506D /* IGListMoveIndex.h in Headers */,
-				FD153EA9B5A2B8D878F3DEF858A6A3A0 /* IGListMoveIndexInternal.h in Headers */,
-				C4D746E4DD31BF495BAD1E424D3E67CA /* IGListMoveIndexPath.h in Headers */,
-				22D3785E32AAA7E050355166AB53F34E /* IGListMoveIndexPathInternal.h in Headers */,
-				CDCE0F8949FCDA85DCC07A91EA102106 /* IGListReloadDataUpdater.h in Headers */,
-				1F20AAB4355466D60A46BDA391AB86EE /* IGListReloadIndexPath.h in Headers */,
-				B15652D58487B23119F5CD952287BF46 /* IGListScrollDelegate.h in Headers */,
-				3876E9EB11373F8E2EF342CB3691BAED /* IGListSectionController.h in Headers */,
-				B5C62515D6137F11E5EE5A150FA4EEA5 /* IGListSectionControllerInternal.h in Headers */,
-				55D072F3C077B3BF47C2A71295522BD9 /* IGListSectionMap+DebugDescription.h in Headers */,
-				775D3EA9ACADCB1061579432AF46A03A /* IGListSectionMap.h in Headers */,
-				6F0CC3FFAF4600EB5B32D2F997FE9661 /* IGListSingleSectionController.h in Headers */,
-				3FE2AF8CFFF1CBCF2EA692B01FDD7AE1 /* IGListStackedSectionController.h in Headers */,
-				E0F57C7DBAC24D7DC63160DA5812C370 /* IGListStackedSectionControllerInternal.h in Headers */,
-				267F7A5F03290F54BCEFDBF866970EE5 /* IGListSupplementaryViewSource.h in Headers */,
-				B32CD5CBE9F25F88399132223D39EA98 /* IGListTransitionDelegate.h in Headers */,
-				913D28466D2B34E687DC0D9702062054 /* IGListUpdatingDelegate.h in Headers */,
-				FF7E567E457135B97BD182D8C67F75F4 /* IGListWorkingRangeDelegate.h in Headers */,
-				ED5C65077D8311258083BF27DAEDCEC8 /* IGListWorkingRangeHandler.h in Headers */,
-				5C3085AEB7ECFA44C0CBCC574C814C22 /* IGSystemVersion.h in Headers */,
-				512468176AE53D4E243476E371CA6384 /* NSNumber+IGListDiffable.h in Headers */,
-				98FDEA8D5C95BB0DFFDA1B059141FB8E /* NSString+IGListDiffable.h in Headers */,
-				7C3A33BD13E4E4BDBBA2A94219AA452D /* UICollectionView+DebugDescription.h in Headers */,
-				8AA91E8D505AAA0E8B448ABF59CD2E95 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
-				ACBC251FDC68254A12F7D7B8C763095D /* UICollectionViewLayout+InteractiveReordering.h in Headers */,
-				D75260F59B10CAEA2E52C2206EE7B0D3 /* UIScrollView+IGListKit.h in Headers */,
+				921B146558C8ABF2838644BE0995FE9D /* IGListAdapter+DebugDescription.h in Headers */,
+				1282117007BC677B95A4CF52D2257565 /* IGListAdapter+UICollectionView.h in Headers */,
+				91B9729085E3DFFF6A2493C75D946344 /* IGListAdapter.h in Headers */,
+				543E895A12B5E4989593120AC9272064 /* IGListAdapterDataSource.h in Headers */,
+				FD8AD5D12D11003C2A062BE079937D79 /* IGListAdapterDelegate.h in Headers */,
+				ECDC0BB3D3F98877AF8562A597899A35 /* IGListAdapterInternal.h in Headers */,
+				B5FBE3FD9252B5AB8A13AE29BA9F7735 /* IGListAdapterMoveDelegate.h in Headers */,
+				EC480E1CF76B2A831A24F0B9EA07DA85 /* IGListAdapterPerformanceDelegate.h in Headers */,
+				39E96236BA4786C17E251772B00FC9D5 /* IGListAdapterProxy.h in Headers */,
+				FCE38CF740B20F9C36A8F74665226E45 /* IGListAdapterUpdateListener.h in Headers */,
+				F20FD96E6EBAF2BCE079A1B391EB6605 /* IGListAdapterUpdater+DebugDescription.h in Headers */,
+				72CCC85E803626A6E85AE3249A918510 /* IGListAdapterUpdater.h in Headers */,
+				9B6A75415BEF5385B5C3D382B1763A0B /* IGListAdapterUpdaterDelegate.h in Headers */,
+				050CB37AEE76ECE3542C348937096F72 /* IGListAdapterUpdaterInternal.h in Headers */,
+				F1344FCB2E4119A707F82DCF02B1AAFF /* IGListArrayUtilsInternal.h in Headers */,
+				F2568F0CB73D4BDCA314C8125D36F364 /* IGListAssert.h in Headers */,
+				DFBAE4FD38CA5B58A0C156DED6D1C701 /* IGListBatchContext.h in Headers */,
+				F80F75C42FD5B327999F711986A2851F /* IGListBatchUpdateData+DebugDescription.h in Headers */,
+				407343653DCC836D08B1A2FB99194E07 /* IGListBatchUpdateData.h in Headers */,
+				5C1B34C156605E407A0F6DE20FD9AE9E /* IGListBatchUpdates.h in Headers */,
+				5938F6A23F345135DB251AC12D2C9CB0 /* IGListBatchUpdateState.h in Headers */,
+				FA49227F4FF92FB7205D8ED3984DAE2C /* IGListBindable.h in Headers */,
+				E870D65E97CFAEB3539758BB9FA0E21E /* IGListBindingSectionController+DebugDescription.h in Headers */,
+				A9E893D7A41C4582B1D87D1B03671A2B /* IGListBindingSectionController.h in Headers */,
+				3713990BA33D5B668C51C9BC030FFAF2 /* IGListBindingSectionControllerDataSource.h in Headers */,
+				C92D69E1A5C840EFA261D5BE92D0B665 /* IGListBindingSectionControllerSelectionDelegate.h in Headers */,
+				0927D0B030275F5F0AA4D5BFC98C5C24 /* IGListCollectionContext.h in Headers */,
+				3E2924EBCF6D645982DD9872C75329C3 /* IGListCollectionScrollingTraits.h in Headers */,
+				A6F4826056A25D8BA1510E4F9C145841 /* IGListCollectionView.h in Headers */,
+				EFBDE12C77935B722442BB23A4DDDB75 /* IGListCollectionViewDelegateLayout.h in Headers */,
+				835F8A26E9D9ED7B28B1A5A8E720D8A5 /* IGListCollectionViewLayout.h in Headers */,
+				D5C431990C04DDD62B11DDA8E66B824C /* IGListCollectionViewLayoutCompatible.h in Headers */,
+				6DD73C34CC787C0D145CA6E408EF42F1 /* IGListCollectionViewLayoutInternal.h in Headers */,
+				D075D5B1D729FBD5D467B9247B36EAD7 /* IGListCompatibility.h in Headers */,
+				842C3167B5F677583A4EB995A0AB9144 /* IGListDebugger.h in Headers */,
+				4B62113EF5872F1B7752C955DEF03E35 /* IGListDebuggingUtilities.h in Headers */,
+				9D28FB3BC158D10F2D39688D02EB8DD2 /* IGListDiff.h in Headers */,
+				B6430BBDD033522F9563BF53B299937B /* IGListDiffable.h in Headers */,
+				87703E311264E96792C69BA3B11A7A8D /* IGListDiffKit.h in Headers */,
+				B25C040E31E7B1BF90B87B1152A19D0C /* IGListDisplayDelegate.h in Headers */,
+				8C381DB929831D42ADFA58031B0111CD /* IGListDisplayHandler.h in Headers */,
+				940829814B26541CB202AF8F1BE1F6DA /* IGListExperiments.h in Headers */,
+				479781E2935028998C7016CFEBBC37C3 /* IGListGenericSectionController.h in Headers */,
+				65D8D6778D494967E8D1857E33EB06B2 /* IGListIndexPathResult.h in Headers */,
+				B0BA766330939CD91E034BD23BA0F030 /* IGListIndexPathResultInternal.h in Headers */,
+				E588EB6372FB13A5CA9B6ACD668E6935 /* IGListIndexSetResult.h in Headers */,
+				436DE67F0C1A1EE7ADD1A104D19783DC /* IGListIndexSetResultInternal.h in Headers */,
+				4A86719B3012A63F47DD316DFA63D67B /* IGListKit-umbrella.h in Headers */,
+				60C252DEA16FA0201AE31B7A516DA2D7 /* IGListKit.h in Headers */,
+				328119A6B5C29D0E167DD4BB2D4B8815 /* IGListMacros.h in Headers */,
+				D976B548E97A8472DD03C110D5840C87 /* IGListMoveIndex.h in Headers */,
+				369C7F203DAF3C82297169F7A76F2898 /* IGListMoveIndexInternal.h in Headers */,
+				0140E79E9A78DCC82A9E0499D6D505A4 /* IGListMoveIndexPath.h in Headers */,
+				66F3C1A0EA3BB9007A18C3671A707474 /* IGListMoveIndexPathInternal.h in Headers */,
+				4C04FC1C6AA89AB03E1703184E79245F /* IGListReloadDataUpdater.h in Headers */,
+				786E49A8F53ED48AEB69D807A208853B /* IGListReloadIndexPath.h in Headers */,
+				565010349B072FD721B750E287779F29 /* IGListScrollDelegate.h in Headers */,
+				9AE5EFDE583ACD4786CF07074474B00D /* IGListSectionController.h in Headers */,
+				50202E0D9BA01738C86218DE29F79FB2 /* IGListSectionControllerInternal.h in Headers */,
+				4DA167EA9BD179605B00005E81582825 /* IGListSectionMap+DebugDescription.h in Headers */,
+				7080F30B82C53E9D621D85B78B0B465C /* IGListSectionMap.h in Headers */,
+				C171FDB4097450BEDF90D08A275628E3 /* IGListSingleSectionController.h in Headers */,
+				BCEFC1DC0089468111DD45674FA6CF38 /* IGListSupplementaryViewSource.h in Headers */,
+				837263F72812458D17329664715B9E00 /* IGListTransitionDelegate.h in Headers */,
+				BDC091D1C2757D68D3AB5A323A4AFD8E /* IGListUpdatingDelegate.h in Headers */,
+				385487A89C4A821AEEC11A3ECFC021A3 /* IGListWorkingRangeDelegate.h in Headers */,
+				0094D67D82CF064A7A4598D2B1458C42 /* IGListWorkingRangeHandler.h in Headers */,
+				159144DE9AB96730A5314BA992AA7D8A /* IGSystemVersion.h in Headers */,
+				170E95301CA7DE703CAAC56EE0061081 /* NSNumber+IGListDiffable.h in Headers */,
+				2A09094BFB39A6184C10B74746FF7A78 /* NSString+IGListDiffable.h in Headers */,
+				96F95E57CF553C5BBEEEAED9B91B2FAB /* UICollectionView+DebugDescription.h in Headers */,
+				20785A08B96FE648530D7BDFEB0AE7C4 /* UICollectionView+IGListBatchUpdateData.h in Headers */,
+				0CDD22A418A269BE2CF27654D0DDF4A4 /* UICollectionViewLayout+InteractiveReordering.h in Headers */,
+				CB9636D8302B605D7F331306729AFD63 /* UIScrollView+IGListKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -781,24 +770,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C366647750138040A1FC88EBB5DD09AC /* Build configuration list for PBXNativeTarget "IGListKit" */;
-			buildPhases = (
-				F7C0172DC4609B819C483A59E0927771 /* Headers */,
-				ABBF128F194B2FB4D8A05C5ABB597CF1 /* Sources */,
-				C780C0D7293D61AF9802BB06C18CDFAF /* Frameworks */,
-				6E9F3806F5D0148F67879F883C5B86E0 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = IGListKit;
-			productName = IGListKit;
-			productReference = 8CAEA38BA4119C7D41068C4FDAB7D01E /* IGListKit.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		93611D31191964DA2D2AA183EB449C82 /* Pods-IGListKitExamples */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2127B2F15D7575477322E01FD7178098 /* Build configuration list for PBXNativeTarget "Pods-IGListKitExamples" */;
@@ -816,6 +787,24 @@
 			name = "Pods-IGListKitExamples";
 			productName = "Pods-IGListKitExamples";
 			productReference = 659DAB79E09D170FB9096949FEA9FA49 /* Pods_IGListKitExamples.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 21C367A2A521329E861976AAA8493412 /* Build configuration list for PBXNativeTarget "IGListKit" */;
+			buildPhases = (
+				79D111E9C4E749D733B9F6253B7D48C1 /* Headers */,
+				EE3CBB4D5A202233ACC8C018D87344BC /* Sources */,
+				F30BF0A691E2CFCE72F8CA3B4519B95E /* Frameworks */,
+				871823166F14553A3F7C762DF7008934 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IGListKit;
+			productName = IGListKit;
+			productReference = 8CAEA38BA4119C7D41068C4FDAB7D01E /* IGListKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -839,7 +828,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */,
+				D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */,
 				93611D31191964DA2D2AA183EB449C82 /* Pods-IGListKitExamples */,
 			);
 		};
@@ -853,7 +842,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6E9F3806F5D0148F67879F883C5B86E0 /* Resources */ = {
+		871823166F14553A3F7C762DF7008934 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -871,48 +860,47 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ABBF128F194B2FB4D8A05C5ABB597CF1 /* Sources */ = {
+		EE3CBB4D5A202233ACC8C018D87344BC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C330A515296CBE24A82292B534CECD32 /* IGListAdapter+DebugDescription.m in Sources */,
-				CCF21C54492902F6AB5756105A55777F /* IGListAdapter+UICollectionView.m in Sources */,
-				46C8A5977F015698E3F8441FD78B3815 /* IGListAdapter.m in Sources */,
-				EDFE97C739D7C27EB5DF573623146AE0 /* IGListAdapterProxy.m in Sources */,
-				894295A77D2FE6D08956E31F5E4BEA90 /* IGListAdapterUpdater+DebugDescription.m in Sources */,
-				EB9DE9CECB4E21D81D66C5F80C2D6209 /* IGListAdapterUpdater.m in Sources */,
-				860968484A55F57A2E0160414C601EFC /* IGListBatchUpdateData+DebugDescription.m in Sources */,
-				8ECF5C6225FE112FFBB5E5C0767BE421 /* IGListBatchUpdateData.mm in Sources */,
-				7C9CDAA99E50763C7A7993D6013C3D82 /* IGListBatchUpdates.m in Sources */,
-				AB14E01885528EF9C1895FA1FDCCA52A /* IGListBindingSectionController+DebugDescription.m in Sources */,
-				639D19E840CEE47B8A8CDAE0DD96AD76 /* IGListBindingSectionController.m in Sources */,
-				71AA970A0AB7DF31644D77F84231EEBF /* IGListCollectionView.m in Sources */,
-				35A6013FD8BDA2148972A36AB0ABB8C5 /* IGListCollectionViewLayout.mm in Sources */,
-				AFF9372D26BC23508C305031EF5BD98A /* IGListDebugger.m in Sources */,
-				40E56342CF63845B458EAFCBD66CD14A /* IGListDebuggingUtilities.m in Sources */,
-				78D3337F28EB0D85D3C227CCA1CAC487 /* IGListDiff.mm in Sources */,
-				5D8602CAA6AE82D1560BA27DB004A614 /* IGListDisplayHandler.m in Sources */,
-				194775034FF52A1FF3EE93459DD1AAA8 /* IGListGenericSectionController.m in Sources */,
-				C3B987D343F39BD8AAD53F80B48CC011 /* IGListIndexPathResult.m in Sources */,
-				8A407059D7A86F31421960855E58D4F9 /* IGListIndexSetResult.m in Sources */,
-				FB2987DAC40437D72958533E7B955EF5 /* IGListKit-dummy.m in Sources */,
-				60B47D935CBB717BC0D1E8B47887CD7D /* IGListMoveIndex.m in Sources */,
-				D350E679B53B363E68753893E2ABEA93 /* IGListMoveIndexPath.m in Sources */,
-				E9D5623481C8CB91D32BDE1D78ED40ED /* IGListReloadDataUpdater.m in Sources */,
-				3F9AC999133EF04647D1A660FD61955D /* IGListReloadIndexPath.m in Sources */,
-				339DE064A51B93D31F00ADD08D65232D /* IGListSectionController.m in Sources */,
-				8DDEB77D26E101539FBC32073BCC91BC /* IGListSectionMap+DebugDescription.m in Sources */,
-				CEBECDD6178C3F768D2FF4BD80405BDE /* IGListSectionMap.m in Sources */,
-				81F8452E9117587E205091DE73A80B76 /* IGListSingleSectionController.m in Sources */,
-				D408771CF05B12485C14D5A819D04B43 /* IGListStackedSectionController.m in Sources */,
-				1BA5D4302BBB5DC62D2CF4587FB5D3BE /* IGListWorkingRangeHandler.mm in Sources */,
-				85893A0F1D8732D0D28035E406DAEF5F /* IGSystemVersion.m in Sources */,
-				798199A75C4A7C31E97B38AA4B037C96 /* NSNumber+IGListDiffable.m in Sources */,
-				E06A01FAC1C0F8053DB7F7D5110B1E9E /* NSString+IGListDiffable.m in Sources */,
-				D709E3D33001D8C64533654DFD7A627D /* UICollectionView+DebugDescription.m in Sources */,
-				D6B9D0372AFCFDB89F5B18A96A9CD0B2 /* UICollectionView+IGListBatchUpdateData.m in Sources */,
-				B3D57B439E9CA31E04FD392FEA45209B /* UICollectionViewLayout+InteractiveReordering.m in Sources */,
-				1F327C2BF81FD3A44F3C928E0A2790B4 /* UIScrollView+IGListKit.m in Sources */,
+				8E8B4C9FA06F091842EB606AE8499CCE /* IGListAdapter+DebugDescription.m in Sources */,
+				502EE857A881018E5FD387A6E23A38F0 /* IGListAdapter+UICollectionView.m in Sources */,
+				120E8310162E61C5E350C905BBD0642F /* IGListAdapter.m in Sources */,
+				89EF06907B308D35A992588930244256 /* IGListAdapterProxy.m in Sources */,
+				09FE869D7DF75AED14C5ECBC9BBE0E77 /* IGListAdapterUpdater+DebugDescription.m in Sources */,
+				2EB99C6459645C76EAEDB614B96E8A7F /* IGListAdapterUpdater.m in Sources */,
+				4D5FC94F0F38840B4F4EF0125C28C073 /* IGListBatchUpdateData+DebugDescription.m in Sources */,
+				9010A8434B660C2264AA992949930C32 /* IGListBatchUpdateData.mm in Sources */,
+				2A3BCB64AA8A37F9D5739904743287A8 /* IGListBatchUpdates.m in Sources */,
+				8DEB6A80425E81F141AFA892B539A17A /* IGListBindingSectionController+DebugDescription.m in Sources */,
+				82DB51EE154C7EACF2ECAEA4ACAB7C71 /* IGListBindingSectionController.m in Sources */,
+				9F2A844A340283F45D94389D884EB8C2 /* IGListCollectionView.m in Sources */,
+				B0B9AC8BB0CDE9B87FBB7E2DE4723A06 /* IGListCollectionViewLayout.mm in Sources */,
+				D7F710D485982645AE922C5D6839901F /* IGListDebugger.m in Sources */,
+				44A1CBBE52A752A925DC49D95C78DB10 /* IGListDebuggingUtilities.m in Sources */,
+				304B559EB0E2155CF01FCD80F852CA08 /* IGListDiff.mm in Sources */,
+				1137E7A3F0AE912B05C6C75267B22948 /* IGListDisplayHandler.m in Sources */,
+				359CF0381AF5C7F81C800A6174A2F5A7 /* IGListGenericSectionController.m in Sources */,
+				7337162978A882C23723096E5F4A0E75 /* IGListIndexPathResult.m in Sources */,
+				EAEC3F09A8484F35F7FE3672321E2361 /* IGListIndexSetResult.m in Sources */,
+				924CBB03106BFF159DE0DEC543355B9E /* IGListKit-dummy.m in Sources */,
+				72E4DF6E435AAED14B9C27571DC08FA0 /* IGListMoveIndex.m in Sources */,
+				CEEC931F251E36D412DBFDB798D60F94 /* IGListMoveIndexPath.m in Sources */,
+				1397AE7BC9FA504F98363C065FBC834B /* IGListReloadDataUpdater.m in Sources */,
+				6A1EFB64B94A1F9BB4616092D761C9AF /* IGListReloadIndexPath.m in Sources */,
+				84EDB91D8FEC7B4F430E9483AE203741 /* IGListSectionController.m in Sources */,
+				07BD381C9D8D8AE0B30B9A2497AF58C3 /* IGListSectionMap+DebugDescription.m in Sources */,
+				6D89FDE6F52F9C3191B616E9B0E05DD5 /* IGListSectionMap.m in Sources */,
+				94D1B6BA3DA2B691BB3C07A95A011F01 /* IGListSingleSectionController.m in Sources */,
+				4E3B217C44E988031BF24FAD15FCEDEF /* IGListWorkingRangeHandler.mm in Sources */,
+				02BF2B7603D611AAACC331E2352B590C /* IGSystemVersion.m in Sources */,
+				07B148F761AF9AC40BBC3A463A21ACAF /* NSNumber+IGListDiffable.m in Sources */,
+				6026AC58E181E1A3411CE6E99F01E136 /* NSString+IGListDiffable.m in Sources */,
+				6C62504ABCCD830B5CCB0701657BAAAF /* UICollectionView+DebugDescription.m in Sources */,
+				80C765861733FEB163A4689F40D889E7 /* UICollectionView+IGListBatchUpdateData.m in Sources */,
+				386AD898815E39BB26F3ED97D5F52A0B /* UICollectionViewLayout+InteractiveReordering.m in Sources */,
+				B56F1064287CC0E3B444CE9A3B8EEE70 /* UIScrollView+IGListKit.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -922,12 +910,44 @@
 		9D7A83CCBE42DC893E21B50607D0A5B6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = IGListKit;
-			target = 7E744CEE24C044B1DCCAA8DFFBCACB6C /* IGListKit */;
+			target = D10AD9FAD40B191F43F847DCF504FE0B /* IGListKit */;
 			targetProxy = ECFCADAB141C83EEB8CC1527E24DFABD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0AFC83AB577FB3EF5761376E668BC99B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A920DCE0F3C24C36F41D7C0E4D2959F4 /* IGListKit.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
+				PRODUCT_MODULE_NAME = IGListKit;
+				PRODUCT_NAME = IGListKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		199D085CC64F89E4517C069824B55B84 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -987,37 +1007,6 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
-		};
-		2CDA0EEF23453FE958A5D30245E7CF26 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5CDFA68B43C6C111AD1B7CA35B525991 /* IGListKit.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				PRODUCT_MODULE_NAME = IGListKit;
-				PRODUCT_NAME = IGListKit;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		336638E624EF0D2107D74E9C8887948C /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1116,6 +1105,37 @@
 			};
 			name = Debug;
 		};
+		BA0EE0150C8C32F3E5B6F89CC2233B03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A920DCE0F3C24C36F41D7C0E4D2959F4 /* IGListKit.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
+				PRODUCT_MODULE_NAME = IGListKit;
+				PRODUCT_NAME = IGListKit;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		C1E1D6A589F1C976543E220B51ED6DA3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F461DC2A68D32B0A19A6CCD26FB3562D /* Pods-IGListKitExamples.release.xcconfig */;
@@ -1150,38 +1170,6 @@
 			};
 			name = Release;
 		};
-		C8132BACDAF9131E08D32D0B2D1BCD5E /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5CDFA68B43C6C111AD1B7CA35B525991 /* IGListKit.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/IGListKit/IGListKit-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/IGListKit/IGListKit-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/IGListKit/IGListKit.modulemap";
-				PRODUCT_MODULE_NAME = IGListKit;
-				PRODUCT_NAME = IGListKit;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1194,20 +1182,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		21C367A2A521329E861976AAA8493412 /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BA0EE0150C8C32F3E5B6F89CC2233B03 /* Debug */,
+				0AFC83AB577FB3EF5761376E668BC99B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				336638E624EF0D2107D74E9C8887948C /* Debug */,
 				199D085CC64F89E4517C069824B55B84 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		C366647750138040A1FC88EBB5DD09AC /* Build configuration list for PBXNativeTarget "IGListKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				2CDA0EEF23453FE958A5D30245E7CF26 /* Debug */,
-				C8132BACDAF9131E08D32D0B2D1BCD5E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Examples/Examples-tvOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
+++ b/Examples/Examples-tvOS/Pods/Target Support Files/IGListKit/IGListKit-umbrella.h
@@ -50,7 +50,6 @@
 #import "IGListScrollDelegate.h"
 #import "IGListSectionController.h"
 #import "IGListSingleSectionController.h"
-#import "IGListStackedSectionController.h"
 #import "IGListSupplementaryViewSource.h"
 #import "IGListTransitionDelegate.h"
 #import "IGListUpdatingDelegate.h"

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,170 +7,170 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		05E63C99E1A7A32396CFE3FD757149D1 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EE227EB2DBB93B0B9BC79549285E23 /* OCMInvocationExpectation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		06D1B6BCA6DCDDB92EC883BDB921DA90 /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BFFB5E68FB464B8E2BC376C5133EFD1 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0AB031FE553C5B2CC98325C5EB4E528D /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BFFB5E68FB464B8E2BC376C5133EFD1 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0BA903E101A263D7034D61C206DD2BE4 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 495A63A75195819B741BF650D6D02E95 /* OCMRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0CAE8FC7FB8D3AF78FE0111803BEAF99 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = E7E871406ECFA78678074A43B67F57A8 /* OCMBlockCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1004E3B3F02C5C61B6387CDDC3A5914E /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E961CF56BA9954B9D87D257C2DF68E /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		13B86E8BDA386EFFCAA680225737A7E4 /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CEA2127E728872F80E58FFA2E6B6BD49 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		159839BDFAA2912B7CD56A77F48C4AEB /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B42B1300EABCBA644D00C82FB8FDDB2 /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		161310D35CE927CB4E0D91DCEAA7755B /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B1D04B4294912E3A2B53028A65C77FB1 /* OCMExceptionReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1652E9EAB46A785A33B3DCF9FE259243 /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 741CDA7FB5A6FDEB8A5BB399F6137460 /* OCMArgAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		17419699A723CF5D97D1052C1D11323E /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D3157613797A16A9BA6D99FE75FFF4D8 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		17F55936F66ACF061EACCC993DA2F730 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 98C06A2A7F88EF744180A55E81D64F24 /* NSValue+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		18C5EAF0850FA948D426EFA8CB46792C /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD83377DCB627C0E18D3EE6D2127144 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1B53E3EC6760D7989626A4173D12A264 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = A276D6A0E43FA8ED1778DC0E70DA9C56 /* OCMObserverRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1BC1B7D8B6A1854E19AA23BEDFF85EBA /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E961CF56BA9954B9D87D257C2DF68E /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1F0A5EE0404C4AE3584B7F570248278E /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 68AC7B831C120B11CBB1F48E14495263 /* OCProtocolMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		1FE0B34EB7C89D09D860ECCC07DD9662 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 92528A8421D0AB8035F601019A51E05A /* OCMRealObjectForwarder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		2AB1FD059470F8710859719ED87A9CFC /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = F6AC619091B745F5D2054865A142EA4A /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2DB19FEA3BD64D03D77564C6F70C5DBA /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 397181337B1A32F9D1D97C2185C2BA75 /* OCMNotificationPoster.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		33FB6CCBAD5D7F3A0F27350C290E1C42 /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = EF760F5AC580FD6A33D7585CB13D91F3 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		345DF50EC98B1BB41C5DCBC2A518E6F0 /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = B335B18374B39E2533DF37073A8D1F17 /* OCMFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		375A076C70570618C9C84A938298B2E0 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DE2E4C28A3C653DD750E95FDA066B /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		385BC4D793CC49D82093BF98ECE98BDD /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA33982346F43731424B503F1761A7 /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		38CD2F7182ABA7F028A74FBA7D25E417 /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D8776DCE9E560DF184E64BF7D46D86A /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		393531D750D1C7DEE049690194D23103 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A5BFC40F4ED9027D84940697968910 /* NSInvocation+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		394EE0AC939A948487CE548E4CADA546 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BECBF1EDC84264AA8EE8912A034726A8 /* Foundation.framework */; };
-		3B0DAA314E5A5F1B37CBF7D39A6A2BB9 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C72441E645C70187EC0D9BCDB8DE588 /* OCMInvocationStub.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		3DB311D40A2DFB263A1F8374561439AC /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C27E1C9D1A5211777D0F972ED88515F /* NSNotificationCenter+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		42576B70FBEAA97460A3BFD32C725CD9 /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 81AB2361DCD889FF3D7BD96D6D965744 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		44337032D9E12EE7861DB4828A98AF40 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EE227EB2DBB93B0B9BC79549285E23 /* OCMInvocationExpectation.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		465735C6EB2C53C3EEBE39D13435AFD2 /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C5162FD6E5A211B63C23FC1903D8A7F /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		48B365AF62153BF8F2A047B4C22D8382 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 362D7DD49B8805571C594CD6EED6F407 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		49A9189549DABEC1539FDFC2ACBD0236 /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = F59DC5FB548DEC8232E66F2F826F2FA0 /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4EFD9BB2056F1227D5B960CF716CF40F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 12EA7F453C881E24340B531D2D2133D0 /* Foundation.framework */; };
-		5022DC019FD5E2965DD8E891A279C113 /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = C8A9AD5673237000ADFD0FDC3C38E203 /* OCMBlockArgCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		510811B7C7F94C97454D10960CFF1B55 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CFB92296F6A094D4B5360DC761DFECE /* OCMBoxedReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		512D7C8EB84E90D5AE3CBD5C8B90FD47 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DE2E4C28A3C653DD750E95FDA066B /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		51CCB4EF7B2B898D41A0A18618FA1A65 /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AB806E2446D395F04C99AC4822865E6 /* OCMReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		51FF66AB9C084B70C05F1B6072FE9B70 /* Pods-IGListKit-tvOSTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C657A08A3CEC4F4157265D404465D6C5 /* Pods-IGListKit-tvOSTests-dummy.m */; };
-		52D5F493AB2C1B54D905AFF29AE39FF8 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C72441E645C70187EC0D9BCDB8DE588 /* OCMInvocationStub.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		575413E821EAB1D2BD78B57221697432 /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 048F00928602955E61050C2EBBD68C0A /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		58489473BFC10E0CAD4A80FABF31BF47 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = B67BDA6AE164B2450296DBD65B97B9E2 /* OCMStubRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		58CFDF087BC2E83FD9EDC723DF93FA76 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DB5F18232A4D62BFA94F14F8841815 /* OCClassMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		59E6CCDF2266C3347E6BB312DA81AFC4 /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BCB1174A82FDDFCACA2B4CDE3B794FF /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5B9C6E91238A67BFA3F2BF4F88E15904 /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = D9E254DCD2C8DA696A35A2A093749012 /* OCMVerifier.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		5C060014E8967CB5774C11DD7A7575DB /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 721FE9FE6798CAA94961C42D5AB44202 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5E02C0BD7B95F5E45566156C45EFBEF4 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B4CB58CB4BB13A854D97E7F6A13D2B36 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5E794654D15A639163687033D9DB9729 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 26CE81F8DCC93B2E058429AA15ADAAEB /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		61DCF0BEBB94C587C53F043F5158A4FE /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = A72CD634D1908FF963D6543A4B0699EF /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		64A6F73FC964088EC293199D8364DD13 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = E7E871406ECFA78678074A43B67F57A8 /* OCMBlockCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		67C074A871E4405F6B3F04600501FECD /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A5BFC40F4ED9027D84940697968910 /* NSInvocation+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		68BA600304FC1110BE5F8241ABDAB359 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA33982346F43731424B503F1761A7 /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6ACFA64760DCBB80C0F731B7E934167B /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AB806E2446D395F04C99AC4822865E6 /* OCMReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6B355DA2E943ADA5468E2D0CC2224007 /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 741CDA7FB5A6FDEB8A5BB399F6137460 /* OCMArgAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		6CF02A914409C7B45AF671A328AF30B0 /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = B335B18374B39E2533DF37073A8D1F17 /* OCMFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D1282CB515AA7B7D4F3E257A86FF53F /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBE301CDF9020678CB8C29C4CA8EA57 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6F33B23042B9DE553BFE3DFD5DBAAF80 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 07DCCAE6ACDA7B3D5D7420344B19BE00 /* OCMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7076E45CBFBBA6B5E8655EC6DE727453 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FEC0A0AA548D223195671B8A7AA132A /* OCMPassByRefSetter.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		74733022A85B416647A368BCC1C51E2B /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C27E1C9D1A5211777D0F972ED88515F /* NSNotificationCenter+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7A37304E5D49627C0D820CDD44617340 /* OCMock-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F398123E655432B4F393298C40F79F9A /* OCMock-tvOS-dummy.m */; };
-		7AE9FA7B6131CE0BBF38EE4660C750A6 /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = F1011713EC6C056ACC37D023D9C2D15A /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7AEBD779FCD70FC14BC943E5EE5A510A /* OCMock-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 14851A29BC0814298E3BFF3819A2D930 /* OCMock-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C81388460369B6F5EF53C6AEAF28B3D /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F17B4561770684928A57AC115A8D3B /* OCMockObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7D73E25D7F6C55197D8094DE19B4ED1B /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = F6AC619091B745F5D2054865A142EA4A /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7ECCACF3554B47C4B2BB90FCDC8B5523 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D035F1D426C3F3C4F1EB324E8A786A /* OCMConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7EF8CC45C08CF5FA58B904B73C63D328 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 92528A8421D0AB8035F601019A51E05A /* OCMRealObjectForwarder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7F4331771D9BEFCD814D420FAAA1367E /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CEA2127E728872F80E58FFA2E6B6BD49 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		800D159753832DEC8EB5673CA7B343C9 /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 11639F91AD6FE7D10252D4E11C62B176 /* OCMLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		803B122E44571882A0B145DE7F5A097A /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = EDC9494345261ABF2FCF9FED0AB34ED1 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		81079A5C8291874346E76B1CFB189CD3 /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C5162FD6E5A211B63C23FC1903D8A7F /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		826F3DAB0AE0B4678B43687AA1EF61BD /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = E831274015F0C341B62F5DD9F4F092DE /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8278D2AE5E38BCB480B449BE1BA54C1A /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 58077E9A9ED4093497A5E0B588CD4E0F /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		83F7E4121F77D3C734678DC6F79288D8 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 26CE81F8DCC93B2E058429AA15ADAAEB /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		85B5DBD3A48C0E109056C033DEF52597 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 12EA7F453C881E24340B531D2D2133D0 /* Foundation.framework */; };
-		8947FC603171292BB45D94F76FC60CAE /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EFCF4C37D6584BFEF0379A35DC435D /* OCObserverMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8BDADD084A05DF43C0FC4FBD8E74A533 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C79E307A78753A501C2DEA2DED298055 /* OCMInvocationMatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8DDF1D7F88727646540EBFB0975668DC /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = D9E254DCD2C8DA696A35A2A093749012 /* OCMVerifier.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8DF92661721DB2FFD93037A1B3D2B03C /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F31528048CF512EEBFC74FFCB6F133E8 /* NSObject+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		8E54D4A18AAB354D863029C01AC81BA4 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 856713793630290B44DDCFA709761FBC /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		904C681AEE7BA35C1FF647AE216B914E /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = F59DC5FB548DEC8232E66F2F826F2FA0 /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		90DE961A8C0AFD01081EED13CF6DE17C /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = A72CD634D1908FF963D6543A4B0699EF /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		918DB8D86E3D6848B2D8610DE78AAE61 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C79E307A78753A501C2DEA2DED298055 /* OCMInvocationMatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		922EE89307E6ACD73C67D4EF3453CBF7 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 856713793630290B44DDCFA709761FBC /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9356E4C71572D93BE17358BD2D3A1DA0 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 98C06A2A7F88EF744180A55E81D64F24 /* NSValue+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		936E206C36CB014CDE98EEE81D330C96 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = A0FBA930F2D633BFB9AF42E83F80790B /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9383BAC9557A23DE7BD277448C4E74DA /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E849DFC39CDDC56F1B18E9F66B0E1113 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		94D41233CC2F8D4F458AFE1F3B4E8286 /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD83377DCB627C0E18D3EE6D2127144 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		96A8BEB618F569C4D0D6B9CEEDAF9A32 /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 397181337B1A32F9D1D97C2185C2BA75 /* OCMNotificationPoster.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		97F7977800B760E1BA0EA846BEAF9C2D /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D8776DCE9E560DF184E64BF7D46D86A /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9B3D597670D528229CFB3327CEC92076 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CFB92296F6A094D4B5360DC761DFECE /* OCMBoxedReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A00FC9D29C3E60023D12F8951E0436D3 /* OCMock-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E04F10EA12ECEE01C3E7A32C47177943 /* OCMock-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A283ED12C6452C75568DBBE7A790D65E /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBE301CDF9020678CB8C29C4CA8EA57 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A2FC79A1AFDCEA36B0B8795E02C68F64 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 07DCCAE6ACDA7B3D5D7420344B19BE00 /* OCMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A3BECEB495C0E826EEBA00DE524609D2 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CD066A6A013DEFF0C9C09009C8E5EE60 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A3C7432F44BC9BE79142705B6B4509D8 /* Pods-IGListKitTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 130C54D33F101344CAD5C552A16D86F7 /* Pods-IGListKitTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A549F62610FBACFCF1947C0A416F83D7 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F48043720695EE6347EFB994E3D78C79 /* OCMFunctionsPrivate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A5BB4B5C9C0DFE3E99BCD8971CA32726 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B1295058ABC5DE9E07A61A001034156E /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A75EABE7F50FF184DF0547EAE6D34914 /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = F59E6AA82CE3A9EF68C76FA8CC3314AF /* OCMExpectationRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		A857BAC4FCC02FD98B321EDFB9AF5DA4 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D3157613797A16A9BA6D99FE75FFF4D8 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AFFBC748AD14900F02E732C0AA47C934 /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = EDC9494345261ABF2FCF9FED0AB34ED1 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B01DF0D6ECC3E76CE6D865C2915B5497 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CD066A6A013DEFF0C9C09009C8E5EE60 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B19733FB1A46C40E429B82A02591779E /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F48043720695EE6347EFB994E3D78C79 /* OCMFunctionsPrivate.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		B3BBACAB947214D410D564463F82BAA3 /* Pods-IGListKit-tvOSTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4926CB9A92BF783D9F06214C4495F607 /* Pods-IGListKit-tvOSTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B9782F37022AC37CAFC1A1222D6EB897 /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = B67BDA6AE164B2450296DBD65B97B9E2 /* OCMStubRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BB029C460CE59C70FC59AE9117E3CB79 /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = F1011713EC6C056ACC37D023D9C2D15A /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BC50F7389E683DA1CA36992873B02029 /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 57BB148227DE7CB2DEE3E56A4CF1CF82 /* NSMethodSignature+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BD29646AB3CE7AC7E9B6A9A64922F122 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 495A63A75195819B741BF650D6D02E95 /* OCMRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BE2613E184073E45D2FF36116FE84D5D /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 57BB148227DE7CB2DEE3E56A4CF1CF82 /* NSMethodSignature+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		BF48F22800CB4889DCF700E0FF7598EF /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = C8A9AD5673237000ADFD0FDC3C38E203 /* OCMBlockArgCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C072983510FB471DF691D89B62387A7B /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = BDF09C6B81F226DD43D87A40013E4011 /* OCMArg.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C09FE5E7CCD88E0C0126E836EC4F87A0 /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 11639F91AD6FE7D10252D4E11C62B176 /* OCMLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C0D936BF720D5C00AA8BB60621E37032 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DB5F18232A4D62BFA94F14F8841815 /* OCClassMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		C236DDAAD94017320F21583CA6D49752 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = E831274015F0C341B62F5DD9F4F092DE /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C5507757F64CA25E1F59F2DF63AD0156 /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 048F00928602955E61050C2EBBD68C0A /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C77AF8C5954ADB7102F57340E9BAD812 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = ADA1F153704FBE678091BDD0D0C999BD /* OCPartialMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		CFC5B12A2934B761F7977E5203C9904D /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BCB1174A82FDDFCACA2B4CDE3B794FF /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D09739C4EDCFAD34F6159F452BEF3181 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F17B4561770684928A57AC115A8D3B /* OCMockObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D290EDEACD3945F296FAE23B16AA13C8 /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 58077E9A9ED4093497A5E0B588CD4E0F /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D680B7DC47BB91E9D949880E73F0B9F0 /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE3E7191897F1C6F2B93354BD88347E /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D7797C4D618A10817A138D2EC6E7EB3F /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B1D04B4294912E3A2B53028A65C77FB1 /* OCMExceptionReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D8E153A064602885EF90DA0CBE89593D /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1497687A64BDBF7E170B5D16567D0CE9 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DBC46244FC6BDBF148C7E38A18166FDE /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE3E7191897F1C6F2B93354BD88347E /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DBCC1DB234F14A9BCDA55C81D0792B36 /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EFCF4C37D6584BFEF0379A35DC435D /* OCObserverMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		DCB570B14D72C18850DE30448EDFE728 /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = EF760F5AC580FD6A33D7585CB13D91F3 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E130D0AF2979CD4141A597002BB444F5 /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = BDF09C6B81F226DD43D87A40013E4011 /* OCMArg.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E2EC638175CADA2A7029D0A527B852D7 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF53648561EA071EA3D4171A451D25C /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E2FA6EB7D15D3DEE72762BD5FAD14FBB /* Pods-IGListKitTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 66424FEFE51F2A991681F3AAC646C488 /* Pods-IGListKitTests-dummy.m */; };
-		E3C19CAE478775B39BE726FC947CF014 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF53648561EA071EA3D4171A451D25C /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E8C79D0A60EA780C80D3E7395CFA21C7 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = A276D6A0E43FA8ED1778DC0E70DA9C56 /* OCMObserverRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		ECA0A4805E559E578721F4D3DD4FD649 /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 68AC7B831C120B11CBB1F48E14495263 /* OCProtocolMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		ED5C996150AC4DB97026F63933C1DEC4 /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E849DFC39CDDC56F1B18E9F66B0E1113 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EDC9E9EA061E09FF068B60417DE34C84 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F31528048CF512EEBFC74FFCB6F133E8 /* NSObject+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		EF3187BF74DA27638A61E7DAE0EA4EF7 /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1497687A64BDBF7E170B5D16567D0CE9 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EFCE09FFE2840AFA78CDF92692E550BD /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B42B1300EABCBA644D00C82FB8FDDB2 /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EFFCA395C12358AD16857F4428729F36 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 362D7DD49B8805571C594CD6EED6F407 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F113FBF070A154E5520B7D1A15054341 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D035F1D426C3F3C4F1EB324E8A786A /* OCMConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F11B9FBCC7C98D1C9F663AB0424C02F6 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B1295058ABC5DE9E07A61A001034156E /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F194DA590299A388595C988635F026B3 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 563B58F20FA831CB7A17B0B13BA8B70B /* OCMIndirectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F3A6C53884F5E9EF171EED7CC640DB33 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B4CB58CB4BB13A854D97E7F6A13D2B36 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F48EC77840841007EE31D32A03254A81 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 563B58F20FA831CB7A17B0B13BA8B70B /* OCMIndirectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		F60EB7E261DBB2B9A5B0CC2E6EE533C8 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = A0FBA930F2D633BFB9AF42E83F80790B /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F624D33BAE96156D863DFE1CE8E1E93C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BECBF1EDC84264AA8EE8912A034726A8 /* Foundation.framework */; };
-		F6BADC64F6B2C733EB4E534244D3CCBD /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FEC0A0AA548D223195671B8A7AA132A /* OCMPassByRefSetter.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		FAB4EC3C97A9ADD4D03530203CBB4125 /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 721FE9FE6798CAA94961C42D5AB44202 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FAF9E80781EDB35C79975B6DF0E8937D /* OCMock-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5247D700C531F22493BB6FEBC2630C01 /* OCMock-iOS-dummy.m */; };
-		FC69869F348A41819AF05E6A4A7CED9A /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = ADA1F153704FBE678091BDD0D0C999BD /* OCPartialMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		FCBA873E50D4A20D213C65A2074E185E /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 81AB2361DCD889FF3D7BD96D6D965744 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FF3036F610784828F959001815D4C36A /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = F59E6AA82CE3A9EF68C76FA8CC3314AF /* OCMExpectationRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		0043955603862B863DA4B0C76F6E6CB7 /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BFFB5E68FB464B8E2BC376C5133EFD1 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		011E1FEF46CFD1FBB7ED39F95F949792 /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 81AB2361DCD889FF3D7BD96D6D965744 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		04795A06B7B6AC807E35C0DF84BB5E05 /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BCB1174A82FDDFCACA2B4CDE3B794FF /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		059134A35A7CE320EA1D4F86425B3415 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C79E307A78753A501C2DEA2DED298055 /* OCMInvocationMatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		066C0CC259102FC7B1F6A4A38F882E24 /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = A276D6A0E43FA8ED1778DC0E70DA9C56 /* OCMObserverRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		06E23E6AD291E76405B9BB002F267199 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F31528048CF512EEBFC74FFCB6F133E8 /* NSObject+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		08610877891351AA7E13C8059414347A /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 048F00928602955E61050C2EBBD68C0A /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0C60616AC9965AB0837AE20C8545928E /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = EDC9494345261ABF2FCF9FED0AB34ED1 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0C92020AD0941B5FC829A388EDABCBF3 /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BCB1174A82FDDFCACA2B4CDE3B794FF /* OCMBoxedReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0E7F1C4344AA26C73715A7717CA57EF2 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 495A63A75195819B741BF650D6D02E95 /* OCMRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		10A3F1210BB88C2C76F020EAECC5EFDB /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E849DFC39CDDC56F1B18E9F66B0E1113 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		10F91650A18EF2329240576D605C9A47 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A5BFC40F4ED9027D84940697968910 /* NSInvocation+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		110AE929E6276B8DE4787B6F479921B1 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D035F1D426C3F3C4F1EB324E8A786A /* OCMConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		158DEB397AE6FB4D95999EAEF1E6B384 /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = EF760F5AC580FD6A33D7585CB13D91F3 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		16AD4ED9330C5B78D56CBE0C63142D82 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 362D7DD49B8805571C594CD6EED6F407 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		16B0B5D85E8BDB73BB5FD2B214816842 /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1497687A64BDBF7E170B5D16567D0CE9 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1730F618BD2B5DEB71A1F01AF381D71B /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 98C06A2A7F88EF744180A55E81D64F24 /* NSValue+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1B1423FB282B7E78425128B963AB2D58 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F48043720695EE6347EFB994E3D78C79 /* OCMFunctionsPrivate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		1C26BE3AC16C34C655F315F2796C7EFE /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = BDF09C6B81F226DD43D87A40013E4011 /* OCMArg.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2014FE8419E4A9A423E1130A751842A6 /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = F1011713EC6C056ACC37D023D9C2D15A /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		20769B9E04F6F5EBF82030F1496EA81E /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = F59E6AA82CE3A9EF68C76FA8CC3314AF /* OCMExpectationRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		20C7275D7DBCE3818584A6BDA53C6BDF /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 58077E9A9ED4093497A5E0B588CD4E0F /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		21656EE637E4EF36276FB20B4BC21D93 /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 048F00928602955E61050C2EBBD68C0A /* OCMBlockCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		21A999CCC2BDC8485651213C71E2C053 /* Pods-IGListKit-tvOSTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 4926CB9A92BF783D9F06214C4495F607 /* Pods-IGListKit-tvOSTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2267EF850DD70C63BC07E359A5D20F46 /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 26CE81F8DCC93B2E058429AA15ADAAEB /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		22F3FDE93EC7750230E306DC4479E39F /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B42B1300EABCBA644D00C82FB8FDDB2 /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25503CF701A648446A450563E52CA04A /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = A72CD634D1908FF963D6543A4B0699EF /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2592D9FEF780A24BA7420C047718F901 /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 362D7DD49B8805571C594CD6EED6F407 /* OCMExceptionReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		26C7242056536D51587358A8555A94A5 /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B42B1300EABCBA644D00C82FB8FDDB2 /* OCMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		26D53544D1B73BB50031D8496B9036B7 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = E7E871406ECFA78678074A43B67F57A8 /* OCMBlockCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		26E097DAADCAD53194B5DAE2B6C69A76 /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = F59E6AA82CE3A9EF68C76FA8CC3314AF /* OCMExpectationRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		27170FD942260EF61AF3C96E43B9EBF2 /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D8776DCE9E560DF184E64BF7D46D86A /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2778F6AFF9623E29A3040F02F3ED7E38 /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = A0FBA930F2D633BFB9AF42E83F80790B /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		27C0A23F92B54E802783C075BDEB7274 /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 397181337B1A32F9D1D97C2185C2BA75 /* OCMNotificationPoster.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		291F014302285645FD342016AEC72CEE /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = B335B18374B39E2533DF37073A8D1F17 /* OCMFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2BB46402F9F45883D6FC8CD17790B496 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EE227EB2DBB93B0B9BC79549285E23 /* OCMInvocationExpectation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2BF0013709E3B8280BD7B3C0B150B5AF /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = F6AC619091B745F5D2054865A142EA4A /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2DC938E4C3837B31603D6CFE55CAE0B3 /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 397181337B1A32F9D1D97C2185C2BA75 /* OCMNotificationPoster.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2E26A66085EEA3DF8627BD4945FBCB9D /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 57BB148227DE7CB2DEE3E56A4CF1CF82 /* NSMethodSignature+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		2E800699648FE534DE5BC809B423C9FD /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EE227EB2DBB93B0B9BC79549285E23 /* OCMInvocationExpectation.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		322EAB6E6D2CAD04C46C1EFF6A263839 /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD83377DCB627C0E18D3EE6D2127144 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3456F0B5CA23E835B07EDE26CBDC5FF7 /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 58077E9A9ED4093497A5E0B588CD4E0F /* OCMRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3723AEFEBE676CB437859F0CEE2B3214 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA33982346F43731424B503F1761A7 /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		38500FE324F12EB2BA8E392084AC66B1 /* OCMock-tvOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F398123E655432B4F393298C40F79F9A /* OCMock-tvOS-dummy.m */; };
+		3AE1CC61908EDA47F420CF984327F7D5 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 856713793630290B44DDCFA709761FBC /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3BBC04E76FDCB7AF4851E8631EA6375D /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B4CB58CB4BB13A854D97E7F6A13D2B36 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3D82EA404C90ACD1AFA8F540C7BE595B /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = AAD83377DCB627C0E18D3EE6D2127144 /* OCPartialMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3D868EB4C33BBEDD82C90072583F7442 /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EFCF4C37D6584BFEF0379A35DC435D /* OCObserverMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		3F930BC77C941E8627D2628F3CA37A01 /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = D9E254DCD2C8DA696A35A2A093749012 /* OCMVerifier.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		441F2BA89997C643569EE59E9CF2D15F /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CFB92296F6A094D4B5360DC761DFECE /* OCMBoxedReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		45811112B1FF52D47571BA221E4A6A01 /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = D9E254DCD2C8DA696A35A2A093749012 /* OCMVerifier.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		46102E73A1DB1E900CE37A97F0B3898C /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DB5F18232A4D62BFA94F14F8841815 /* OCClassMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		46161F17A2F404BDF1F97AFCD34980AA /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CEA2127E728872F80E58FFA2E6B6BD49 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		480A0203B7F7E0182FF488E570A10A28 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = E831274015F0C341B62F5DD9F4F092DE /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		48C2380E44CE2729CD59685BFD9551D5 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 07DCCAE6ACDA7B3D5D7420344B19BE00 /* OCMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D335C62BCE3AFB527CD1C15B981408E /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE3E7191897F1C6F2B93354BD88347E /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4F077F71364BDDC44456CAB544B2E132 /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = BDF09C6B81F226DD43D87A40013E4011 /* OCMArg.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FC178D108422A5E23CF4A8396A38DB3 /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BE3E7191897F1C6F2B93354BD88347E /* OCMIndirectReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		51565BB64B62E9DBED49F189848ED56A /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBE301CDF9020678CB8C29C4CA8EA57 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		51DE08BE1E52CCBCA5FC489698226780 /* Pods-IGListKitTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 66424FEFE51F2A991681F3AAC646C488 /* Pods-IGListKitTests-dummy.m */; };
+		51FEDBD2188411A5797540FA0D443B0D /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 1497687A64BDBF7E170B5D16567D0CE9 /* OCObserverMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		53E6FFE0655641B38B53A4DB2D7C3358 /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B4CB58CB4BB13A854D97E7F6A13D2B36 /* OCMObserverRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		54EA3A596AA02034AAE4AA9BD71CC4FD /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 26CE81F8DCC93B2E058429AA15ADAAEB /* OCMInvocationStub.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5DFAFFD2BB4BE413F1F0D338A1BA7D66 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 563B58F20FA831CB7A17B0B13BA8B70B /* OCMIndirectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6279FB7DAB88CBB1747FC88CB19F8B2E /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = F59DC5FB548DEC8232E66F2F826F2FA0 /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6577B5DDD007589D5D0C4297DF048E84 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DE2E4C28A3C653DD750E95FDA066B /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		669AE33C8D12C446D457755FA76199BB /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B1D04B4294912E3A2B53028A65C77FB1 /* OCMExceptionReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6A4A5A4533DCAC91F29951A2BE98C8AC /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = F59DC5FB548DEC8232E66F2F826F2FA0 /* OCMArg.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6B14869E86C77CE735DBAEBB19F8945A /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A0EFCF4C37D6584BFEF0379A35DC435D /* OCObserverMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6C1D9E6C5857EF9BB7C2095531F8E0AC /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = A0FBA930F2D633BFB9AF42E83F80790B /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6CF37CE1EB56B6D7F9CDC8534081FD0D /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = C8A9AD5673237000ADFD0FDC3C38E203 /* OCMBlockArgCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		6FF84FE104355F1815DBA54A24FEC23E /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = B335B18374B39E2533DF37073A8D1F17 /* OCMFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		702D7E112218C066F92BAD6D78828EA0 /* Pods-IGListKit-tvOSTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C657A08A3CEC4F4157265D404465D6C5 /* Pods-IGListKit-tvOSTests-dummy.m */; };
+		718D64A47C3F0B97F4D862AA92EEC948 /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 11639F91AD6FE7D10252D4E11C62B176 /* OCMLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7227965DC753708A9668FEB68C353CDC /* Pods-IGListKitTests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 130C54D33F101344CAD5C552A16D86F7 /* Pods-IGListKitTests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72841DE97DC5417CC5C01BD493569D31 /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 68AC7B831C120B11CBB1F48E14495263 /* OCProtocolMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		73CF7C447211C639B8946CB2CA8C2685 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D3157613797A16A9BA6D99FE75FFF4D8 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		73ED67E0315D832C3EC9A1E6BDCB6932 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = C79E307A78753A501C2DEA2DED298055 /* OCMInvocationMatcher.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		75147405E63FA23DCECD95C71A2686BA /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BFFB5E68FB464B8E2BC376C5133EFD1 /* OCMReturnValueProvider.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7744593FB0FDC7575FC0BE7F2A951A38 /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA33982346F43731424B503F1761A7 /* OCMFunctions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		77CCE9A5B1233BB93FF7F7EA0AF51328 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B712C7D27EB7CD8F8A18A3EDE52765C0 /* Foundation.framework */; };
+		7809A855D585E232A3BDB30C3B6A9D41 /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B1295058ABC5DE9E07A61A001034156E /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		79A007F049E58DAA6FADA8D0D8F938D0 /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = E831274015F0C341B62F5DD9F4F092DE /* OCMNotificationPoster.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7C0A292F90BCAB990CEC91199464C995 /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = E7E871406ECFA78678074A43B67F57A8 /* OCMBlockCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7C70426CF7B5F6CA650E21A6CDBB5F71 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FEC0A0AA548D223195671B8A7AA132A /* OCMPassByRefSetter.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		7CD453892F1A8E1A148F3333428C0CCC /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = F6AC619091B745F5D2054865A142EA4A /* OCMInvocationExpectation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7F0C11F5437A1F4BBAF3719C1C155959 /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 856713793630290B44DDCFA709761FBC /* OCMRealObjectForwarder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8128597042D2405A272366448DECD9C8 /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = F31528048CF512EEBFC74FFCB6F133E8 /* NSObject+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		82CDA00190623EA990B6AC646701A292 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D3157613797A16A9BA6D99FE75FFF4D8 /* NSValue+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		82F12DA8CC90A334DE69502A23198B9A /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = B67BDA6AE164B2450296DBD65B97B9E2 /* OCMStubRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		83E919706D79D752C3182841C7BA56A0 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CD066A6A013DEFF0C9C09009C8E5EE60 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		84E962C9F748CC48A04E23C608FAEFC9 /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FEC0A0AA548D223195671B8A7AA132A /* OCMPassByRefSetter.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8690A4847966E58D94955F70DCB31299 /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AB806E2446D395F04C99AC4822865E6 /* OCMReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		86CC33926D425C0F98FDD3FFE3357769 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80D50031945639C9CFCD3CBF24E18561 /* Foundation.framework */; };
+		87EE61E21AC3510DF30566A2255B3A14 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = ADA1F153704FBE678091BDD0D0C999BD /* OCPartialMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		88F20C6DBC809D869768D82E8AB271C8 /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = B1D04B4294912E3A2B53028A65C77FB1 /* OCMExceptionReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8BE56FB488389ACDDE88F14D8EA46595 /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E2DB5F18232A4D62BFA94F14F8841815 /* OCClassMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8C00AF4FBC6F26E402B8D4BD90E64C17 /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CFB92296F6A094D4B5360DC761DFECE /* OCMBoxedReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		8D7B3B9E2BDEC37BA29D948351B098C7 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F17B4561770684928A57AC115A8D3B /* OCMockObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9132F2F18A77C94EFA3F6FF656714E4B /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C27E1C9D1A5211777D0F972ED88515F /* NSNotificationCenter+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		91FDBFC124DF0BC13AAAF85552F23920 /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 741CDA7FB5A6FDEB8A5BB399F6137460 /* OCMArgAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		92C936309A821CC82477660D7BA15A74 /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 8D8776DCE9E560DF184E64BF7D46D86A /* OCMMacroState.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9CA0E24E0868DC2CE7A433057DC0F9D2 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 92528A8421D0AB8035F601019A51E05A /* OCMRealObjectForwarder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9DB76828E66BBAA9820AEFF98AC701F1 /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 721FE9FE6798CAA94961C42D5AB44202 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9F7FBE37D7663C2AB4207B3978D98B25 /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D035F1D426C3F3C4F1EB324E8A786A /* OCMConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A15438F50C41BCB03734F26D58B75C9B /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = A276D6A0E43FA8ED1778DC0E70DA9C56 /* OCMObserverRecorder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A27747AE4518D21D05ADAB5998EFFBC5 /* OCMock-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 14851A29BC0814298E3BFF3819A2D930 /* OCMock-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5B17B56CF04520A57C270C347C7F29C /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 68AC7B831C120B11CBB1F48E14495263 /* OCProtocolMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A90623D3FB36F3F28475180F517F8381 /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = A1A5BFC40F4ED9027D84940697968910 /* NSInvocation+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		A9ED013B5C6DCF2ECFDCE7D34122103B /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 57BB148227DE7CB2DEE3E56A4CF1CF82 /* NSMethodSignature+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B13343A34499E3D38A49576F33B60931 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C72441E645C70187EC0D9BCDB8DE588 /* OCMInvocationStub.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B1A17CF8FD0BD99FF2C687E4D9617683 /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 07DCCAE6ACDA7B3D5D7420344B19BE00 /* OCMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B30C1061D09D7FFA7060585EF1A7CEBC /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = EF760F5AC580FD6A33D7585CB13D91F3 /* OCProtocolMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B37F20281B1CDC706ABDCACEFF7EF154 /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 741CDA7FB5A6FDEB8A5BB399F6137460 /* OCMArgAction.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B43A9CFCAEB91C589819DEC2C7CE5ABC /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = A72CD634D1908FF963D6543A4B0699EF /* OCMArgAction.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B5D97911E7A6A847E3C368025C7DBAEA /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E961CF56BA9954B9D87D257C2DF68E /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B79CBF967716FD6ABC1C062F54F6F0F6 /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C72441E645C70187EC0D9BCDB8DE588 /* OCMInvocationStub.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		B885EDBF636B4DC1FC20FF4B7FB97802 /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C27E1C9D1A5211777D0F972ED88515F /* NSNotificationCenter+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BE5760C3BFABE64FC5ED1106FBE7D932 /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C5162FD6E5A211B63C23FC1903D8A7F /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BF16FB8A5413565910BB3E2D92792518 /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 92528A8421D0AB8035F601019A51E05A /* OCMRealObjectForwarder.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		C65F0B6AC5349E81D38CBF17B3A77A40 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = CD066A6A013DEFF0C9C09009C8E5EE60 /* NSObject+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C8E44A0ED21BDE1CAA5AD1EC61697689 /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 495A63A75195819B741BF650D6D02E95 /* OCMRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C9642EF15274D3BF9554919EFE710B0A /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 81AB2361DCD889FF3D7BD96D6D965744 /* OCMVerifier.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C96F240851643FDEB4980F69416F204B /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = CEA2127E728872F80E58FFA2E6B6BD49 /* OCMStubRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C9FA2F5CBD8A70A6819ED52BDC6EB772 /* OCMock-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5247D700C531F22493BB6FEBC2630C01 /* OCMock-iOS-dummy.m */; };
+		CA3AAC617EE7B03F48A7A645FB9728F9 /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = ADA1F153704FBE678091BDD0D0C999BD /* OCPartialMockObject.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		D1BBDDD1CACFCD403C3501ABF828B026 /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 33F17B4561770684928A57AC115A8D3B /* OCMockObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D2DC134DFCF9D30F747B95370C9E88DA /* OCMock-tvOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E04F10EA12ECEE01C3E7A32C47177943 /* OCMock-tvOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D691F2CCF4714802DBF52AC8DA3524C5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80D50031945639C9CFCD3CBF24E18561 /* Foundation.framework */; };
+		D7D094BB8BBAD8DB7F273FDA22DA3D63 /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = C8A9AD5673237000ADFD0FDC3C38E203 /* OCMBlockArgCaller.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		DD362AE58AFA00B78D78D843FC845B6D /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C5162FD6E5A211B63C23FC1903D8A7F /* NSInvocation+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DD8036A32A801396DE6B6EAED501B955 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF53648561EA071EA3D4171A451D25C /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DE4D0C13161E1CE029E42BC70D232DD0 /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBE301CDF9020678CB8C29C4CA8EA57 /* OCClassMockObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DED14BFC7B371EB56BAF48429FCFAA01 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F48043720695EE6347EFB994E3D78C79 /* OCMFunctionsPrivate.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		DF491C27923F8DA644D84D3CBE2D859F /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = B1295058ABC5DE9E07A61A001034156E /* OCMExpectationRecorder.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E0AB257B00B552E451B45107C23F0A7E /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = EDC9494345261ABF2FCF9FED0AB34ED1 /* OCMPassByRefSetter.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E1B32C66A583D14438C748FD9CD5872E /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 721FE9FE6798CAA94961C42D5AB44202 /* NSNotificationCenter+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E265EFE084613D893101DCAB6727CB6F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B712C7D27EB7CD8F8A18A3EDE52765C0 /* Foundation.framework */; };
+		E3E443536B5E4D1ADF77EB6414C43989 /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 11639F91AD6FE7D10252D4E11C62B176 /* OCMLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E5600614439859750460A368508BCEA9 /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = EFF53648561EA071EA3D4171A451D25C /* OCMConstraint.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EA3BCC8D57093194F96F68CF678182B9 /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 98C06A2A7F88EF744180A55E81D64F24 /* NSValue+OCMAdditions.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		EEBA09F1319934B5C6ACD988086B7D86 /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 563B58F20FA831CB7A17B0B13BA8B70B /* OCMIndirectReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F306775FFBBA3DDB756A4FFA6F92EECC /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = B67BDA6AE164B2450296DBD65B97B9E2 /* OCMStubRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F8DAF40AF22145557BF950A55D304B06 /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = D0E961CF56BA9954B9D87D257C2DF68E /* NSMethodSignature+OCMAdditions.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F95697591B8427E88256F5BC438E3D75 /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = F1011713EC6C056ACC37D023D9C2D15A /* OCMBlockArgCaller.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FA0E4CCEFE5577E696583703743BC35B /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = E849DFC39CDDC56F1B18E9F66B0E1113 /* OCMInvocationMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FB2B15FB06D12DB0949294EF17155585 /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AB806E2446D395F04C99AC4822865E6 /* OCMReturnValueProvider.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FE2212BE27C3233ACFC53B9C7C1E8BE2 /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D9DE2E4C28A3C653DD750E95FDA066B /* OCMLocation.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		81A3BC0EBD9AAE8190DA0EB5A37AF646 /* PBXContainerItemProxy */ = {
+		34D5AD073A2213F2B27F4381EA1CB9BA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = A42C6C749C629BBA32B9193724D6EB53;
-			remoteInfo = "OCMock-tvOS";
-		};
-		B9FD7F3A2837B7098668B840B8B974EB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8AF9F398A1E64F014A9121074F6701F6;
+			remoteGlobalIDString = C8E76D7400B2260D37AD0BD81395C059;
 			remoteInfo = "OCMock-iOS";
+		};
+		8DA3FF6FCD6285E0A5B16AF7A6142E54 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 609DCF78F50CE8CD06E2848D8C22E2E9;
+			remoteInfo = "OCMock-tvOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -183,7 +183,6 @@
 		0BE3E7191897F1C6F2B93354BD88347E /* OCMIndirectReturnValueProvider.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMIndirectReturnValueProvider.m; path = Source/OCMock/OCMIndirectReturnValueProvider.m; sourceTree = "<group>"; };
 		0CE2889F4BD718AD7B056C7E169B1299 /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = OCMock.framework; path = "OCMock-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		11639F91AD6FE7D10252D4E11C62B176 /* OCMLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMLocation.h; path = Source/OCMock/OCMLocation.h; sourceTree = "<group>"; };
-		12EA7F453C881E24340B531D2D2133D0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		130C54D33F101344CAD5C552A16D86F7 /* Pods-IGListKitTests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-IGListKitTests-umbrella.h"; sourceTree = "<group>"; };
 		14851A29BC0814298E3BFF3819A2D930 /* OCMock-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OCMock-iOS-umbrella.h"; sourceTree = "<group>"; };
 		1497687A64BDBF7E170B5D16567D0CE9 /* OCObserverMockObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCObserverMockObject.m; path = Source/OCMock/OCObserverMockObject.m; sourceTree = "<group>"; };
@@ -219,6 +218,7 @@
 		741CDA7FB5A6FDEB8A5BB399F6137460 /* OCMArgAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArgAction.h; path = Source/OCMock/OCMArgAction.h; sourceTree = "<group>"; };
 		75785F0C973A05BF18D81031C3313C8C /* OCMock-tvOS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "OCMock-tvOS-Info.plist"; path = "../OCMock-tvOS/OCMock-tvOS-Info.plist"; sourceTree = "<group>"; };
 		7FD83E173EBCF53E46019F1D6F02A5FC /* Pods-IGListKitTests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-IGListKitTests-Info.plist"; sourceTree = "<group>"; };
+		80D50031945639C9CFCD3CBF24E18561 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		81AB2361DCD889FF3D7BD96D6D965744 /* OCMVerifier.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMVerifier.m; path = Source/OCMock/OCMVerifier.m; sourceTree = "<group>"; };
 		856713793630290B44DDCFA709761FBC /* OCMRealObjectForwarder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMRealObjectForwarder.m; path = Source/OCMock/OCMRealObjectForwarder.m; sourceTree = "<group>"; };
 		8D8776DCE9E560DF184E64BF7D46D86A /* OCMMacroState.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMMacroState.m; path = Source/OCMock/OCMMacroState.m; sourceTree = "<group>"; };
@@ -240,8 +240,8 @@
 		B335B18374B39E2533DF37073A8D1F17 /* OCMFunctions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMFunctions.h; path = Source/OCMock/OCMFunctions.h; sourceTree = "<group>"; };
 		B4CB58CB4BB13A854D97E7F6A13D2B36 /* OCMObserverRecorder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = OCMObserverRecorder.m; path = Source/OCMock/OCMObserverRecorder.m; sourceTree = "<group>"; };
 		B67BDA6AE164B2450296DBD65B97B9E2 /* OCMStubRecorder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMStubRecorder.h; path = Source/OCMock/OCMStubRecorder.h; sourceTree = "<group>"; };
+		B712C7D27EB7CD8F8A18A3EDE52765C0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BDF09C6B81F226DD43D87A40013E4011 /* OCMArg.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = OCMArg.h; path = Source/OCMock/OCMArg.h; sourceTree = "<group>"; };
-		BECBF1EDC84264AA8EE8912A034726A8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BFF567767E8B289BB314D5A83B8B0B23 /* OCMock-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OCMock-iOS-prefix.pch"; sourceTree = "<group>"; };
 		C56BE1B6CFA1DA72C6D0AC4B6A4A4134 /* Pods-IGListKit-tvOSTests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-IGListKit-tvOSTests-frameworks.sh"; sourceTree = "<group>"; };
 		C657A08A3CEC4F4157265D404465D6C5 /* Pods-IGListKit-tvOSTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-IGListKit-tvOSTests-dummy.m"; sourceTree = "<group>"; };
@@ -283,35 +283,35 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		8C3F9656C94E5A6D11CEC1FF48A9C9F4 /* Frameworks */ = {
+		5A5036C16810B69EC205530CC78F0DF7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4EFD9BB2056F1227D5B960CF716CF40F /* Foundation.framework in Frameworks */,
+				77CCE9A5B1233BB93FF7F7EA0AF51328 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CF04FD2EF3BEC2D9BD37BB9B11470EA1 /* Frameworks */ = {
+		5DFE6F6DB6A9AEE48A904D562BA1E2D3 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				394EE0AC939A948487CE548E4CADA546 /* Foundation.framework in Frameworks */,
+				E265EFE084613D893101DCAB6727CB6F /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DAE5DF750589210250C8762FBCBC2676 /* Frameworks */ = {
+		6E801221F208C6D594642D02CD615306 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				85B5DBD3A48C0E109056C033DEF52597 /* Foundation.framework in Frameworks */,
+				86CC33926D425C0F98FDD3FFE3357769 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E7AFE1A01A1AD5B264E17F41A9B2079E /* Frameworks */ = {
+		CF7D4DD330E22BF6B588C19F89B1A3AF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F624D33BAE96156D863DFE1CE8E1E93C /* Foundation.framework in Frameworks */,
+				D691F2CCF4714802DBF52AC8DA3524C5 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -338,10 +338,10 @@
 			path = "../Target Support Files/OCMock-iOS";
 			sourceTree = "<group>";
 		};
-		5A8CE8058340022AE855C127A28C4E03 /* tvOS */ = {
+		71BF10D9671F60B91D333968CED34958 /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
-				12EA7F453C881E24340B531D2D2133D0 /* Foundation.framework */,
+				B712C7D27EB7CD8F8A18A3EDE52765C0 /* Foundation.framework */,
 			);
 			name = tvOS;
 			sourceTree = "<group>";
@@ -349,8 +349,8 @@
 		8910DE18F4068EE7F2F8E36E5101A369 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				B0189968EF7671928A0419E2336FE0D8 /* iOS */,
-				5A8CE8058340022AE855C127A28C4E03 /* tvOS */,
+				9A88CC71D6E55F0202A23277A509BCA0 /* iOS */,
+				71BF10D9671F60B91D333968CED34958 /* tvOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -364,10 +364,10 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		B0189968EF7671928A0419E2336FE0D8 /* iOS */ = {
+		9A88CC71D6E55F0202A23277A509BCA0 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				BECBF1EDC84264AA8EE8912A034726A8 /* Foundation.framework */,
+				80D50031945639C9CFCD3CBF24E18561 /* Foundation.framework */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -516,156 +516,119 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		577F6E657BD0B2B508D5866804924994 /* Headers */ = {
+		2182563C212D91A1AA63DCE7E26343BD /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A3C7432F44BC9BE79142705B6B4509D8 /* Pods-IGListKitTests-umbrella.h in Headers */,
+				7227965DC753708A9668FEB68C353CDC /* Pods-IGListKitTests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		97F8CB18D4E264A0BCD607F3D6A813BE /* Headers */ = {
+		9428E6CC2E574156AF0F5AF99FE9EFC8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				67C074A871E4405F6B3F04600501FECD /* NSInvocation+OCMAdditions.h in Headers */,
-				BE2613E184073E45D2FF36116FE84D5D /* NSMethodSignature+OCMAdditions.h in Headers */,
-				3DB311D40A2DFB263A1F8374561439AC /* NSNotificationCenter+OCMAdditions.h in Headers */,
-				EDC9E9EA061E09FF068B60417DE34C84 /* NSObject+OCMAdditions.h in Headers */,
-				17F55936F66ACF061EACCC993DA2F730 /* NSValue+OCMAdditions.h in Headers */,
-				58CFDF087BC2E83FD9EDC723DF93FA76 /* OCClassMockObject.h in Headers */,
-				C072983510FB471DF691D89B62387A7B /* OCMArg.h in Headers */,
-				6B355DA2E943ADA5468E2D0CC2224007 /* OCMArgAction.h in Headers */,
-				BF48F22800CB4889DCF700E0FF7598EF /* OCMBlockArgCaller.h in Headers */,
-				0CAE8FC7FB8D3AF78FE0111803BEAF99 /* OCMBlockCaller.h in Headers */,
-				510811B7C7F94C97454D10960CFF1B55 /* OCMBoxedReturnValueProvider.h in Headers */,
-				F113FBF070A154E5520B7D1A15054341 /* OCMConstraint.h in Headers */,
-				161310D35CE927CB4E0D91DCEAA7755B /* OCMExceptionReturnValueProvider.h in Headers */,
-				FF3036F610784828F959001815D4C36A /* OCMExpectationRecorder.h in Headers */,
-				6CF02A914409C7B45AF671A328AF30B0 /* OCMFunctions.h in Headers */,
-				A549F62610FBACFCF1947C0A416F83D7 /* OCMFunctionsPrivate.h in Headers */,
-				F48EC77840841007EE31D32A03254A81 /* OCMIndirectReturnValueProvider.h in Headers */,
-				05E63C99E1A7A32396CFE3FD757149D1 /* OCMInvocationExpectation.h in Headers */,
-				918DB8D86E3D6848B2D8610DE78AAE61 /* OCMInvocationMatcher.h in Headers */,
-				3B0DAA314E5A5F1B37CBF7D39A6A2BB9 /* OCMInvocationStub.h in Headers */,
-				C09FE5E7CCD88E0C0126E836EC4F87A0 /* OCMLocation.h in Headers */,
-				936E206C36CB014CDE98EEE81D330C96 /* OCMMacroState.h in Headers */,
-				96A8BEB618F569C4D0D6B9CEEDAF9A32 /* OCMNotificationPoster.h in Headers */,
-				1B53E3EC6760D7989626A4173D12A264 /* OCMObserverRecorder.h in Headers */,
-				7AEBD779FCD70FC14BC943E5EE5A510A /* OCMock-iOS-umbrella.h in Headers */,
-				A2FC79A1AFDCEA36B0B8795E02C68F64 /* OCMock.h in Headers */,
-				D09739C4EDCFAD34F6159F452BEF3181 /* OCMockObject.h in Headers */,
-				F6BADC64F6B2C733EB4E534244D3CCBD /* OCMPassByRefSetter.h in Headers */,
-				7EF8CC45C08CF5FA58B904B73C63D328 /* OCMRealObjectForwarder.h in Headers */,
-				0BA903E101A263D7034D61C206DD2BE4 /* OCMRecorder.h in Headers */,
-				6ACFA64760DCBB80C0F731B7E934167B /* OCMReturnValueProvider.h in Headers */,
-				B9782F37022AC37CAFC1A1222D6EB897 /* OCMStubRecorder.h in Headers */,
-				5B9C6E91238A67BFA3F2BF4F88E15904 /* OCMVerifier.h in Headers */,
-				8947FC603171292BB45D94F76FC60CAE /* OCObserverMockObject.h in Headers */,
-				C77AF8C5954ADB7102F57340E9BAD812 /* OCPartialMockObject.h in Headers */,
-				ECA0A4805E559E578721F4D3DD4FD649 /* OCProtocolMockObject.h in Headers */,
+				21A999CCC2BDC8485651213C71E2C053 /* Pods-IGListKit-tvOSTests-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AC1FE3B5606141B69CF52CAB84481786 /* Headers */ = {
+		AEC442C157E21715432C1F9AF507650A /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				393531D750D1C7DEE049690194D23103 /* NSInvocation+OCMAdditions.h in Headers */,
-				BC50F7389E683DA1CA36992873B02029 /* NSMethodSignature+OCMAdditions.h in Headers */,
-				74733022A85B416647A368BCC1C51E2B /* NSNotificationCenter+OCMAdditions.h in Headers */,
-				8DF92661721DB2FFD93037A1B3D2B03C /* NSObject+OCMAdditions.h in Headers */,
-				9356E4C71572D93BE17358BD2D3A1DA0 /* NSValue+OCMAdditions.h in Headers */,
-				C0D936BF720D5C00AA8BB60621E37032 /* OCClassMockObject.h in Headers */,
-				E130D0AF2979CD4141A597002BB444F5 /* OCMArg.h in Headers */,
-				1652E9EAB46A785A33B3DCF9FE259243 /* OCMArgAction.h in Headers */,
-				5022DC019FD5E2965DD8E891A279C113 /* OCMBlockArgCaller.h in Headers */,
-				64A6F73FC964088EC293199D8364DD13 /* OCMBlockCaller.h in Headers */,
-				9B3D597670D528229CFB3327CEC92076 /* OCMBoxedReturnValueProvider.h in Headers */,
-				7ECCACF3554B47C4B2BB90FCDC8B5523 /* OCMConstraint.h in Headers */,
-				D7797C4D618A10817A138D2EC6E7EB3F /* OCMExceptionReturnValueProvider.h in Headers */,
-				A75EABE7F50FF184DF0547EAE6D34914 /* OCMExpectationRecorder.h in Headers */,
-				345DF50EC98B1BB41C5DCBC2A518E6F0 /* OCMFunctions.h in Headers */,
-				B19733FB1A46C40E429B82A02591779E /* OCMFunctionsPrivate.h in Headers */,
-				F194DA590299A388595C988635F026B3 /* OCMIndirectReturnValueProvider.h in Headers */,
-				44337032D9E12EE7861DB4828A98AF40 /* OCMInvocationExpectation.h in Headers */,
-				8BDADD084A05DF43C0FC4FBD8E74A533 /* OCMInvocationMatcher.h in Headers */,
-				52D5F493AB2C1B54D905AFF29AE39FF8 /* OCMInvocationStub.h in Headers */,
-				800D159753832DEC8EB5673CA7B343C9 /* OCMLocation.h in Headers */,
-				F60EB7E261DBB2B9A5B0CC2E6EE533C8 /* OCMMacroState.h in Headers */,
-				2DB19FEA3BD64D03D77564C6F70C5DBA /* OCMNotificationPoster.h in Headers */,
-				E8C79D0A60EA780C80D3E7395CFA21C7 /* OCMObserverRecorder.h in Headers */,
-				A00FC9D29C3E60023D12F8951E0436D3 /* OCMock-tvOS-umbrella.h in Headers */,
-				6F33B23042B9DE553BFE3DFD5DBAAF80 /* OCMock.h in Headers */,
-				7C81388460369B6F5EF53C6AEAF28B3D /* OCMockObject.h in Headers */,
-				7076E45CBFBBA6B5E8655EC6DE727453 /* OCMPassByRefSetter.h in Headers */,
-				1FE0B34EB7C89D09D860ECCC07DD9662 /* OCMRealObjectForwarder.h in Headers */,
-				BD29646AB3CE7AC7E9B6A9A64922F122 /* OCMRecorder.h in Headers */,
-				51CCB4EF7B2B898D41A0A18618FA1A65 /* OCMReturnValueProvider.h in Headers */,
-				58489473BFC10E0CAD4A80FABF31BF47 /* OCMStubRecorder.h in Headers */,
-				8DDF1D7F88727646540EBFB0975668DC /* OCMVerifier.h in Headers */,
-				DBCC1DB234F14A9BCDA55C81D0792B36 /* OCObserverMockObject.h in Headers */,
-				FC69869F348A41819AF05E6A4A7CED9A /* OCPartialMockObject.h in Headers */,
-				1F0A5EE0404C4AE3584B7F570248278E /* OCProtocolMockObject.h in Headers */,
+				10F91650A18EF2329240576D605C9A47 /* NSInvocation+OCMAdditions.h in Headers */,
+				A9ED013B5C6DCF2ECFDCE7D34122103B /* NSMethodSignature+OCMAdditions.h in Headers */,
+				B885EDBF636B4DC1FC20FF4B7FB97802 /* NSNotificationCenter+OCMAdditions.h in Headers */,
+				06E23E6AD291E76405B9BB002F267199 /* NSObject+OCMAdditions.h in Headers */,
+				EA3BCC8D57093194F96F68CF678182B9 /* NSValue+OCMAdditions.h in Headers */,
+				46102E73A1DB1E900CE37A97F0B3898C /* OCClassMockObject.h in Headers */,
+				1C26BE3AC16C34C655F315F2796C7EFE /* OCMArg.h in Headers */,
+				B37F20281B1CDC706ABDCACEFF7EF154 /* OCMArgAction.h in Headers */,
+				6CF37CE1EB56B6D7F9CDC8534081FD0D /* OCMBlockArgCaller.h in Headers */,
+				7C0A292F90BCAB990CEC91199464C995 /* OCMBlockCaller.h in Headers */,
+				441F2BA89997C643569EE59E9CF2D15F /* OCMBoxedReturnValueProvider.h in Headers */,
+				110AE929E6276B8DE4787B6F479921B1 /* OCMConstraint.h in Headers */,
+				88F20C6DBC809D869768D82E8AB271C8 /* OCMExceptionReturnValueProvider.h in Headers */,
+				26E097DAADCAD53194B5DAE2B6C69A76 /* OCMExpectationRecorder.h in Headers */,
+				6FF84FE104355F1815DBA54A24FEC23E /* OCMFunctions.h in Headers */,
+				DED14BFC7B371EB56BAF48429FCFAA01 /* OCMFunctionsPrivate.h in Headers */,
+				EEBA09F1319934B5C6ACD988086B7D86 /* OCMIndirectReturnValueProvider.h in Headers */,
+				2BB46402F9F45883D6FC8CD17790B496 /* OCMInvocationExpectation.h in Headers */,
+				73ED67E0315D832C3EC9A1E6BDCB6932 /* OCMInvocationMatcher.h in Headers */,
+				B13343A34499E3D38A49576F33B60931 /* OCMInvocationStub.h in Headers */,
+				E3E443536B5E4D1ADF77EB6414C43989 /* OCMLocation.h in Headers */,
+				2778F6AFF9623E29A3040F02F3ED7E38 /* OCMMacroState.h in Headers */,
+				27C0A23F92B54E802783C075BDEB7274 /* OCMNotificationPoster.h in Headers */,
+				066C0CC259102FC7B1F6A4A38F882E24 /* OCMObserverRecorder.h in Headers */,
+				D2DC134DFCF9D30F747B95370C9E88DA /* OCMock-tvOS-umbrella.h in Headers */,
+				B1A17CF8FD0BD99FF2C687E4D9617683 /* OCMock.h in Headers */,
+				D1BBDDD1CACFCD403C3501ABF828B026 /* OCMockObject.h in Headers */,
+				84E962C9F748CC48A04E23C608FAEFC9 /* OCMPassByRefSetter.h in Headers */,
+				9CA0E24E0868DC2CE7A433057DC0F9D2 /* OCMRealObjectForwarder.h in Headers */,
+				0E7F1C4344AA26C73715A7717CA57EF2 /* OCMRecorder.h in Headers */,
+				FB2B15FB06D12DB0949294EF17155585 /* OCMReturnValueProvider.h in Headers */,
+				82F12DA8CC90A334DE69502A23198B9A /* OCMStubRecorder.h in Headers */,
+				3F930BC77C941E8627D2628F3CA37A01 /* OCMVerifier.h in Headers */,
+				3D868EB4C33BBEDD82C90072583F7442 /* OCObserverMockObject.h in Headers */,
+				87EE61E21AC3510DF30566A2255B3A14 /* OCPartialMockObject.h in Headers */,
+				72841DE97DC5417CC5C01BD493569D31 /* OCProtocolMockObject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FDC0AC6FA566A0630A6CD6488F2B324F /* Headers */ = {
+		F6942EA067A48456410CBD2A84889F11 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3BBACAB947214D410D564463F82BAA3 /* Pods-IGListKit-tvOSTests-umbrella.h in Headers */,
+				A90623D3FB36F3F28475180F517F8381 /* NSInvocation+OCMAdditions.h in Headers */,
+				2E26A66085EEA3DF8627BD4945FBCB9D /* NSMethodSignature+OCMAdditions.h in Headers */,
+				9132F2F18A77C94EFA3F6FF656714E4B /* NSNotificationCenter+OCMAdditions.h in Headers */,
+				8128597042D2405A272366448DECD9C8 /* NSObject+OCMAdditions.h in Headers */,
+				1730F618BD2B5DEB71A1F01AF381D71B /* NSValue+OCMAdditions.h in Headers */,
+				8BE56FB488389ACDDE88F14D8EA46595 /* OCClassMockObject.h in Headers */,
+				4F077F71364BDDC44456CAB544B2E132 /* OCMArg.h in Headers */,
+				91FDBFC124DF0BC13AAAF85552F23920 /* OCMArgAction.h in Headers */,
+				D7D094BB8BBAD8DB7F273FDA22DA3D63 /* OCMBlockArgCaller.h in Headers */,
+				26D53544D1B73BB50031D8496B9036B7 /* OCMBlockCaller.h in Headers */,
+				8C00AF4FBC6F26E402B8D4BD90E64C17 /* OCMBoxedReturnValueProvider.h in Headers */,
+				9F7FBE37D7663C2AB4207B3978D98B25 /* OCMConstraint.h in Headers */,
+				669AE33C8D12C446D457755FA76199BB /* OCMExceptionReturnValueProvider.h in Headers */,
+				20769B9E04F6F5EBF82030F1496EA81E /* OCMExpectationRecorder.h in Headers */,
+				291F014302285645FD342016AEC72CEE /* OCMFunctions.h in Headers */,
+				1B1423FB282B7E78425128B963AB2D58 /* OCMFunctionsPrivate.h in Headers */,
+				5DFAFFD2BB4BE413F1F0D338A1BA7D66 /* OCMIndirectReturnValueProvider.h in Headers */,
+				2E800699648FE534DE5BC809B423C9FD /* OCMInvocationExpectation.h in Headers */,
+				059134A35A7CE320EA1D4F86425B3415 /* OCMInvocationMatcher.h in Headers */,
+				B79CBF967716FD6ABC1C062F54F6F0F6 /* OCMInvocationStub.h in Headers */,
+				718D64A47C3F0B97F4D862AA92EEC948 /* OCMLocation.h in Headers */,
+				6C1D9E6C5857EF9BB7C2095531F8E0AC /* OCMMacroState.h in Headers */,
+				2DC938E4C3837B31603D6CFE55CAE0B3 /* OCMNotificationPoster.h in Headers */,
+				A15438F50C41BCB03734F26D58B75C9B /* OCMObserverRecorder.h in Headers */,
+				A27747AE4518D21D05ADAB5998EFFBC5 /* OCMock-iOS-umbrella.h in Headers */,
+				48C2380E44CE2729CD59685BFD9551D5 /* OCMock.h in Headers */,
+				8D7B3B9E2BDEC37BA29D948351B098C7 /* OCMockObject.h in Headers */,
+				7C70426CF7B5F6CA650E21A6CDBB5F71 /* OCMPassByRefSetter.h in Headers */,
+				BF16FB8A5413565910BB3E2D92792518 /* OCMRealObjectForwarder.h in Headers */,
+				C8E44A0ED21BDE1CAA5AD1EC61697689 /* OCMRecorder.h in Headers */,
+				8690A4847966E58D94955F70DCB31299 /* OCMReturnValueProvider.h in Headers */,
+				F306775FFBBA3DDB756A4FFA6F92EECC /* OCMStubRecorder.h in Headers */,
+				45811112B1FF52D47571BA221E4A6A01 /* OCMVerifier.h in Headers */,
+				6B14869E86C77CE735DBAEBB19F8945A /* OCObserverMockObject.h in Headers */,
+				CA3AAC617EE7B03F48A7A645FB9728F9 /* OCPartialMockObject.h in Headers */,
+				A5B17B56CF04520A57C270C347C7F29C /* OCProtocolMockObject.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1CF7F3C0B7CA0535499B28DA489E93F0 /* Pods-IGListKit-tvOSTests */ = {
+		609DCF78F50CE8CD06E2848D8C22E2E9 /* OCMock-tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 0BAAD1FD68C99C425EE646CB598CBFC8 /* Build configuration list for PBXNativeTarget "Pods-IGListKit-tvOSTests" */;
+			buildConfigurationList = 194475CCD3CFDA1D80A0D09994B332FF /* Build configuration list for PBXNativeTarget "OCMock-tvOS" */;
 			buildPhases = (
-				FDC0AC6FA566A0630A6CD6488F2B324F /* Headers */,
-				74620F43BCA5CE0F0404D2C8AC3F0909 /* Sources */,
-				DAE5DF750589210250C8762FBCBC2676 /* Frameworks */,
-				03C20936EF7831264AD85D7BF7A4CCA3 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				895076ADA710B04EBA5C979784D3B7C9 /* PBXTargetDependency */,
-			);
-			name = "Pods-IGListKit-tvOSTests";
-			productName = "Pods-IGListKit-tvOSTests";
-			productReference = 5060A6C42F27F050A0309370E596CD8F /* Pods_IGListKit_tvOSTests.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		8AF9F398A1E64F014A9121074F6701F6 /* OCMock-iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 39293889DB6E6523ED08009ED4241D82 /* Build configuration list for PBXNativeTarget "OCMock-iOS" */;
-			buildPhases = (
-				97F8CB18D4E264A0BCD607F3D6A813BE /* Headers */,
-				1AE0E943DACB27CE2CD7EA7879811EDC /* Sources */,
-				E7AFE1A01A1AD5B264E17F41A9B2079E /* Frameworks */,
-				D929C5C726B4A7EC76486236467F9031 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "OCMock-iOS";
-			productName = "OCMock-iOS";
-			productReference = 0CE2889F4BD718AD7B056C7E169B1299 /* OCMock.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		A42C6C749C629BBA32B9193724D6EB53 /* OCMock-tvOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BD8D15BCC9F08A6D8A27DF1C728D4336 /* Build configuration list for PBXNativeTarget "OCMock-tvOS" */;
-			buildPhases = (
-				AC1FE3B5606141B69CF52CAB84481786 /* Headers */,
-				8B23E9667B874C8D5409568243B06845 /* Sources */,
-				8C3F9656C94E5A6D11CEC1FF48A9C9F4 /* Frameworks */,
-				3BEA394E26D87B3B74974E8AB70435D5 /* Resources */,
+				AEC442C157E21715432C1F9AF507650A /* Headers */,
+				5F6514BCFF375AA3830BB391F865EBF1 /* Sources */,
+				5DFE6F6DB6A9AEE48A904D562BA1E2D3 /* Frameworks */,
+				42E48E40433993934EDF2A3A7EE4B6D8 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -676,23 +639,60 @@
 			productReference = DE785B8D90B2E61DF911993D353959D8 /* OCMock.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		FF557FF8A8298F109DCC8858334E3FDE /* Pods-IGListKitTests */ = {
+		6474A33341F6F1D6E701FE1368CA7212 /* Pods-IGListKitTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8C37347D43619B47816CFD7E5792720A /* Build configuration list for PBXNativeTarget "Pods-IGListKitTests" */;
+			buildConfigurationList = ABC441EA4C1B5DEC2D67F90987AC3A45 /* Build configuration list for PBXNativeTarget "Pods-IGListKitTests" */;
 			buildPhases = (
-				577F6E657BD0B2B508D5866804924994 /* Headers */,
-				31BC952D1759C4E11B46CEF5A8046AB8 /* Sources */,
-				CF04FD2EF3BEC2D9BD37BB9B11470EA1 /* Frameworks */,
-				ACB579EA47A47F17D4241825AB01F389 /* Resources */,
+				2182563C212D91A1AA63DCE7E26343BD /* Headers */,
+				32130E0B8892C99A356C3AE7BA0497A5 /* Sources */,
+				CF7D4DD330E22BF6B588C19F89B1A3AF /* Frameworks */,
+				6708CF8E923D3FF15831108C7085DF0B /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				157859B3BD4AA1549F104F33E64EA004 /* PBXTargetDependency */,
+				0FFB99C3F2CC09C84B2551654BBAE8DF /* PBXTargetDependency */,
 			);
 			name = "Pods-IGListKitTests";
 			productName = "Pods-IGListKitTests";
 			productReference = EF90A36F0BE06AADDC383D90A5D4A245 /* Pods_IGListKitTests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B83E6CD1470726A18F5E4339943E5E4B /* Pods-IGListKit-tvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 07660FB725460404A034B004BBD91695 /* Build configuration list for PBXNativeTarget "Pods-IGListKit-tvOSTests" */;
+			buildPhases = (
+				9428E6CC2E574156AF0F5AF99FE9EFC8 /* Headers */,
+				3FDC666BADD53211086FF071A1E009F9 /* Sources */,
+				5A5036C16810B69EC205530CC78F0DF7 /* Frameworks */,
+				8FBDE095592C775439E05FD22FCA5CBB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				08375015CC49C3737B73DF8E0EEB89FA /* PBXTargetDependency */,
+			);
+			name = "Pods-IGListKit-tvOSTests";
+			productName = "Pods-IGListKit-tvOSTests";
+			productReference = 5060A6C42F27F050A0309370E596CD8F /* Pods_IGListKit_tvOSTests.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		C8E76D7400B2260D37AD0BD81395C059 /* OCMock-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5AC1BC8E546A2BA6272FBE0CB5897A4 /* Build configuration list for PBXNativeTarget "OCMock-iOS" */;
+			buildPhases = (
+				F6942EA067A48456410CBD2A84889F11 /* Headers */,
+				D396E3F512B1E4F9199040B76A6343DB /* Sources */,
+				6E801221F208C6D594642D02CD615306 /* Frameworks */,
+				A712DD6E7E18D890BF6C51302D75CF23 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "OCMock-iOS";
+			productName = "OCMock-iOS";
+			productReference = 0CE2889F4BD718AD7B056C7E169B1299 /* OCMock.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -701,52 +701,53 @@
 		BFDFE7DC352907FC980B868725387E98 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = CF1408CF629C7361332E53B88F7BD30C;
 			productRefGroup = C15735FF7249AD1CA3258D7AE7573AA4 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				8AF9F398A1E64F014A9121074F6701F6 /* OCMock-iOS */,
-				A42C6C749C629BBA32B9193724D6EB53 /* OCMock-tvOS */,
-				1CF7F3C0B7CA0535499B28DA489E93F0 /* Pods-IGListKit-tvOSTests */,
-				FF557FF8A8298F109DCC8858334E3FDE /* Pods-IGListKitTests */,
+				C8E76D7400B2260D37AD0BD81395C059 /* OCMock-iOS */,
+				609DCF78F50CE8CD06E2848D8C22E2E9 /* OCMock-tvOS */,
+				B83E6CD1470726A18F5E4339943E5E4B /* Pods-IGListKit-tvOSTests */,
+				6474A33341F6F1D6E701FE1368CA7212 /* Pods-IGListKitTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		03C20936EF7831264AD85D7BF7A4CCA3 /* Resources */ = {
+		42E48E40433993934EDF2A3A7EE4B6D8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3BEA394E26D87B3B74974E8AB70435D5 /* Resources */ = {
+		6708CF8E923D3FF15831108C7085DF0B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ACB579EA47A47F17D4241825AB01F389 /* Resources */ = {
+		8FBDE095592C775439E05FD22FCA5CBB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D929C5C726B4A7EC76486236467F9031 /* Resources */ = {
+		A712DD6E7E18D890BF6C51302D75CF23 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -756,125 +757,190 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		1AE0E943DACB27CE2CD7EA7879811EDC /* Sources */ = {
+		32130E0B8892C99A356C3AE7BA0497A5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				81079A5C8291874346E76B1CFB189CD3 /* NSInvocation+OCMAdditions.m in Sources */,
-				1BC1B7D8B6A1854E19AA23BEDFF85EBA /* NSMethodSignature+OCMAdditions.m in Sources */,
-				FAB4EC3C97A9ADD4D03530203CBB4125 /* NSNotificationCenter+OCMAdditions.m in Sources */,
-				A3BECEB495C0E826EEBA00DE524609D2 /* NSObject+OCMAdditions.m in Sources */,
-				17419699A723CF5D97D1052C1D11323E /* NSValue+OCMAdditions.m in Sources */,
-				A283ED12C6452C75568DBBE7A790D65E /* OCClassMockObject.m in Sources */,
-				904C681AEE7BA35C1FF647AE216B914E /* OCMArg.m in Sources */,
-				90DE961A8C0AFD01081EED13CF6DE17C /* OCMArgAction.m in Sources */,
-				BB029C460CE59C70FC59AE9117E3CB79 /* OCMBlockArgCaller.m in Sources */,
-				575413E821EAB1D2BD78B57221697432 /* OCMBlockCaller.m in Sources */,
-				CFC5B12A2934B761F7977E5203C9904D /* OCMBoxedReturnValueProvider.m in Sources */,
-				E3C19CAE478775B39BE726FC947CF014 /* OCMConstraint.m in Sources */,
-				48B365AF62153BF8F2A047B4C22D8382 /* OCMExceptionReturnValueProvider.m in Sources */,
-				A5BB4B5C9C0DFE3E99BCD8971CA32726 /* OCMExpectationRecorder.m in Sources */,
-				385BC4D793CC49D82093BF98ECE98BDD /* OCMFunctions.m in Sources */,
-				D680B7DC47BB91E9D949880E73F0B9F0 /* OCMIndirectReturnValueProvider.m in Sources */,
-				7D73E25D7F6C55197D8094DE19B4ED1B /* OCMInvocationExpectation.m in Sources */,
-				ED5C996150AC4DB97026F63933C1DEC4 /* OCMInvocationMatcher.m in Sources */,
-				83F7E4121F77D3C734678DC6F79288D8 /* OCMInvocationStub.m in Sources */,
-				512D7C8EB84E90D5AE3CBD5C8B90FD47 /* OCMLocation.m in Sources */,
-				38CD2F7182ABA7F028A74FBA7D25E417 /* OCMMacroState.m in Sources */,
-				C236DDAAD94017320F21583CA6D49752 /* OCMNotificationPoster.m in Sources */,
-				5E02C0BD7B95F5E45566156C45EFBEF4 /* OCMObserverRecorder.m in Sources */,
-				FAF9E80781EDB35C79975B6DF0E8937D /* OCMock-iOS-dummy.m in Sources */,
-				159839BDFAA2912B7CD56A77F48C4AEB /* OCMockObject.m in Sources */,
-				803B122E44571882A0B145DE7F5A097A /* OCMPassByRefSetter.m in Sources */,
-				8E54D4A18AAB354D863029C01AC81BA4 /* OCMRealObjectForwarder.m in Sources */,
-				D290EDEACD3945F296FAE23B16AA13C8 /* OCMRecorder.m in Sources */,
-				0AB031FE553C5B2CC98325C5EB4E528D /* OCMReturnValueProvider.m in Sources */,
-				7F4331771D9BEFCD814D420FAAA1367E /* OCMStubRecorder.m in Sources */,
-				42576B70FBEAA97460A3BFD32C725CD9 /* OCMVerifier.m in Sources */,
-				EF3187BF74DA27638A61E7DAE0EA4EF7 /* OCObserverMockObject.m in Sources */,
-				18C5EAF0850FA948D426EFA8CB46792C /* OCPartialMockObject.m in Sources */,
-				33FB6CCBAD5D7F3A0F27350C290E1C42 /* OCProtocolMockObject.m in Sources */,
+				51DE08BE1E52CCBCA5FC489698226780 /* Pods-IGListKitTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		31BC952D1759C4E11B46CEF5A8046AB8 /* Sources */ = {
+		3FDC666BADD53211086FF071A1E009F9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E2FA6EB7D15D3DEE72762BD5FAD14FBB /* Pods-IGListKitTests-dummy.m in Sources */,
+				702D7E112218C066F92BAD6D78828EA0 /* Pods-IGListKit-tvOSTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		74620F43BCA5CE0F0404D2C8AC3F0909 /* Sources */ = {
+		5F6514BCFF375AA3830BB391F865EBF1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				51FF66AB9C084B70C05F1B6072FE9B70 /* Pods-IGListKit-tvOSTests-dummy.m in Sources */,
+				DD362AE58AFA00B78D78D843FC845B6D /* NSInvocation+OCMAdditions.m in Sources */,
+				B5D97911E7A6A847E3C368025C7DBAEA /* NSMethodSignature+OCMAdditions.m in Sources */,
+				E1B32C66A583D14438C748FD9CD5872E /* NSNotificationCenter+OCMAdditions.m in Sources */,
+				83E919706D79D752C3182841C7BA56A0 /* NSObject+OCMAdditions.m in Sources */,
+				82CDA00190623EA990B6AC646701A292 /* NSValue+OCMAdditions.m in Sources */,
+				DE4D0C13161E1CE029E42BC70D232DD0 /* OCClassMockObject.m in Sources */,
+				6279FB7DAB88CBB1747FC88CB19F8B2E /* OCMArg.m in Sources */,
+				25503CF701A648446A450563E52CA04A /* OCMArgAction.m in Sources */,
+				F95697591B8427E88256F5BC438E3D75 /* OCMBlockArgCaller.m in Sources */,
+				21656EE637E4EF36276FB20B4BC21D93 /* OCMBlockCaller.m in Sources */,
+				0C92020AD0941B5FC829A388EDABCBF3 /* OCMBoxedReturnValueProvider.m in Sources */,
+				DD8036A32A801396DE6B6EAED501B955 /* OCMConstraint.m in Sources */,
+				16AD4ED9330C5B78D56CBE0C63142D82 /* OCMExceptionReturnValueProvider.m in Sources */,
+				7809A855D585E232A3BDB30C3B6A9D41 /* OCMExpectationRecorder.m in Sources */,
+				7744593FB0FDC7575FC0BE7F2A951A38 /* OCMFunctions.m in Sources */,
+				4FC178D108422A5E23CF4A8396A38DB3 /* OCMIndirectReturnValueProvider.m in Sources */,
+				2BF0013709E3B8280BD7B3C0B150B5AF /* OCMInvocationExpectation.m in Sources */,
+				10A3F1210BB88C2C76F020EAECC5EFDB /* OCMInvocationMatcher.m in Sources */,
+				54EA3A596AA02034AAE4AA9BD71CC4FD /* OCMInvocationStub.m in Sources */,
+				FE2212BE27C3233ACFC53B9C7C1E8BE2 /* OCMLocation.m in Sources */,
+				27170FD942260EF61AF3C96E43B9EBF2 /* OCMMacroState.m in Sources */,
+				79A007F049E58DAA6FADA8D0D8F938D0 /* OCMNotificationPoster.m in Sources */,
+				53E6FFE0655641B38B53A4DB2D7C3358 /* OCMObserverRecorder.m in Sources */,
+				38500FE324F12EB2BA8E392084AC66B1 /* OCMock-tvOS-dummy.m in Sources */,
+				22F3FDE93EC7750230E306DC4479E39F /* OCMockObject.m in Sources */,
+				0C60616AC9965AB0837AE20C8545928E /* OCMPassByRefSetter.m in Sources */,
+				3AE1CC61908EDA47F420CF984327F7D5 /* OCMRealObjectForwarder.m in Sources */,
+				20C7275D7DBCE3818584A6BDA53C6BDF /* OCMRecorder.m in Sources */,
+				75147405E63FA23DCECD95C71A2686BA /* OCMReturnValueProvider.m in Sources */,
+				C96F240851643FDEB4980F69416F204B /* OCMStubRecorder.m in Sources */,
+				011E1FEF46CFD1FBB7ED39F95F949792 /* OCMVerifier.m in Sources */,
+				16B0B5D85E8BDB73BB5FD2B214816842 /* OCObserverMockObject.m in Sources */,
+				3D82EA404C90ACD1AFA8F540C7BE595B /* OCPartialMockObject.m in Sources */,
+				158DEB397AE6FB4D95999EAEF1E6B384 /* OCProtocolMockObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8B23E9667B874C8D5409568243B06845 /* Sources */ = {
+		D396E3F512B1E4F9199040B76A6343DB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				465735C6EB2C53C3EEBE39D13435AFD2 /* NSInvocation+OCMAdditions.m in Sources */,
-				1004E3B3F02C5C61B6387CDDC3A5914E /* NSMethodSignature+OCMAdditions.m in Sources */,
-				5C060014E8967CB5774C11DD7A7575DB /* NSNotificationCenter+OCMAdditions.m in Sources */,
-				B01DF0D6ECC3E76CE6D865C2915B5497 /* NSObject+OCMAdditions.m in Sources */,
-				A857BAC4FCC02FD98B321EDFB9AF5DA4 /* NSValue+OCMAdditions.m in Sources */,
-				6D1282CB515AA7B7D4F3E257A86FF53F /* OCClassMockObject.m in Sources */,
-				49A9189549DABEC1539FDFC2ACBD0236 /* OCMArg.m in Sources */,
-				61DCF0BEBB94C587C53F043F5158A4FE /* OCMArgAction.m in Sources */,
-				7AE9FA7B6131CE0BBF38EE4660C750A6 /* OCMBlockArgCaller.m in Sources */,
-				C5507757F64CA25E1F59F2DF63AD0156 /* OCMBlockCaller.m in Sources */,
-				59E6CCDF2266C3347E6BB312DA81AFC4 /* OCMBoxedReturnValueProvider.m in Sources */,
-				E2EC638175CADA2A7029D0A527B852D7 /* OCMConstraint.m in Sources */,
-				EFFCA395C12358AD16857F4428729F36 /* OCMExceptionReturnValueProvider.m in Sources */,
-				F11B9FBCC7C98D1C9F663AB0424C02F6 /* OCMExpectationRecorder.m in Sources */,
-				68BA600304FC1110BE5F8241ABDAB359 /* OCMFunctions.m in Sources */,
-				DBC46244FC6BDBF148C7E38A18166FDE /* OCMIndirectReturnValueProvider.m in Sources */,
-				2AB1FD059470F8710859719ED87A9CFC /* OCMInvocationExpectation.m in Sources */,
-				9383BAC9557A23DE7BD277448C4E74DA /* OCMInvocationMatcher.m in Sources */,
-				5E794654D15A639163687033D9DB9729 /* OCMInvocationStub.m in Sources */,
-				375A076C70570618C9C84A938298B2E0 /* OCMLocation.m in Sources */,
-				97F7977800B760E1BA0EA846BEAF9C2D /* OCMMacroState.m in Sources */,
-				826F3DAB0AE0B4678B43687AA1EF61BD /* OCMNotificationPoster.m in Sources */,
-				F3A6C53884F5E9EF171EED7CC640DB33 /* OCMObserverRecorder.m in Sources */,
-				7A37304E5D49627C0D820CDD44617340 /* OCMock-tvOS-dummy.m in Sources */,
-				EFCE09FFE2840AFA78CDF92692E550BD /* OCMockObject.m in Sources */,
-				AFFBC748AD14900F02E732C0AA47C934 /* OCMPassByRefSetter.m in Sources */,
-				922EE89307E6ACD73C67D4EF3453CBF7 /* OCMRealObjectForwarder.m in Sources */,
-				8278D2AE5E38BCB480B449BE1BA54C1A /* OCMRecorder.m in Sources */,
-				06D1B6BCA6DCDDB92EC883BDB921DA90 /* OCMReturnValueProvider.m in Sources */,
-				13B86E8BDA386EFFCAA680225737A7E4 /* OCMStubRecorder.m in Sources */,
-				FCBA873E50D4A20D213C65A2074E185E /* OCMVerifier.m in Sources */,
-				D8E153A064602885EF90DA0CBE89593D /* OCObserverMockObject.m in Sources */,
-				94D41233CC2F8D4F458AFE1F3B4E8286 /* OCPartialMockObject.m in Sources */,
-				DCB570B14D72C18850DE30448EDFE728 /* OCProtocolMockObject.m in Sources */,
+				BE5760C3BFABE64FC5ED1106FBE7D932 /* NSInvocation+OCMAdditions.m in Sources */,
+				F8DAF40AF22145557BF950A55D304B06 /* NSMethodSignature+OCMAdditions.m in Sources */,
+				9DB76828E66BBAA9820AEFF98AC701F1 /* NSNotificationCenter+OCMAdditions.m in Sources */,
+				C65F0B6AC5349E81D38CBF17B3A77A40 /* NSObject+OCMAdditions.m in Sources */,
+				73CF7C447211C639B8946CB2CA8C2685 /* NSValue+OCMAdditions.m in Sources */,
+				51565BB64B62E9DBED49F189848ED56A /* OCClassMockObject.m in Sources */,
+				6A4A5A4533DCAC91F29951A2BE98C8AC /* OCMArg.m in Sources */,
+				B43A9CFCAEB91C589819DEC2C7CE5ABC /* OCMArgAction.m in Sources */,
+				2014FE8419E4A9A423E1130A751842A6 /* OCMBlockArgCaller.m in Sources */,
+				08610877891351AA7E13C8059414347A /* OCMBlockCaller.m in Sources */,
+				04795A06B7B6AC807E35C0DF84BB5E05 /* OCMBoxedReturnValueProvider.m in Sources */,
+				E5600614439859750460A368508BCEA9 /* OCMConstraint.m in Sources */,
+				2592D9FEF780A24BA7420C047718F901 /* OCMExceptionReturnValueProvider.m in Sources */,
+				DF491C27923F8DA644D84D3CBE2D859F /* OCMExpectationRecorder.m in Sources */,
+				3723AEFEBE676CB437859F0CEE2B3214 /* OCMFunctions.m in Sources */,
+				4D335C62BCE3AFB527CD1C15B981408E /* OCMIndirectReturnValueProvider.m in Sources */,
+				7CD453892F1A8E1A148F3333428C0CCC /* OCMInvocationExpectation.m in Sources */,
+				FA0E4CCEFE5577E696583703743BC35B /* OCMInvocationMatcher.m in Sources */,
+				2267EF850DD70C63BC07E359A5D20F46 /* OCMInvocationStub.m in Sources */,
+				6577B5DDD007589D5D0C4297DF048E84 /* OCMLocation.m in Sources */,
+				92C936309A821CC82477660D7BA15A74 /* OCMMacroState.m in Sources */,
+				480A0203B7F7E0182FF488E570A10A28 /* OCMNotificationPoster.m in Sources */,
+				3BBC04E76FDCB7AF4851E8631EA6375D /* OCMObserverRecorder.m in Sources */,
+				C9FA2F5CBD8A70A6819ED52BDC6EB772 /* OCMock-iOS-dummy.m in Sources */,
+				26C7242056536D51587358A8555A94A5 /* OCMockObject.m in Sources */,
+				E0AB257B00B552E451B45107C23F0A7E /* OCMPassByRefSetter.m in Sources */,
+				7F0C11F5437A1F4BBAF3719C1C155959 /* OCMRealObjectForwarder.m in Sources */,
+				3456F0B5CA23E835B07EDE26CBDC5FF7 /* OCMRecorder.m in Sources */,
+				0043955603862B863DA4B0C76F6E6CB7 /* OCMReturnValueProvider.m in Sources */,
+				46161F17A2F404BDF1F97AFCD34980AA /* OCMStubRecorder.m in Sources */,
+				C9642EF15274D3BF9554919EFE710B0A /* OCMVerifier.m in Sources */,
+				51FEDBD2188411A5797540FA0D443B0D /* OCObserverMockObject.m in Sources */,
+				322EAB6E6D2CAD04C46C1EFF6A263839 /* OCPartialMockObject.m in Sources */,
+				B30C1061D09D7FFA7060585EF1A7CEBC /* OCProtocolMockObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		157859B3BD4AA1549F104F33E64EA004 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "OCMock-iOS";
-			target = 8AF9F398A1E64F014A9121074F6701F6 /* OCMock-iOS */;
-			targetProxy = B9FD7F3A2837B7098668B840B8B974EB /* PBXContainerItemProxy */;
-		};
-		895076ADA710B04EBA5C979784D3B7C9 /* PBXTargetDependency */ = {
+		08375015CC49C3737B73DF8E0EEB89FA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "OCMock-tvOS";
-			target = A42C6C749C629BBA32B9193724D6EB53 /* OCMock-tvOS */;
-			targetProxy = 81A3BC0EBD9AAE8190DA0EB5A37AF646 /* PBXContainerItemProxy */;
+			target = 609DCF78F50CE8CD06E2848D8C22E2E9 /* OCMock-tvOS */;
+			targetProxy = 8DA3FF6FCD6285E0A5B16AF7A6142E54 /* PBXContainerItemProxy */;
+		};
+		0FFB99C3F2CC09C84B2551654BBAE8DF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "OCMock-iOS";
+			target = C8E76D7400B2260D37AD0BD81395C059 /* OCMock-iOS */;
+			targetProxy = 34D5AD073A2213F2B27F4381EA1CB9BA /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		05EF623FF9A66B3EFD8015F78F9523F2 /* Release */ = {
+		00949037D7964280924D2068B5A9F564 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1863A869DEAECDB87A31B34AE56C0CB4 /* Pods-IGListKitTests.release.xcconfig */;
+			baseConfigurationReference = D89831DAC45A95CCE6622687FC823552 /* OCMock-tvOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/OCMock-tvOS/OCMock-tvOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS.modulemap";
+				PRODUCT_MODULE_NAME = OCMock;
+				PRODUCT_NAME = OCMock;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		0C0D688050E00261E62D274C75A2D7C6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 30FA4E102F84348EF906F313B7CB3B9D /* Pods-IGListKit-tvOSTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3B68C44A70F97D2A83B7DD870307B834 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4D47523D6A2F1CAC7CD182E2285010A5 /* Pods-IGListKitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
@@ -900,13 +966,75 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4195993191CC9E056FF8FF76B6A60874 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E31C4A34C9678DF6167E55994724A52C /* OCMock-iOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/OCMock-iOS/OCMock-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS.modulemap";
+				PRODUCT_MODULE_NAME = OCMock;
+				PRODUCT_NAME = OCMock;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5A5CC8356F062DED58FD6792B66DFE37 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E31C4A34C9678DF6167E55994724A52C /* OCMock-iOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/OCMock-iOS/OCMock-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS.modulemap";
+				PRODUCT_MODULE_NAME = OCMock;
+				PRODUCT_NAME = OCMock;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
-		427E8DC4C1944DB483966E79991809B2 /* Debug */ = {
+		66A6CEE5F2EE4762075015A946845036 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -965,15 +1093,15 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
-		4A2E7CCD6BABBB2FD47CEC007CBCE878 /* Debug */ = {
+		711E81A233450925145198F41BF9DC8E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D47523D6A2F1CAC7CD182E2285010A5 /* Pods-IGListKitTests.debug.xcconfig */;
+			baseConfigurationReference = 1863A869DEAECDB87A31B34AE56C0CB4 /* Pods-IGListKitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				CODE_SIGN_IDENTITY = "";
@@ -999,12 +1127,78 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		866027EB337845841ECDFEB7915E81DC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D89831DAC45A95CCE6622687FC823552 /* OCMock-tvOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/OCMock-tvOS/OCMock-tvOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS.modulemap";
+				PRODUCT_MODULE_NAME = OCMock;
+				PRODUCT_NAME = OCMock;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
-		4EEE4F6333587E541D03D1F272094CF2 /* Release */ = {
+		8D236224FA77161AA741CF384D52111B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E1A60FB55DF0FC8A91D1E0AA68204EA9 /* Pods-IGListKit-tvOSTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests.modulemap";
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F406DA30E8420BA4061CB8BE19A8C0D1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1059,222 +1253,29 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				SYMROOT = "${SRCROOT}/../build";
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
-		504A8F36011542D06A98318FE8F92CE8 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E31C4A34C9678DF6167E55994724A52C /* OCMock-iOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/OCMock-iOS/OCMock-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS.modulemap";
-				PRODUCT_MODULE_NAME = OCMock;
-				PRODUCT_NAME = OCMock;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		83D647E3BE2F7D4955460A07D1B11ED3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 30FA4E102F84348EF906F313B7CB3B9D /* Pods-IGListKit-tvOSTests.debug.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		A01FA0479E6EF772E26B46BFD25592E6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D89831DAC45A95CCE6622687FC823552 /* OCMock-tvOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/OCMock-tvOS/OCMock-tvOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS.modulemap";
-				PRODUCT_MODULE_NAME = OCMock;
-				PRODUCT_NAME = OCMock;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		C9F066C48793CB85091B484739478861 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D89831DAC45A95CCE6622687FC823552 /* OCMock-tvOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/OCMock-tvOS/OCMock-tvOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/OCMock-tvOS/OCMock-tvOS.modulemap";
-				PRODUCT_MODULE_NAME = OCMock;
-				PRODUCT_NAME = OCMock;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		CBAB1EF0280145FD16B6140D5C4407F6 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E1A60FB55DF0FC8A91D1E0AA68204EA9 /* Pods-IGListKit-tvOSTests.release.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACH_O_TYPE = staticlib;
-				MODULEMAP_FILE = "Target Support Files/Pods-IGListKit-tvOSTests/Pods-IGListKit-tvOSTests.modulemap";
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		F4821581FD1C13A11D4930914C664D76 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E31C4A34C9678DF6167E55994724A52C /* OCMock-iOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/OCMock-iOS/OCMock-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/OCMock-iOS/OCMock-iOS.modulemap";
-				PRODUCT_MODULE_NAME = OCMock;
-				PRODUCT_NAME = OCMock;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		0BAAD1FD68C99C425EE646CB598CBFC8 /* Build configuration list for PBXNativeTarget "Pods-IGListKit-tvOSTests" */ = {
+		07660FB725460404A034B004BBD91695 /* Build configuration list for PBXNativeTarget "Pods-IGListKit-tvOSTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				83D647E3BE2F7D4955460A07D1B11ED3 /* Debug */,
-				CBAB1EF0280145FD16B6140D5C4407F6 /* Release */,
+				0C0D688050E00261E62D274C75A2D7C6 /* Debug */,
+				8D236224FA77161AA741CF384D52111B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		39293889DB6E6523ED08009ED4241D82 /* Build configuration list for PBXNativeTarget "OCMock-iOS" */ = {
+		194475CCD3CFDA1D80A0D09994B332FF /* Build configuration list for PBXNativeTarget "OCMock-tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F4821581FD1C13A11D4930914C664D76 /* Debug */,
-				504A8F36011542D06A98318FE8F92CE8 /* Release */,
+				866027EB337845841ECDFEB7915E81DC /* Debug */,
+				00949037D7964280924D2068B5A9F564 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -1282,26 +1283,26 @@
 		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				427E8DC4C1944DB483966E79991809B2 /* Debug */,
-				4EEE4F6333587E541D03D1F272094CF2 /* Release */,
+				66A6CEE5F2EE4762075015A946845036 /* Debug */,
+				F406DA30E8420BA4061CB8BE19A8C0D1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8C37347D43619B47816CFD7E5792720A /* Build configuration list for PBXNativeTarget "Pods-IGListKitTests" */ = {
+		ABC441EA4C1B5DEC2D67F90987AC3A45 /* Build configuration list for PBXNativeTarget "Pods-IGListKitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4A2E7CCD6BABBB2FD47CEC007CBCE878 /* Debug */,
-				05EF623FF9A66B3EFD8015F78F9523F2 /* Release */,
+				3B68C44A70F97D2A83B7DD870307B834 /* Debug */,
+				711E81A233450925145198F41BF9DC8E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BD8D15BCC9F08A6D8A27DF1C728D4336 /* Build configuration list for PBXNativeTarget "OCMock-tvOS" */ = {
+		E5AC1BC8E546A2BA6272FBE0CB5897A4 /* Build configuration list for PBXNativeTarget "OCMock-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A01FA0479E6EF772E26B46BFD25592E6 /* Debug */,
-				C9F066C48793CB85091B484739478861 /* Release */,
+				4195993191CC9E056FF8FF76B6A60874 /* Debug */,
+				5A5CC8356F062DED58FD6792B66DFE37 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Summary:
Our [builds](https://travis-ci.org/Instagram/IGListKit) have been failing since `IGListStackedSectionController` was removed in [D17200801](D17200801)/[1355](https://github.com/Instagram/IGListKit/pull/1355). The error message in our Travis logs points to something related to `IGListStackedSectionController` causing the error:

```
X  error: /Users/travis/build/Instagram/IGListKit/Source/Internal/IGListStackedSectionControllerInternal.h: No such file or directory

** BUILD FAILED **

The following build commands failed:
	CpHeader /Users/travis/build/Instagram/IGListKit/Source/Internal/IGListStackedSectionControllerInternal.h /Users/travis/Library/Developer/Xcode/DerivedData/IGListKitExamples-cfbxdbnpimeeplcoaiqrlyrrqjxn/Build/Products/Debug-iphonesimulator/IGListKit/IGListKit.framework/PrivateHeaders/IGListStackedSectionControllerInternal.h
(1 failure)
```

Pretty sure the issue here is that the `xcodeproj` files were not rebuilt after deleting these files, which meant they were pointing to files that no longer existed, which caused the build to fail. I was able to fix this issue by running our `setup.sh` script, which regenerated the `xcodeproj` files.

Reviewed By: bdotdub

Differential Revision: D18064465

