### PR TITLE
Add shouldSelectItemAtIndex to IGListSectionController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 ### Enhancements
 
+- Added `shouldSelectItemAtIndex:` to `IGListSectionController` . [dirtmelon](https://github.com/dirtmelon)
+
 - Introduce `IGListSwiftKit`, with Swift refinements for `dequeueReusableCellOfClass` methods. [Koen Punt](https://github.com/koenpunt) [(#1388)](https://github.com/Instagram/IGListKit/pull/1388).
 
 - Added `APPLICATION_EXTENSION_API_ONLY` support for `IGListDiffKit` [Peter Meyers](https://github.com/pm-dev) [(#1422)](https://github.com/Instagram/IGListKit/pull/1422)

--- a/Source/IGListKit/IGListSectionController.h
+++ b/Source/IGListKit/IGListSectionController.h
@@ -76,6 +76,15 @@ NS_SWIFT_NAME(ListSectionController)
 - (void)didUpdateToObject:(id)object;
 
 /**
+ Asks the section controller if the cell at the specified index path should be selected
+
+ @param index The index of cell to be selected.
+
+ @note The default implementation returns YES. **Calling super is not required.**
+ */
+- (BOOL)shouldSelectItemAtIndex:(NSInteger)index;
+
+/**
  Tells the section controller that the cell at the specified index path was selected.
 
  @param index The index of the selected cell.

--- a/Source/IGListKit/IGListSectionController.m
+++ b/Source/IGListKit/IGListSectionController.m
@@ -80,6 +80,10 @@ void IGListSectionControllerPopThread(void) {
 
 - (void)didUpdateToObject:(id)object {}
 
+- (BOOL)shouldSelectItemAtIndex:(NSInteger)index {
+    return YES;
+}
+
 - (void)didSelectItemAtIndex:(NSInteger)index {}
 
 - (void)didDeselectItemAtIndex:(NSInteger)index {}

--- a/Source/IGListKit/Internal/IGListAdapter+UICollectionView.m
+++ b/Source/IGListKit/Internal/IGListAdapter+UICollectionView.m
@@ -118,6 +118,11 @@
 
 #pragma mark - UICollectionViewDelegate
 
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    IGListSectionController * sectionController = [self sectionControllerForSection:indexPath.section];
+    return [sectionController shouldSelectItemAtIndex:indexPath.item];
+}
+
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
     // forward this method to the delegate b/c this implementation will steal the message from the proxy
     id<UICollectionViewDelegate> collectionViewDelegate = self.collectionViewDelegate;


### PR DESCRIPTION
## Changes in this pull request
Add `shouldSelectItemAtIndex:` to `IGListSectionController`.

Issue fixed: #1033 

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
