### PR TITLE
Support Project Catalyst

### DIFF
--- a/Source/IGListKit/Internal/IGListAdapter+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListAdapter+DebugDescription.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <IGListKit/IGListKit.h>
 #import <IGListKit/IGListAdapter.h>
 
 @interface IGListAdapter (DebugDescription)

--- a/Source/IGListKit/Internal/IGListAdapter+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListAdapter+DebugDescription.h
@@ -6,6 +6,7 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListAdapter.h>
 
 @interface IGListAdapter (DebugDescription)
 

--- a/Source/IGListKit/Internal/IGListAdapter+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListAdapter+DebugDescription.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <IGListKit/IGListKit.h>
 #import <IGListKit/IGListAdapter.h>
 
 @interface IGListAdapter (DebugDescription)

--- a/Source/IGListKit/Internal/IGListAdapterUpdater+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListAdapterUpdater+DebugDescription.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <IGListKit/IGListKit.h>
 #import <IGListKit/IGListAdapterUpdater.h>
 
 @interface IGListAdapterUpdater (DebugDescription)

--- a/Source/IGListKit/Internal/IGListAdapterUpdater+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListAdapterUpdater+DebugDescription.h
@@ -6,6 +6,7 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListAdapterUpdater.h>
 
 @interface IGListAdapterUpdater (DebugDescription)
 

--- a/Source/IGListKit/Internal/IGListAdapterUpdater+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListAdapterUpdater+DebugDescription.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <IGListKit/IGListKit.h>
 #import <IGListKit/IGListAdapterUpdater.h>
 
 @interface IGListAdapterUpdater (DebugDescription)

--- a/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <IGListKit/IGListKit.h>
+#import <UIKit/UIKit.h>
+
 #import <IGListDiffKit/IGListBatchUpdateData.h>
 
 @interface IGListBatchUpdateData (DebugDescription)

--- a/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <IGListKit/IGListBatchUpdateData.h>
 
 @interface IGListBatchUpdateData (DebugDescription)
 

--- a/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <IGListKit/IGListKit.h>
 #import <IGListDiffKit/IGListBatchUpdateData.h>
 
 @interface IGListBatchUpdateData (DebugDescription)

--- a/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <IGListKit/IGListKit.h>
 
 @interface IGListBatchUpdateData (DebugDescription)
 

--- a/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBatchUpdateData+DebugDescription.h
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <IGListKit/IGListBatchUpdateData.h>
+#import <IGListDiffKit/IGListBatchUpdateData.h>
 
 @interface IGListBatchUpdateData (DebugDescription)
 

--- a/Source/IGListKit/Internal/IGListBindingSectionController+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBindingSectionController+DebugDescription.h
@@ -6,6 +6,7 @@
  */
 
 #import <IGListKit/IGListKit.h>
+#import <IGListKit/IGListBindingSectionController.h>
 
 @interface IGListBindingSectionController (DebugDescription)
 

--- a/Source/IGListKit/Internal/IGListBindingSectionController+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBindingSectionController+DebugDescription.h
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <IGListKit/IGListKit.h>
 #import <IGListKit/IGListBindingSectionController.h>
 
 @interface IGListBindingSectionController (DebugDescription)

--- a/Source/IGListKit/Internal/IGListBindingSectionController+DebugDescription.h
+++ b/Source/IGListKit/Internal/IGListBindingSectionController+DebugDescription.h
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <IGListKit/IGListKit.h>
 #import <IGListKit/IGListBindingSectionController.h>
 
 @interface IGListBindingSectionController (DebugDescription)


### PR DESCRIPTION
## Changes in this pull request

Add support when compile Catalyst.
Fix this error: `Cannot define category for undefined class 'IGListAdapter'`
![Screenshot 2019-11-22 at 22 35 31](https://user-images.githubusercontent.com/14871122/69440931-49979c80-0d7c-11ea-8673-f9b8a60441f0.jpg)

## Step To Reproduce
In the Main target, check the Mac under Deployment Info, more Info in [here](https://developer.apple.com/documentation/uikit/mac_catalyst?language=objc)

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
