### PR TITLE
Update IGListCollectionContext+Refinements.swift

### DIFF
--- a/Source/IGListSwiftKit/IGListCollectionContext+Refinements.swift
+++ b/Source/IGListSwiftKit/IGListCollectionContext+Refinements.swift
@@ -87,7 +87,7 @@ extension ListCollectionContext {
                 for: sectionController,
                 at: index
         ) as? T else {
-            fatalError("A nib named \"\(nibName)\" was not found in \(bundle)")
+            fatalError("A nib named \"\(nibName)\" was not found in \(String(describing:bundle))")
         }
 
         return cell


### PR DESCRIPTION
Silence warning:
```
Source/IGListSwiftKit/IGListCollectionContext+Refinements.swift:90:71: warning: string interpolation produces a debug description for an optional value; did you mean to make this explicit?
            fatalError("A nib named \"\(nibName)\" was not found in \(bundle)")
                                                                      ^~~~~~
Source/IGListSwiftKit/IGListCollectionContext+Refinements.swift:90:71: note: use 'String(describing:)' to silence this warning
            fatalError("A nib named \"\(nibName)\" was not found in \(bundle)")
                                                                      ^~~~~~
                                                                      String(describing:  )
Source/IGListSwiftKit/IGListCollectionContext+Refinements.swift:90:71: note: provide a default value to avoid this warning
            fatalError("A nib named \"\(nibName)\" was not found in \(bundle)")
                                                                      ^~~~~~
```

## Changes in this pull request

Issue fixed: #

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
