### PR TITLE
Fix incorrect publicHeaderPath in swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,13 +9,10 @@ let package = Package(
     ],
     products: [
         .library(name: "IGListDiffKit",
-                 type: .static,
                  targets: ["IGListDiffKit"]),
         .library(name: "IGListKit",
-                 type: .static,
                  targets: ["IGListKit"]),
         .library(name: "IGListSwiftKit",
-                 type: .static,
                  targets: ["IGListSwiftKit"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,14 @@ let package = Package(
     targets: [
         .target(
             name: "IGListDiffKit",
-            path: "spm/Sources/IGListDiffKit"
+            path: "spm/Sources/IGListDiffKit",
+            publicHeadersPath: "include"
         ),
         .target(
             name: "IGListKit",
             dependencies: ["IGListDiffKit"],
-            path: "spm/Sources/IGListKit"
+            path: "spm/Sources/IGListKit",
+            publicHeadersPath: "include"
         ),
         .target(
             name: "IGListSwiftKit",


### PR DESCRIPTION
## Changes in this pull request

- The swift package works static type by default, so i removes static type in product library.
- If target's path is changed, it must manually specify the `publicHeaderPath`. I specifies the `publicHeaderPath` property.



### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [ ] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [ ] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/main/.github/CONTRIBUTING.md)
