### PR TITLE
Add explicit `activesupport` version as CocoaPods dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem "activesupport", "= 7.0.8"
 gem 'cocoapods', '~> 1.12.0'
 gem 'danger', '~> 9.2.0'
 gem 'danger-swiftlint', '~> 0.32.0'


### PR DESCRIPTION
## Changes in this pull request

All of the tests started failing today with a cryptic Ruby error. It turns out that a new version of `activesupport`, a dependency of CocoaPods was released and it introduced a bug. CocoaPods wasn't referencing a direct version of `activesupport` required, and so it was automatically trying to pull in this new invalid version.

This PR fixes the issue by explicitly specifying the last known good version of the dependency in the `Gemfile`.

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/main/.github/CONTRIBUTING.md)
