### PR TITLE
Update version.sh to work with macOS 10.15.

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -6,4 +6,4 @@
 
 cd "$(dirname "$(dirname "$0")")" || exit 1
 
-exec defaults read "$(pwd)/Source/Info" CFBundleShortVersionString
+/usr/libexec/PlistBuddy -c "print CFBundleShortVersionString" "$(pwd)/Source/Info.plist"


### PR DESCRIPTION
Reads the version with `PlistBuddy`. Taken from instagram/IGListKit#1423.

## Changes in this pull request

Issue fixed: #1420

There are no breaking changes, and the code just fixes an issue that came up because of the way 10.15 handles the default command.

This fix is crucial to get the demo project back on track. It doesn't compile in the current master branch!

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
