### PR TITLE
fix cell height in macOS sample projects

### DIFF
--- a/Examples/Examples-macOS/IGListKitExamples/View/UserCollectionViewCell.xib
+++ b/Examples/Examples-macOS/IGListKitExamples/View/UserCollectionViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -22,8 +22,8 @@
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="zDT-HW-k24" userLabel="Content View">
                     <rect key="frame" x="5" y="5" width="470" height="37"/>
                     <subviews>
-                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ypj-SS-m9s">
-                            <rect key="frame" x="8" y="10" width="454" height="17"/>
+                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ypj-SS-m9s">
+                            <rect key="frame" x="8" y="11" width="454" height="16"/>
                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="User Name" id="EMD-h2-FhR">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -42,12 +42,13 @@
                         </button>
                     </subviews>
                     <constraints>
+                        <constraint firstAttribute="bottom" secondItem="OMr-G1-CjN" secondAttribute="bottom" constant="8" id="C6E-Cb-HKe"/>
                         <constraint firstItem="Ypj-SS-m9s" firstAttribute="leading" secondItem="zDT-HW-k24" secondAttribute="leading" constant="10" id="Ihp-O8-Efo"/>
                         <constraint firstAttribute="trailing" secondItem="OMr-G1-CjN" secondAttribute="trailing" constant="15" id="KAP-rQ-1IY"/>
                         <constraint firstItem="OMr-G1-CjN" firstAttribute="centerY" secondItem="zDT-HW-k24" secondAttribute="centerY" id="OpF-yx-eVP"/>
-                        <constraint firstItem="Ypj-SS-m9s" firstAttribute="top" secondItem="zDT-HW-k24" secondAttribute="top" constant="10" id="fgx-2W-GAC"/>
-                        <constraint firstAttribute="bottom" secondItem="Ypj-SS-m9s" secondAttribute="bottom" constant="10" id="l0W-g6-GHk"/>
+                        <constraint firstItem="Ypj-SS-m9s" firstAttribute="firstBaseline" secondItem="OMr-G1-CjN" secondAttribute="firstBaseline" id="Zrc-aD-qpC"/>
                         <constraint firstAttribute="trailing" secondItem="Ypj-SS-m9s" secondAttribute="trailing" constant="10" id="ngw-Cc-XUB"/>
+                        <constraint firstItem="OMr-G1-CjN" firstAttribute="top" secondItem="zDT-HW-k24" secondAttribute="top" constant="8" id="yb5-x6-RM9"/>
                     </constraints>
                 </customView>
             </subviews>
@@ -57,8 +58,9 @@
                 <constraint firstAttribute="bottom" secondItem="zDT-HW-k24" secondAttribute="bottom" constant="5" id="rt6-4r-5RK"/>
                 <constraint firstAttribute="trailing" secondItem="zDT-HW-k24" secondAttribute="trailing" constant="5" id="tQO-4a-4WN"/>
             </constraints>
+            <point key="canvasLocation" x="140" y="154"/>
         </customView>
-        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="NO" id="MA2-Td-T4f">
+        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="MA2-Td-T4f">
             <rect key="frame" x="0.0" y="0.0" width="38" height="17"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Mhd-Im-KQa">

--- a/Examples/Examples-macOS/IGListKitExamples/ViewControllers/UsersViewController.swift
+++ b/Examples/Examples-macOS/IGListKitExamples/ViewControllers/UsersViewController.swift
@@ -155,6 +155,6 @@ extension UsersViewController: NSCollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: NSCollectionView, layout collectionViewLayout: NSCollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> NSSize {
 
         let availableWidth = collectionView.bounds.width
-        return CGSize(width: availableWidth, height: 44)
+        return CGSize(width: availableWidth, height: 47)
     }
 }


### PR DESCRIPTION
## Changes in this pull request

The macOS sample project used to cut off descenders of the letters "y" and "g". I adjusted the programmatic cell height to match the Nib, and recenter the components vertically.

| Before | After |
| ---- |  ---- |
| ![image](https://user-images.githubusercontent.com/59080/87017842-caeb5480-c1d0-11ea-8c58-5d396ddd6081.png) | ![Screen Shot 2020-07-09 at 10 35 15](https://user-images.githubusercontent.com/59080/87017936-ea827d00-c1d0-11ea-9705-ab26b7e63c64.png) |


### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
    - This doesn't sound newsworthy :)
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
