### PR TITLE
fix: sectionController never fresh like a deadlock

### DIFF
--- a/Source/IGListKit/IGListBindingSectionController.m
+++ b/Source/IGListKit/IGListBindingSectionController.m
@@ -46,6 +46,9 @@ typedef NS_ENUM(NSInteger, IGListDiffingSectionState) {
     __block NSArray<id<IGListDiffable>> *oldViewModels = nil;
 
     id<IGListCollectionContext> collectionContext = self.collectionContext;
+    if (self.collectionContext == nil) {
+        self.state = IGListDiffingSectionStateIdle;
+    }
     [self.collectionContext performBatchAnimated:animated updates:^(id<IGListBatchContext> batchContext) {
         if (self.state != IGListDiffingSectionStateUpdateQueued) {
             return;


### PR DESCRIPTION
when you create a subclass of IGListBindingSectionController,then fill with data and use 'update(animated: true, completion: nil)' when this secontroller 'listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController' never return .  then 'listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController' return this sectionController , and this sectionContrloller use 'update(animated: true' ,but it will never refresh because it's state is IGListDiffingSectionStateUpdateQueued and never update to IGListDiffingSectionStateIdle . so it's refresh method is blocked and never refresh like a deadlock

## Changes in this pull request

Issue fixed: #

### Checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/master/.github/CONTRIBUTING.md)
