### PR TITLE
Remove assert from working range handler

### DIFF
--- a/Source/IGListKit/Internal/IGListWorkingRangeHandler.mm
+++ b/Source/IGListKit/Internal/IGListWorkingRangeHandler.mm
@@ -124,8 +124,6 @@ typedef std::unordered_set<_IGListWorkingRangeHandlerIndexPath, _IGListWorkingRa
         workingRangeSectionControllers.insert({sectionController});
     }
 
-    IGAssert(workingRangeSectionControllers.size() < 1000, @"This algorithm is way too slow with so many objects:%lu", workingRangeSectionControllers.size());
-
     // Tell any new section controllers that they have entered the working range
     for (const _IGListWorkingRangeHandlerSectionControllerWrapper &wrapper : workingRangeSectionControllers) {
         // Check if the item exists in the old working range item array.


### PR DESCRIPTION
Summary: This assert causes crashes on debug builds. While it's known that this algorithm is slow with a large number of items to work through, it doesn't seem to have been an issue for most when working with IGListKit. Removing this assertion to avoid crashes for others.

Reviewed By: bdotdub

Differential Revision: D19251924

