### PR TITLE
Fix 'The domain/default pair of (Info.plist,CFBundleShortVersionString) does not exist' issue

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -6,4 +6,4 @@
 
 cd "$(dirname "$(dirname "$0")")" || exit 1
 
-exec defaults read "$(pwd)/Source/Info" CFBundleShortVersionString
+exec /usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$(pwd)/Source/Info.plist"


### PR DESCRIPTION
Fix 'The domain/default pair of (Info.plist,CFBundleShortVersionString) does not exist' issue

## Changes in this pull request

Issue fixed: #

when run pod install under Examples/Examples-iOS, you may encounter the error: 

```
The domain/default pair of (path/to/IGListKit/Source/Info, CFBundleShortVersionString) does not exist.
[!] The `IGListDiffKit` pod failed to validate due to 1 error:
    - ERROR | version: A version is required
```
Changed the usage of `defaults read` in scripts/version.sh to `/usr/libexec/PlistBuddy` will fix the problem.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
