### PR TITLE
Adds support for Apple Silicon brew directory

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,6 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# Adds support for Apple Silicon brew directory
+if test -d "/opt/homebrew/bin/"; then
+  PATH="/opt/homebrew/bin/:${PATH}"
+  export PATH
+fi
+
 VERSION="0.24.2"
 FOUND=$(swiftlint version)
 


### PR DESCRIPTION
## Changes in this pull request

Issue fixed: #

When I've tried to run the `Examples/Examples-iOS` the compilation of the project failed on the `Swiftlint` phase. 
`../../scripts/lint.sh: line 8: swiftlint: command not found
    Error: SwiftLint not installed!
    Download from https://github.com/realm/SwiftLint,
    or brew install swiftlint.`


### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
