### PR TITLE
The README file in this repo has a bad link - [404:NotFound] - “MIT-licensed”

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ We have a set of [starter tasks](https://github.com/Instagram/IGListKit/issues?q
 
 ## License
 
-`IGListKit` is [MIT-licensed](./LICENSE).
+`IGListKit` is [MIT-licensed](./LICENSE.md).
 
 The files in the `/Examples/` directory are licensed under a separate license as specified in each file. Documentation is licensed [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
The markup version of the readme that is displayed for the main page in this repo contains the following bad link:

“MIT-licensed”
https://github.com/Instagram/IGListKit/blob/master/LICENSE

It should be: https://github.com/Instagram/IGListKit/blob/master/LICENSE.md

**Extra**


This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

Re-check this Repo via: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fInstagram%2fIGListKit

If this has been helpful, or if you have any feedback on the tool itself, then please feel free to share your thoughts by adding a comment here, or adding to a “Discussion” in the tool’s Repo.

## Changes in this pull request

Issue fixed: Did not log issue for trivial typo in readme.

### Checklist

- [N/A] All tests pass. Demo project builds and runs.
- [N/A] I added tests, an experiment, or detailed why my change isn't tested.
- [N/A] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [N/A] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
