### PR TITLE
docs: Adding ELI5 video to the home page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -313,6 +313,15 @@
 
 <p>A data-driven <code>UICollectionView</code> framework for building fast and flexible lists.</p>
 
+<div align="center">
+  <h3>Watch Introductory Video</h3>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/3-WwZaiuJ3g" 
+  title="Explain Like I'm 5: IGListKit" frameBorder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowFullScreen ></iframe>
+</div>
+<br/>
+
 <table><thead>
 <tr>
 <th></th>


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc.

## Test plan
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/12485205/155072488-785a36f7-5873-4d94-8492-55de70702847.png">