### PR TITLE
Simplify the code and use `_itemCountIsZero`

### DIFF
--- a/Source/IGListKit/IGListAdapter.m
+++ b/Source/IGListKit/IGListAdapter.m
@@ -660,12 +660,7 @@
         [[map sectionControllerForObject:object] didUpdateToObject:object];
     }
 
-    NSInteger itemCount = 0;
-    for (IGListSectionController *sectionController in sectionControllers) {
-        itemCount += [sectionController numberOfItems];
-    }
-
-    [self _updateBackgroundViewShouldHide:itemCount > 0];
+    [self _updateBackgroundViewShouldHide:![self _itemCountIsZero]];
 }
 
 - (void)_updateBackgroundViewShouldHide:(BOOL)shouldHide {


### PR DESCRIPTION
…uld show empty view

## Changes in this pull request

Basically we can use the existing _itemCountIsZero like all the other usage, and it's faster since it stopped early, compared to before we loop through all the sectionController.numberOfItems and sum up.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
