### PR TITLE
Scrol to object with offset deducted

### DIFF
--- a/Source/IGListAdapter.h
+++ b/Source/IGListAdapter.h
@@ -257,6 +257,13 @@ NS_SWIFT_NAME(ListAdapter)
         scrollPosition:(UICollectionViewScrollPosition)scrollPosition
               animated:(BOOL)animated;
 
+- (void)scrollToObject:(id)object
+    supplementaryKinds:(nullable NSArray<NSString *> *)supplementaryKinds
+       scrollDirection:(UICollectionViewScrollDirection)scrollDirection
+        scrollPosition:(UICollectionViewScrollPosition)scrollPosition
+              animated:(BOOL)animated
+                deductOffset:(int)suplementaryHeight;
+
 /**
  Returns the size of a cell at the specified index path.
 


### PR DESCRIPTION
Added a new method for scrolling to deduct offset from collection with supplementary views

## Changes in this pull request

Issue fixed: #

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
