### PR TITLE
Get index path or scroll position of first visible item in list

### DIFF
--- a/Source/IGListKit/IGListAdapter.h
+++ b/Source/IGListKit/IGListAdapter.h
@@ -256,7 +256,7 @@ NS_SWIFT_NAME(ListAdapter)
  @param scrollPosition An option that specifies where the item should be positioned when scrolling finishes.
  @param additionalOffset Additional offset amount from the scroll position.
  @param animated A flag indicating if the scrolling should be animated.
- 
+
  @note The additional offset amount is to shift the final scroll position by some horizontal or vertical amount
  depending on the scroll direction. This is necessary when scrolling to an object on a view with sticky headers, since
  the sticky header would otherwise cover the top portion of the object.
@@ -267,6 +267,27 @@ NS_SWIFT_NAME(ListAdapter)
         scrollPosition:(UICollectionViewScrollPosition)scrollPosition
       additionalOffset:(CGFloat)additionalOffset
               animated:(BOOL)animated;
+
+/**
+ Returns the index path for the first visible cell that has been scrolled to.
+ This refers to the cell currently at the top/left (0, 0) of the collection view's frame,
+ inset by the collection view's contentInset top or left value if defined.
+
+ @return The index path of the cell or nil if not found.
+ */
+- (nullable NSIndexPath *)indexPathForFirstVisibleItem;
+
+/**
+ Gets the scroll offset of the first visible cell scrolled into in the collection view.
+ This refers to the cell currently at the top/left (0, 0) of the collection view's frame,
+ inset by the collection view's contentInset top or left value if defined.
+
+ @param scrollDirection  An option indicating the direction to scroll.
+
+ @return additionalOffset is the offset amount the first visible cell is shifted from the start of the cell,
+ the amount it has been scrolled into in the coordinates of the cell's bounds.
+ */
+- (CGFloat)offsetForFirstVisibleItemWithScrollDirection:(UICollectionViewScrollDirection)scrollDirection;
 
 /**
  Returns the size of a cell at the specified index path.

--- a/Tests/IGListAdapterTests.m
+++ b/Tests/IGListAdapterTests.m
@@ -928,6 +928,241 @@
     XCTAssertTrue(lastSection.wasDisplayed);
 }
 
+- (void)test_whenScrolledVertically_thatIndexPathForFirstVisibleItemIsCorrect {
+    self.dataSource.objects = @[@1, @2, @3];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 3);
+    [self.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(0, 8) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(0, 12) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:1]);
+    [self.collectionView setContentOffset:CGPointMake(0, 35) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(0, 40) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:1 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(0, 59) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:2 inSection:2]);
+}
+
+- (void)test_whenScrolledVerticallyWithContentInset_thatIndexPathForFirstVisibleItemIsCorrect {
+    const CGFloat inset = 5;
+    self.collectionView.contentInset = UIEdgeInsetsMake(inset, 0, inset, 0);
+    self.dataSource.objects = @[@1, @2, @3];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 3);
+    [self.collectionView setContentOffset:CGPointMake(0, 0 - inset) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(0, 8 - inset) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(0, 12 - inset) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:1]);
+    [self.collectionView setContentOffset:CGPointMake(0, 35 - inset) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(0, 40 - inset) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:1 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(0, 59 - inset) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:2 inSection:2]);
+}
+
+- (void)test_whenScrolledHorizontallyWithSingleRow_thatIndexPathForFirstVisibleItemIsCorrect {
+    self.dataSource.objects = @[@1, @2, @3, @4];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.collectionView.frame = CGRectMake(0, 0, 300, 10);
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 4);
+    [self.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(80, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(120, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:1]);
+    [self.collectionView setContentOffset:CGPointMake(350, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(400, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:1 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(590, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:2 inSection:2]);
+}
+
+- (void)test_whenScrolledHorizontallyWithSingleRowWithContentInset_thatIndexPathForFirstVisibleItemIsCorrect {
+    const CGFloat inset = 172;
+    self.collectionView.contentInset = UIEdgeInsetsMake(0, inset, 0, inset);
+    self.dataSource.objects = @[@1, @2, @3, @4];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.collectionView.frame = CGRectMake(0, 0, 300, 10);
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 4);
+    [self.collectionView setContentOffset:CGPointMake(0 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(80 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(120 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:1]);
+    [self.collectionView setContentOffset:CGPointMake(350 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(400 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:1 inSection:2]);
+    [self.collectionView setContentOffset:CGPointMake(590 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:2 inSection:2]);
+}
+
+- (void)test_whenScrolledHorizontallyWithStackedSections_thatIndexPathForFirstVisibleItemIsCorrect {
+    self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 6);
+    [self.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(80, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:0]);
+    [self.collectionView setContentOffset:CGPointMake(120, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:1]);
+    [self.collectionView setContentOffset:CGPointMake(350, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:3]);
+    [self.collectionView setContentOffset:CGPointMake(400, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:4]);
+    [self.collectionView setContentOffset:CGPointMake(590, 0) animated:NO];
+    XCTAssertEqual([self.adapter indexPathForFirstVisibleItem], [NSIndexPath indexPathForItem:0 inSection:5]);
+}
+
+- (void)test_whenScrolledVertically_thatOffsetForFirstVisibleItemIsCorrect {
+    self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 6);
+    [self.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 0);
+    [self.collectionView setContentOffset:CGPointMake(0, 8) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 8);
+    [self.collectionView setContentOffset:CGPointMake(0, 12) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 2);
+    [self.collectionView setContentOffset:CGPointMake(0, 35) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 5);
+    [self.collectionView setContentOffset:CGPointMake(0, 40) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 0);
+    [self.collectionView setContentOffset:CGPointMake(0, 59) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 9);
+}
+
+- (void)test_whenScrolledVerticallyWithContentInset_thatOffsetForFirstVisibleItemIsCorrect {
+    const CGFloat inset = 5;
+    self.collectionView.contentInset = UIEdgeInsetsMake(inset, 0, inset, 0);
+    self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 6);
+    [self.collectionView setContentOffset:CGPointMake(0, 0 - inset) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 0);
+    [self.collectionView setContentOffset:CGPointMake(0, 8 - inset) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 8);
+    [self.collectionView setContentOffset:CGPointMake(0, 12 - inset) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 2);
+    [self.collectionView setContentOffset:CGPointMake(0, 35 - inset) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 5);
+    [self.collectionView setContentOffset:CGPointMake(0, 40 - inset) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 0);
+    [self.collectionView setContentOffset:CGPointMake(0, 59 - inset) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 9);
+}
+
+- (void)test_whenScrolledHorizontallyWithSingleRow_thatOffsetForFirstVisibleItemIsCorrect {
+    self.dataSource.objects = @[@1, @2, @3, @4];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.collectionView.frame = CGRectMake(0, 0, 300, 10);
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 4);
+    [self.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.collectionView setContentOffset:CGPointMake(80, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 80);
+    [self.collectionView setContentOffset:CGPointMake(120, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 20);
+    [self.collectionView setContentOffset:CGPointMake(350, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 50);
+    [self.collectionView setContentOffset:CGPointMake(400, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.collectionView setContentOffset:CGPointMake(599, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 99);
+}
+
+- (void)test_whenScrolledHorizontallyWithSingleRowWithContentInset_thatOffsetForFirstVisibleItemIsCorrect {
+    const CGFloat inset = 172;
+    self.collectionView.contentInset = UIEdgeInsetsMake(0, inset, 0, inset);
+    self.dataSource.objects = @[@1, @2, @3, @4];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    self.collectionView.frame = CGRectMake(0, 0, 300, 10);
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 4);
+    [self.collectionView setContentOffset:CGPointMake(0 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.collectionView setContentOffset:CGPointMake(80 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 80);
+    [self.collectionView setContentOffset:CGPointMake(120 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 20);
+    [self.collectionView setContentOffset:CGPointMake(350 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 50);
+    [self.collectionView setContentOffset:CGPointMake(400 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.collectionView setContentOffset:CGPointMake(599 - inset, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 99);
+}
+
+- (void)test_whenScrolledHorizontallyWithStackedSections_thatOffsetForFirstVisibleItemIsCorrect {
+    self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 6);
+    [self.collectionView setContentOffset:CGPointMake(0, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.collectionView setContentOffset:CGPointMake(80, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 80);
+    [self.collectionView setContentOffset:CGPointMake(120, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 20);
+    [self.collectionView setContentOffset:CGPointMake(350, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 50);
+    [self.collectionView setContentOffset:CGPointMake(400, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.collectionView setContentOffset:CGPointMake(599, 0) animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 99);
+}
+
+- (void)test_whenScrollToIndexPathWithAdditionalOffsetVerticially_thatOffsetForFirstVisibleItemIsCorrect {
+    const CGFloat inset = 5;
+    self.collectionView.contentInset = UIEdgeInsetsMake(inset, 0, inset, 0);
+    self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 6);
+    [self.adapter scrollToObject:@1 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone additionalOffset:0 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 0);
+    [self.adapter scrollToObject:@1 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone additionalOffset:7 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 7);
+    [self.adapter scrollToObject:@3 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone additionalOffset:0 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 0);
+    [self.adapter scrollToObject:@3 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone additionalOffset:3 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 3);
+    [self.adapter scrollToObject:@4 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionVertical scrollPosition:UICollectionViewScrollPositionNone additionalOffset:9 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionVertical], 9);
+}
+
+- (void)test_whenScrollToIndexPathWithAdditionalOffsetHorizontally_thatOffsetForFirstVisibleItemIsCorrect {
+    const CGFloat inset = 172;
+    self.collectionView.contentInset = UIEdgeInsetsMake(0, inset, 0, inset);
+    self.dataSource.objects = @[@1, @2, @3, @4, @5, @6];
+    self.layout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    [self.adapter reloadDataWithCompletion:nil];
+    XCTAssertEqual([self.collectionView numberOfSections], 6);
+    [self.adapter scrollToObject:@1 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionHorizontal scrollPosition:UICollectionViewScrollPositionNone additionalOffset:0 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.adapter scrollToObject:@1 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionHorizontal scrollPosition:UICollectionViewScrollPositionNone additionalOffset:73 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 73);
+    [self.adapter scrollToObject:@3 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionHorizontal scrollPosition:UICollectionViewScrollPositionNone additionalOffset:0 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 0);
+    [self.adapter scrollToObject:@3 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionHorizontal scrollPosition:UICollectionViewScrollPositionNone additionalOffset:36 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 36);
+    [self.adapter scrollToObject:@4 supplementaryKinds:nil scrollDirection:UICollectionViewScrollDirectionHorizontal scrollPosition:UICollectionViewScrollPositionNone additionalOffset:99 animated:NO];
+    XCTAssertEqual([self.adapter offsetForFirstVisibleItemWithScrollDirection:UICollectionViewScrollDirectionHorizontal], 99);
+}
+
 - (void)test_whenQueryingIndexPath_withOOBSectionController_thatNilReturned {
     self.dataSource.objects = @[@0, @1, @2];
     [self.adapter reloadDataWithCompletion:nil];


### PR DESCRIPTION
Summary:
Refactored and added functions to IGListAdapter for getting index path or scroll position of first visible item in list.

This makes it possible to see which item is the current first visible item scrolled to in the list, and determine how far it is scrolled into (analogous to additionalOffset in scrollToObject:).

Differential Revision: D32196398

