### PR TITLE
Fix the podlint error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,11 @@ jobs:
       name: Cocoapods Lint
       # We need to pass all of the podspecs here so that Cocoapods uses the local version,
       # rather than searching the specs repository for the other specs in the repo.
-      script: bundle exec pod lib lint --allow-warnings "--include-podspecs=*.podspec"
-
+      script: 
+        - bundle exec pod lib lint IGListDiffKit.podspec --allow-warnings
+        - bundle exec pod lib lint IGListKit.podspec --allow-warnings "--include-podspecs=IGListDiffKit.podspec"
+        - bundle exec pod lib lint IGListSwiftKit.podspec --allow-warnings "--include-podspecs=*.podspec"
+        
     # Build example projects
     - &build-examples
       stage: build examples


### PR DESCRIPTION
Summary:
We kept getting an error as the following:

```
    - ERROR | [OSX] unknown: Encountered an unknown error (The platform of the target `App` (macOS 10.11) is not compatible with `IGListSwiftKit (4.1.0)`, which does not support `macOS`.) during validation.
```

Looks like IGListSwiftKit did not support macos, wondering why this is the case here.

Potentially this error was introduced in this PR: https://github.com/Instagram/IGListKit/pull/1388
cc natestedman who might know the context here

Differential Revision: D20036436

