### PR TITLE
ListoGram Demo and Improve UI Testing Infrastructure

### DIFF
--- a/Examples/Examples-iOS/IGListKitExamples-UITests/DemosViewControllerUITests.swift
+++ b/Examples/Examples-iOS/IGListKitExamples-UITests/DemosViewControllerUITests.swift
@@ -80,22 +80,32 @@ final class DemosViewControllerUITests: UITestCase {
     func test_whenSelectingRecorderCells_thatReorderCellsDemoDetailScreenIsPresented() {
         enterAndAssertScreen(withTitle: "Reorder Cells")
     }
+    
+    func test_whenSelectingListoGram_thatListoGramDetailScreenIsPresented() {
+        enterAndAssertScreen(withTitle: "ListoGram")
+    }
 
     private func enterAndAssertScreen(withTitle title: String) {
-        XCUIApplication().activate()
-        let elem = XCUIApplication().collectionViews.cells.staticTexts[title]
+        let app = XCUIApplication()
+        app.activate()
 
-        var numberOfTries = 0
-        while !elem.isHittable {
-            XCUIApplication().collectionViews.element.swipeUp()
-            numberOfTries += 1
-            if numberOfTries >= 10 {
-                break
-            }
+        let cell = app.collectionViews.cells.staticTexts[title]
+        scrollToElement(cell)                       // your helper
+        XCTAssertTrue(cell.exists, "Couldn’t find demo named “\(title)”")
+        cell.tap()
+
+        let exactBar    = app.navigationBars[title]
+        let compactBar  = app.navigationBars[title.replacingOccurrences(of: " ", with: "")]
+
+        waitToAppear(element: exactBar, timeout: 2)
+
+        if !exactBar.exists {
+            waitToAppear(element: compactBar, timeout: 2)
         }
 
-        XCTAssertTrue(elem.exists)
-        elem.tap()
-        XCTAssertTrue(XCUIApplication().navigationBars[title].exists)
+        XCTAssertTrue(
+            exactBar.exists || compactBar.exists,
+            "Expected a navigation bar titled “\(title)” (or its compact form) to appear"
+        )
     }
 }

--- a/Examples/Examples-iOS/IGListKitExamples-UITests/ListoGramViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples-UITests/ListoGramViewController.swift
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import XCTest
+
+final class ListoGramViewControllerUITests: UITestCase {
+
+    // MARK: - Short-cuts
+    
+    private var app: XCUIApplication { XCUIApplication() }
+
+    /// The collection-view that shows the ListoGram feed.
+    private var feed: XCUIElement {
+        let collections = app.collectionViews
+        guard collections.count > 1 else { return collections.firstMatch }
+
+        for idx in 0..<collections.count {
+            let cv = collections.element(boundBy: idx)
+            if cv.buttons["optionsButton"].waitForExistence(timeout: 0.4) {
+                return cv
+            }
+        }
+        return collections.element(boundBy: 1)
+    }
+
+    // MARK: - Lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        enterListoGramDetailScreen()
+    }
+
+    // MARK: - Tests
+    
+    func test_whenLoadingInitialContent_postsAreDisplayed() {
+        waitToAppear(element: feed.cells.element(boundBy: 0), timeout: 5)
+        XCTAssertTrue(feed.cells.count > 0)
+    }
+
+    func test_whenRefreshing_newContentIsLoaded() {
+        waitToAppear(element: feed.cells.element(boundBy: 0), timeout: 5)
+        app.navigationBars["ListoGram"].buttons["Refresh"].tap()
+        waitToAppear(element: feed, timeout: 5)
+        XCTAssertTrue(feed.exists)
+    }
+
+    func test_whenScrollingToBottom_loadMoreIndicatorAppears() {
+        waitToAppear(element: feed.cells.element(boundBy: 0), timeout: 5)
+        (0..<3).forEach { _ in feed.swipeUp() }
+        XCTAssertTrue(feed.cells.count > 0)
+    }
+
+    func test_whenTappingOptionsButton_actionSheetAppears() {
+        let firstPost = firstVisiblePost()
+
+        locateOptionsButton(in: firstPost).tap()
+        let sheet = app.sheets.firstMatch
+        waitToAppear(element: sheet, timeout: 2)
+
+        XCTAssertTrue(sheet.buttons["Delete"].exists)
+        XCTAssertTrue(sheet.buttons["Report"].exists)
+
+        app.tap()
+    }
+
+    func test_whenDeletingPost_postIsRemoved() {
+        let firstPost = firstVisiblePost()
+        let caption   = firstPost.staticTexts.firstMatch.label
+        XCTAssertFalse(caption.isEmpty, "Post should contain a visible caption")
+
+        locateOptionsButton(in: firstPost).tap()
+        waitToAppear(element: app.sheets.firstMatch, timeout: 2)
+        app.sheets.firstMatch.buttons["Delete"].tap()
+
+        let deletedCell = feed.cells
+                            .containing(.staticText, identifier: caption)
+                            .firstMatch
+
+        XCTAssertTrue(
+            waitUntilGone(element: deletedCell, timeout: 5),
+            "Cell with caption “\(caption)” should disappear after deletion"
+        )
+    }
+
+    // MARK: - Helpers
+    
+    private func enterListoGramDetailScreen() {
+        let demo = app.collectionViews.staticTexts["ListoGram"]
+        scrollToElement(demo, in: app.collectionViews)
+        XCTAssertTrue(demo.exists)
+
+        demo.tap()
+        XCTAssertTrue(app.navigationBars["ListoGram"].exists)
+    }
+
+    @discardableResult
+    private func waitUntilGone(element: XCUIElement,
+                               timeout: TimeInterval) -> Bool {
+        let gone = NSPredicate(format: "exists == false")
+        let exp  = expectation(for: gone, evaluatedWith: element, handler: nil)
+        return XCTWaiter().wait(for: [exp], timeout: timeout) == .completed
+    }
+
+    private func firstVisiblePost() -> XCUIElement {
+        let post = feed.cells.element(boundBy: 0)
+        waitToAppear(element: post, timeout: 5)
+        return post
+    }
+
+    /// Finds the trailing “…” button in a post, whatever Apple calls it this week.
+    private func locateOptionsButton(in post: XCUIElement) -> XCUIElement {
+        let predicate = NSPredicate(
+            format: "identifier == 'optionsButton' || " +
+                    "label CONTAINS[c] 'ellipsis'  || " +
+                    "label CONTAINS[c] 'more'"
+        )
+
+        for container in [post, feed, app] {
+            let btn = container.descendants(matching: .any)
+                               .matching(predicate)
+                               .firstMatch
+            if btn.waitForExistence(timeout: 2) { return btn }
+        }
+
+        fatalError("Options button should appear somewhere on screen")
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples-UITests/UITestCase.swift
+++ b/Examples/Examples-iOS/IGListKitExamples-UITests/UITestCase.swift
@@ -70,3 +70,23 @@ class UITestCase: XCTestCase {
         }
     }
 }
+
+// MARK: - Helpers added for multiple collection-views (iPad split-view)
+
+private extension XCUIElementQuery {
+    /// The list we want to scroll in our UI-tests.
+    /// • On iPhone there is only one collection-view, so this is that one.
+    /// • On iPad split-view there are two; `firstMatch` is always the master list.
+    var primary: XCUIElement { firstMatch }
+}
+
+/// Scrolls until `element` is hittable or `maxSwipes` is reached.
+internal func scrollToElement(_ element: XCUIElement,
+                              in scrollView: XCUIElementQuery = XCUIApplication().collectionViews,
+                              maxSwipes: Int = 15) {
+    var swipes = 0
+    while !element.isHittable && swipes < maxSwipes {
+        scrollView.primary.swipeUp()
+        swipes += 1
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -1161,7 +1161,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
@@ -1190,7 +1190,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
@@ -1217,7 +1217,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas.UITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1244,7 +1244,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas.UITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -1270,7 +1270,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.messages-example";
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1298,7 +1298,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.messages-example";
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1324,7 +1324,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.todays-example";
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1351,7 +1351,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.todays-example";
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.today;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -86,6 +86,15 @@
 		576D20162B2CF1A50012C5B8 /* HorizontalCardsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576D20152B2CF1A50012C5B8 /* HorizontalCardsSection.swift */; };
 		576D20182B2CF24F0012C5B8 /* HorizontalComposableSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576D20172B2CF24F0012C5B8 /* HorizontalComposableSectionController.swift */; };
 		576D201A2B2CF82C0012C5B8 /* SwipeActionSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576D20192B2CF82C0012C5B8 /* SwipeActionSection.swift */; };
+		7D4506D22DC001670029D095 /* ListoGramViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506D12DC001670029D095 /* ListoGramViewController.swift */; };
+		7D4506D52DC001C40029D095 /* PostModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506D42DC001C40029D095 /* PostModel.swift */; };
+		7D4506D62DC001C40029D095 /* LoadingCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506D32DC001C40029D095 /* LoadingCellModel.swift */; };
+		7D4506D82DC001DD0029D095 /* APIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506D72DC001DD0029D095 /* APIService.swift */; };
+		7D4506DB2DC001FC0029D095 /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506DA2DC001FC0029D095 /* PostCell.swift */; };
+		7D4506DC2DC001FC0029D095 /* LoadingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506D92DC001FC0029D095 /* LoadingCell.swift */; };
+		7D4506E02DC0020C0029D095 /* LoadingSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506DD2DC0020C0029D095 /* LoadingSectionController.swift */; };
+		7D4506E22DC0020C0029D095 /* PostSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506DE2DC0020C0029D095 /* PostSectionController.swift */; };
+		7D4506E62DC0052C0029D095 /* ListoGramViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4506E52DC0052C0029D095 /* ListoGramViewController.swift */; };
 		821BC4B61DB8B3DC00172ED0 /* StoryboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4B51DB8B3DC00172ED0 /* StoryboardViewController.swift */; };
 		821BC4B81DB8B48300172ED0 /* StoryboardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4B71DB8B48300172ED0 /* StoryboardCell.swift */; };
 		821BC4BA1DB8B61200172ED0 /* StoryboardLabelSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821BC4B91DB8B61200172ED0 /* StoryboardLabelSectionController.swift */; };
@@ -259,6 +268,15 @@
 		576D20152B2CF1A50012C5B8 /* HorizontalCardsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCardsSection.swift; sourceTree = "<group>"; };
 		576D20172B2CF24F0012C5B8 /* HorizontalComposableSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalComposableSectionController.swift; sourceTree = "<group>"; };
 		576D20192B2CF82C0012C5B8 /* SwipeActionSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeActionSection.swift; sourceTree = "<group>"; };
+		7D4506D12DC001670029D095 /* ListoGramViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListoGramViewController.swift; sourceTree = "<group>"; };
+		7D4506D32DC001C40029D095 /* LoadingCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingCellModel.swift; sourceTree = "<group>"; };
+		7D4506D42DC001C40029D095 /* PostModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostModel.swift; sourceTree = "<group>"; };
+		7D4506D72DC001DD0029D095 /* APIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIService.swift; sourceTree = "<group>"; };
+		7D4506D92DC001FC0029D095 /* LoadingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingCell.swift; sourceTree = "<group>"; };
+		7D4506DA2DC001FC0029D095 /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
+		7D4506DD2DC0020C0029D095 /* LoadingSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingSectionController.swift; sourceTree = "<group>"; };
+		7D4506DE2DC0020C0029D095 /* PostSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSectionController.swift; sourceTree = "<group>"; };
+		7D4506E52DC0052C0029D095 /* ListoGramViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListoGramViewController.swift; sourceTree = "<group>"; };
 		821BC4B51DB8B3DC00172ED0 /* StoryboardViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardViewController.swift; sourceTree = "<group>"; };
 		821BC4B71DB8B48300172ED0 /* StoryboardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardCell.swift; sourceTree = "<group>"; };
 		821BC4B91DB8B61200172ED0 /* StoryboardLabelSectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardLabelSectionController.swift; sourceTree = "<group>"; };
@@ -298,6 +316,10 @@
 		FF73FF9B1FBA4B4400F2AB06 /* UserFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFooterView.swift; sourceTree = "<group>"; };
 		FF73FF9D1FBA4B5500F2AB06 /* UserFooterView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserFooterView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		7D4506E32DC003730029D095 /* DelegateProtocols */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = DelegateProtocols; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		2961B3871D68B031001C9451 /* Frameworks */ = {
@@ -388,6 +410,8 @@
 				2942FF8B1D9F39E00015D24B /* UserSectionController.swift */,
 				2981BA361DB869FF00A987F9 /* WorkingRangeSectionController.swift */,
 				576D200C2B2CE9C60012C5B8 /* With Composable Layout */,
+				7D4506DD2DC0020C0029D095 /* LoadingSectionController.swift */,
+				7D4506DE2DC0020C0029D095 /* PostSectionController.swift */,
 			);
 			path = SectionControllers;
 			sourceTree = "<group>";
@@ -419,6 +443,7 @@
 		2961B38C1D68B031001C9451 /* IGListKitExamples */ = {
 			isa = PBXGroup;
 			children = (
+				7D4506E32DC003730029D095 /* DelegateProtocols */,
 				2961B38D1D68B031001C9451 /* AppDelegate.swift */,
 				2961B3941D68B031001C9451 /* Assets.xcassets */,
 				9DB684DF251B1093002023DD /* Extensions */,
@@ -438,6 +463,7 @@
 		2961B3A31D68B0B5001C9451 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				7D4506D12DC001670029D095 /* ListoGramViewController.swift */,
 				29F7E2A91E9283FF00197586 /* AnnouncingDepsViewController.swift */,
 				292658561E749EDC0041B56D /* CalendarViewController.swift */,
 				2961B3A41D68B0B5001C9451 /* DemosViewController.swift */,
@@ -468,6 +494,8 @@
 		2961B3A61D68B0B5001C9451 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				7D4506D92DC001FC0029D095 /* LoadingCell.swift */,
+				7D4506DA2DC001FC0029D095 /* PostCell.swift */,
 				292658651E74A49D0041B56D /* CalendarDayCell.swift */,
 				2991F9181D7BADC900B0C58F /* CenterLabelCell.swift */,
 				56C05B701E49B32A0026DB39 /* CommentCell.h */,
@@ -507,6 +535,9 @@
 		2991F91C1D7BB30300B0C58F /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				7D4506D72DC001DD0029D095 /* APIService.swift */,
+				7D4506D32DC001C40029D095 /* LoadingCellModel.swift */,
+				7D4506D42DC001C40029D095 /* PostModel.swift */,
 				4119B2AA2D89BB1200D397BC /* ActivityItem.swift */,
 				29C6297C1DCFD8E5004A5BB1 /* FeedItem.swift */,
 				292658581E749F820041B56D /* Month.swift */,
@@ -557,6 +588,7 @@
 		95F7F9121DE5006C00A64FEE /* IGListKitExamples-UITests */ = {
 			isa = PBXGroup;
 			children = (
+				7D4506E52DC0052C0029D095 /* ListoGramViewController.swift */,
 				9518E3CA1DED27840008CC46 /* DemosViewControllerUITests.swift */,
 				95F7F9151DE5006C00A64FEE /* Info.plist */,
 				9518E3C41DED057E0008CC46 /* LoadMoreViewControllerUITests.swift */,
@@ -647,6 +679,9 @@
 			dependencies = (
 				986FB71E1DBBA60900A65C18 /* PBXTargetDependency */,
 				986FB73A1DBBAD8600A65C18 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				7D4506E32DC003730029D095 /* DelegateProtocols */,
 			);
 			name = IGListKitExamples;
 			packageProductDependencies = (
@@ -847,6 +882,8 @@
 				576D20162B2CF1A50012C5B8 /* HorizontalCardsSection.swift in Sources */,
 				2981BA351DB868A500A987F9 /* ImageCell.swift in Sources */,
 				2942FF931D9F39E00015D24B /* SearchSectionController.swift in Sources */,
+				7D4506E02DC0020C0029D095 /* LoadingSectionController.swift in Sources */,
+				7D4506E22DC0020C0029D095 /* PostSectionController.swift in Sources */,
 				297546FA1DD25384002A6F89 /* FullWidthSelfSizingCell.swift in Sources */,
 				292658681E74AE8A0041B56D /* MonthTitleViewModel.swift in Sources */,
 				576D20102B2CEC4E0012C5B8 /* GridComposableSectionController.swift in Sources */,
@@ -862,7 +899,9 @@
 				29C629831DCFDB57004A5BB1 /* UserHeaderView.swift in Sources */,
 				2961B3AC1D68B0B5001C9451 /* LoadMoreViewController.swift in Sources */,
 				26271C941DAE9F050073E116 /* NibCell.swift in Sources */,
+				7D4506D22DC001670029D095 /* ListoGramViewController.swift in Sources */,
 				2991F9191D7BADC900B0C58F /* CenterLabelCell.swift in Sources */,
+				7D4506D82DC001DD0029D095 /* APIService.swift in Sources */,
 				295D8A9A1E92EC96001F7C06 /* PostSectionController.m in Sources */,
 				4119B2AB2D89BB1E00D397BC /* ActivityItem.swift in Sources */,
 				29628F141D91905A0026B15A /* DetailLabelCell.swift in Sources */,
@@ -891,6 +930,10 @@
 				2942FF8F1D9F39E00015D24B /* GridSectionController.swift in Sources */,
 				821BC4B81DB8B48300172ED0 /* StoryboardCell.swift in Sources */,
 				56C05B781E49B3A50026DB39 /* PhotoCell.m in Sources */,
+				7D4506DB2DC001FC0029D095 /* PostCell.swift in Sources */,
+				7D4506DC2DC001FC0029D095 /* LoadingCell.swift in Sources */,
+				7D4506D52DC001C40029D095 /* PostModel.swift in Sources */,
+				7D4506D62DC001C40029D095 /* LoadingCellModel.swift in Sources */,
 				576D201A2B2CF82C0012C5B8 /* SwipeActionSection.swift in Sources */,
 				2942FF921D9F39E00015D24B /* RemoveSectionController.swift in Sources */,
 				26271C8E1DAE9D3F0073E116 /* SingleSectionViewController.swift in Sources */,
@@ -929,6 +972,7 @@
 				9518E3C51DED057E0008CC46 /* LoadMoreViewControllerUITests.swift in Sources */,
 				9518E3CB1DED27840008CC46 /* DemosViewControllerUITests.swift in Sources */,
 				9518E3C91DED1BCB0008CC46 /* MixedDataViewControllerUITests.swift in Sources */,
+				7D4506E62DC0052C0029D095 /* ListoGramViewController.swift in Sources */,
 				9518E3C71DED18370008CC46 /* SearchViewControllerUITests.swift in Sources */,
 				9518E3C31DED03520008CC46 /* UITestCase.swift in Sources */,
 			);
@@ -1109,7 +1153,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = IGListKitExamples/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1117,7 +1161,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
@@ -1138,7 +1182,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = IGListKitExamples/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1146,7 +1190,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
@@ -1164,7 +1208,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = "IGListKitExamples-UITests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1173,7 +1217,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples-UITests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas.UITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1191,7 +1235,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = "IGListKitExamples-UITests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1200,7 +1244,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples-UITests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.abhyas.UITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -1217,7 +1261,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = "$(SRCROOT)/IGListKitMessageExample/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1226,7 +1270,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitMessageExample;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.messages-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1245,7 +1289,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = "$(SRCROOT)/IGListKitMessageExample/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1254,7 +1298,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitMessageExample;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.messages-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1271,7 +1315,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = IGListKitTodayExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1280,7 +1324,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitTodayExample;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.todays-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1298,7 +1342,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 92KLD58G24;
 				INFOPLIST_FILE = IGListKitTodayExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1307,7 +1351,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitTodayExample;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples.abhyas.todays-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
+++ b/Examples/Examples-iOS/IGListKitExamples.xcodeproj/project.pbxproj
@@ -1153,7 +1153,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IGListKitExamples/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1161,7 +1161,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
@@ -1182,7 +1182,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IGListKitExamples/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1190,7 +1190,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTS_MACCATALYST = YES;
@@ -1208,7 +1208,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "IGListKitExamples-UITests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1217,7 +1217,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples-UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -1235,7 +1235,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "IGListKitExamples-UITests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1244,7 +1244,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.instagram.IGListKitExamples-UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
@@ -1261,7 +1261,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/IGListKitMessageExample/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1270,7 +1270,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitMessageExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1289,7 +1289,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/IGListKitMessageExample/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1298,7 +1298,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitMessageExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1315,7 +1315,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IGListKitTodayExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1324,7 +1324,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.today;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitTodayExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1342,7 +1342,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 92KLD58G24;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = IGListKitTodayExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1351,7 +1351,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.contribute.abhyas.today;
+				PRODUCT_BUNDLE_IDENTIFIER = com.instagram.IGListKitExamples.IGListKitTodayExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;

--- a/Examples/Examples-iOS/IGListKitExamples/DelegateProtocols/PostSectionControllerDelegate.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/DelegateProtocols/PostSectionControllerDelegate.swift
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import UIKit
+
+/// To allow communication between PostSectionController and FeedViewController
+protocol PostSectionControllerDelegate: AnyObject {
+    func postSectionController(_ sectionController: PostSectionController, didSelectOptionsFor post: Post, from sourceView: UIView)
+}

--- a/Examples/Examples-iOS/IGListKitExamples/DelegateProtocols/PostSectionControllerDelegate.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/DelegateProtocols/PostSectionControllerDelegate.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-/// To allow communication between PostSectionController and FeedViewController
+/// To allow communication between PostSectionController and ListoGramViewController
 protocol PostSectionControllerDelegate: AnyObject {
     func postSectionController(_ sectionController: PostSectionController, didSelectOptionsFor post: Post, from sourceView: UIView)
 }

--- a/Examples/Examples-iOS/IGListKitExamples/Models/APIService.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/APIService.swift
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Foundation
+
+// MARK: - Data Provider
+
+// In IGListKit architecture, the data provider is separated from the UI components
+// This enables clean separation of concerns and makes testing easier
+class APIService {
+    static let shared = APIService()
+    
+    // Pagination state
+    private var currentPage = 1
+    private var isLoading = false
+    private var hasMoreData = true
+    
+    // Fetch posts with pagination support
+    // This is called by the view controller to load data
+    // IGListKit will handle the diffing and UI updates based on the results
+    func fetchPosts(completion: @escaping([Post]) -> Void) {
+        guard !isLoading, hasMoreData else { return }
+        
+        self.isLoading = true
+        
+        // Simulate network delay
+        DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) {
+            let posts = self.generateMockPosts(page: self.currentPage)
+            
+            if self.currentPage >= 5 {
+                self.hasMoreData = false
+            }
+            
+            self.currentPage += 1
+            self.isLoading = false
+            
+            DispatchQueue.main.async {
+                completion(posts)
+            }
+        }
+    }
+    
+    // Reset pagination state for refreshing
+    func resetPagination() {
+        self.currentPage = 1
+        self.hasMoreData = true
+    }
+    
+    // Generate mock data for the demo app
+    // In a real app, this would be replaced with API calls
+    func generateMockPosts(page: Int) -> [Post] {
+        let baseCount = (page - 1) * 5
+        
+        return (1...5).map { index in
+            let id = "\(baseCount + index)"
+            return Post(
+                id: id,
+                username: "user\(Int.random(in: 100...999))",
+                userAvatarURL: URL(string: "https://randomuser.me/api/portraits/men/\(Int.random(in: 1...99)).jpg"),
+                imageURL: URL(string: "https://picsum.photos/id/\(baseCount + index + 10)/500/500"),
+                title: "Post #\(id)",
+                description: "This is a beautiful photo I took while traveling. What do you think? #travel #photography #nature",
+                likes: Int.random(in: 10...1000),
+                timeStamp: Date().addingTimeInterval(-Double(Int.random(in: 1...86400) * (baseCount + index)))
+            )
+        }
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/Models/APIService.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/APIService.swift
@@ -28,7 +28,7 @@ class APIService {
         self.isLoading = true
         
         // Simulate network delay
-        DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
             let posts = self.generateMockPosts(page: self.currentPage)
             
             if self.currentPage >= 5 {

--- a/Examples/Examples-iOS/IGListKitExamples/Models/LoadingCellModel.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/LoadingCellModel.swift
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import UIKit
+import IGListKit
+
+final class LoadingCellModel {
+    let identifier = "loading-cell"
+}
+
+// MARK: - ListDiffable Implementation
+
+// Even simple models like this loading indicator need to conform to ListDiffable
+// in order to be used with IGListKit
+extension LoadingCellModel: ListDiffable {
+    
+    // The diffIdentifier uniquely identifies this object
+    // For a singleton loading indicator, a static string ID is sufficient
+    func diffIdentifier() -> any NSObjectProtocol {
+        return self.identifier as NSObjectProtocol
+    }
+    
+    // isEqual compares properties that affect the visual representation
+    // For this simple case, comparing identifiers is enough
+    func isEqual(toDiffableObject object: (any ListDiffable)?) -> Bool {
+        guard let object = object as? LoadingCellModel else { return false }
+        return self.identifier == object.identifier
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/Models/PostModel.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Models/PostModel.swift
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import IGListKit
+import UIKit
+
+final class Post {
+    let id: String
+    let username: String
+    let userAvatarURL: URL?
+    let imageURL: URL?
+    let title: String
+    let description: String
+    let likes: Int
+    let timeStamp: Date
+    
+    init(id: String, username: String, userAvatarURL: URL?, imageURL: URL?, title: String, description: String, likes: Int, timeStamp: Date) {
+        self.id = id
+        self.username = username
+        self.userAvatarURL = userAvatarURL
+        self.imageURL = imageURL
+        self.title = title
+        self.description = description
+        self.likes = likes
+        self.timeStamp = timeStamp
+    }
+}
+
+// MARK: - ListDiffable Implementation
+
+// ListDiffable is the core protocol in IGListKit for data diffing
+// It's similar to Equatable but with more specific requirements for efficient diffing
+extension Post: ListDiffable {
+    
+    // This method returns a unique identifier for the object
+    // IGListKit uses this to track objects across updates
+    // It should be unique and stable across updates (like a database ID)
+    func diffIdentifier() -> NSObjectProtocol {
+        return self.id as NSObjectProtocol
+    }
+    
+    // This method compares all properties that might cause visual changes
+    // If this returns false for objects with the same diffIdentifier,
+    // IGListKit will reload that section instead of leaving it alone
+    func isEqual(toDiffableObject object: (any ListDiffable)?) -> Bool {
+        guard let object = object as? Post else { return false }
+        
+        return self.id == object.id &&
+               self.username == object.username &&
+               self.userAvatarURL == object.userAvatarURL &&
+               self.imageURL == object.imageURL &&
+               self.title == object.title &&
+               self.description == object.description &&
+               self.likes == object.likes
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LoadingSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/LoadingSectionController.swift
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import IGListKit
+
+// MARK: - LoadingSectionController
+
+// A simpler section controller that manages the loading indicator
+// Note that each type of content gets its own section controller
+// This is a key concept in IGListKit - each model type gets a dedicated controller
+final class LoadingSectionController: ListSectionController {
+    
+    override init() {
+        super.init()
+        self.inset = UIEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
+    }
+    
+    // Set the size for the loading indicator cell
+    override func sizeForItem(at index: Int) -> CGSize {
+        let width = collectionContext?.containerSize.width ?? 0
+        return CGSize(width: width, height: 60)
+    }
+    
+    // Create and return the loading cell
+    override func cellForItem(at index: Int) -> UICollectionViewCell {
+        guard let cell = collectionContext?.dequeueReusableCell(of: LoadingCell.self, for: self, at: index) else {
+            fatalError("Failed to dequeue LoadingCell")
+        }
+        return cell
+    }
+    
+    // Nothing to update for this simple controller
+    override func didUpdate(to object: Any) {
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/SectionControllers/PostSectionController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/SectionControllers/PostSectionController.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import IGListKit
+
+// MARK: - ListSectionController
+
+// In IGListKit, section controllers manage a single type of data object
+// and are responsible for:
+// - Creating and configuring cells
+// - Handling cell selection
+// - Determining cell sizes
+// - Managing section-specific actions
+final class PostSectionController: ListSectionController {
+    
+    var post: Post?
+    weak var delegate: PostSectionControllerDelegate?
+    
+    override init() {
+        super.init()
+        // Setting insets for the entire section
+        self.inset = UIEdgeInsets(top: 0, left: 0, bottom: 10, right: 0)
+    }
+    
+    // Determines the size of cells in this section
+    // IGListKit calls this method to calculate cell dimensions
+    override func sizeForItem(at index: Int) -> CGSize {
+        // collectionContext is a bridge that connects the section controller
+        // to the actual UICollectionView it exists within
+        let width = collectionContext?.containerSize.width ?? 0
+        return CGSize(width: width, height: width + 200)
+    }
+    
+    // Creates and configures a cell for this section
+    // Similar to cellForRowAt in UICollectionViewDataSource
+    override func cellForItem(at index: Int) -> UICollectionViewCell {
+        guard let cell = collectionContext?.dequeueReusableCell(of: PostCell.self, for: self, at: index) as? PostCell,
+              let post = post else {
+            fatalError("Failed to dequeue PostCell")
+        }
+        
+        cell.configure(with: post)
+        
+        cell.optionsButtonTapped = { [weak self] (button: UIButton) in
+            guard let self = self, let post = self.post else { return }
+            self.delegate?.postSectionController(self, didSelectOptionsFor: post, from: button)
+        }
+        
+        return cell
+    }
+    
+    // Handles selection of cells in this section
+    override func didSelectItem(at index: Int) {
+        guard let post = post else { return }
+        print("Post ID:\(post.id) was tapped.")
+    }
+    
+    // Called when the data object for this section controller is updated
+    // This is where you store a reference to your model object
+    override func didUpdate(to object: Any) {
+        post = object as? Post
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/DemosViewController.swift
@@ -57,7 +57,8 @@ final class DemosViewController: UIViewController, ListAdapterDataSource {
         DemoItem(name: "Reorder Cells", imageName: "arrow.up.and.down.and.arrow.left.and.right",
                  controllerClass: ReorderableViewController.self),
         DemoItem(name: "Compositional Layout", imageName: "square.stack",
-                 controllerClass: CompositionLayoutViewController.self)
+                 controllerClass: CompositionLayoutViewController.self),
+        DemoItem(name: "ListoGram", imageName: "camera.circle", controllerClass: ListoGramViewController.self)
     ]
 
     override func viewDidLoad() {

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ListoGramViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ListoGramViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 
 final class ListoGramViewController: UIViewController, ListAdapterDataSource {
     
+    
+    
     // MARK: - Properties
     
     private lazy var adapter: ListAdapter = {

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ListoGramViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ListoGramViewController.swift
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import IGListKit
+import UIKit
+
+final class ListoGramViewController: UIViewController, ListAdapterDataSource {
+    
+    // MARK: - Properties
+    
+    private lazy var adapter: ListAdapter = {
+        return ListAdapter(updater: ListAdapterUpdater(), viewController: self)
+    }()
+    
+    private lazy var collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.backgroundColor = .systemBackground
+        collectionView.alwaysBounceVertical = true
+        return collectionView
+    }()
+    
+    private var posts: [Post] = []
+    private var isLoading = false
+    private var shouldShowLoadingCell = false
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupAdapter()
+        loadInitialData()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        title = "ListoGram"
+        
+        view.backgroundColor = .systemBackground
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .refresh,
+            target: self,
+            action: #selector(refreshFeed)
+        )
+        
+        view.addSubview(collectionView)
+        
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    private func setupAdapter() {
+        adapter.collectionView = collectionView
+        adapter.scrollViewDelegate = self
+        adapter.dataSource = self
+    }
+    
+    // MARK: - Data Loading
+    
+    private func loadInitialData() {
+        isLoading = true
+        APIService.shared.resetPagination()
+        posts = []
+        shouldShowLoadingCell = true
+        adapter.performUpdates(animated: true)
+        
+        APIService.shared.fetchPosts { [weak self] newPosts in
+            guard let self = self else { return }
+            self.posts = newPosts
+            self.isLoading = false
+            self.adapter.performUpdates(animated: true)
+        }
+    }
+    
+    private func loadMoreData() {
+        guard !isLoading else { return }
+        
+        isLoading = true
+        shouldShowLoadingCell = true
+        adapter.performUpdates(animated: true)
+        
+        APIService.shared.fetchPosts { [weak self] newPosts in
+            guard let self = self else { return }
+            
+            // Append new posts to existing posts
+            self.posts.append(contentsOf: newPosts)
+            self.isLoading = false
+            
+            // If no new posts were fetched, hide the loading cell
+            if newPosts.isEmpty {
+                self.shouldShowLoadingCell = false
+            }
+            
+            self.adapter.performUpdates(animated: true)
+        }
+    }
+    
+    @objc private func refreshFeed() {
+        loadInitialData()
+    }
+    
+    // MARK: - ListAdapterDataSource
+    
+    func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
+        var objects: [ListDiffable] = posts
+        
+        if shouldShowLoadingCell {
+            objects.append(LoadingCellModel())
+        }
+        
+        return objects
+    }
+    
+    func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {
+        if object is Post {
+            let sectionController = PostSectionController()
+            sectionController.delegate = self
+            return sectionController
+        } else {
+            return LoadingSectionController()
+        }
+    }
+    
+    func emptyView(for listAdapter: ListAdapter) -> UIView? {
+        let emptyView = UIView()
+        
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "No posts available"
+        label.textAlignment = .center
+        label.textColor = .gray
+        
+        emptyView.addSubview(label)
+        
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: emptyView.centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: emptyView.centerYAnchor)
+        ])
+        
+        return emptyView
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension ListoGramViewController: UIScrollViewDelegate {
+    
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, 
+                                  withVelocity velocity: CGPoint, 
+                                  targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        
+        let distance = scrollView.contentSize.height - (targetContentOffset.pointee.y + scrollView.bounds.height)
+        
+        if !isLoading && distance < 200 && !posts.isEmpty {
+            loadMoreData()
+        }
+    }
+}
+
+// MARK: - PostSectionControllerDelegate
+
+extension ListoGramViewController: PostSectionControllerDelegate {
+    func postSectionController(_ sectionController: PostSectionController, didSelectOptionsFor post: Post, from sourceView: UIView) {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        let deleteAction = UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+            self?.deletePost(post)
+        }
+        
+        let reportAction = UIAlertAction(title: "Report", style: .default) { _ in
+            print("Reported post: \(post.id)")
+        }
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+        
+        alertController.addAction(deleteAction)
+        alertController.addAction(reportAction)
+        alertController.addAction(cancelAction)
+        
+        // Configure for iPad
+        if let popoverController = alertController.popoverPresentationController {
+            // If we have a specific source view (like a button), use it
+            popoverController.sourceView = sourceView
+            popoverController.sourceRect = sourceView.bounds
+        }
+        
+        present(alertController, animated: true, completion: nil)
+    }
+    
+    func postSectionController(_ sectionController: PostSectionController, didRequestDeleteFor post: Post) {
+        deletePost(post)
+    }
+    
+    private func deletePost(_ post: Post) {
+        if let index = posts.firstIndex(where: { $0.id == post.id }) {
+            posts.remove(at: index)
+            adapter.performUpdates(animated: true)
+        }
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ListoGramViewController.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/ViewControllers/ListoGramViewController.swift
@@ -10,8 +10,6 @@ import UIKit
 
 final class ListoGramViewController: UIViewController, ListAdapterDataSource {
     
-    
-    
     // MARK: - Properties
     
     private lazy var adapter: ListAdapter = {

--- a/Examples/Examples-iOS/IGListKitExamples/Views/LoadingCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/LoadingCell.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import UIKit
+
+final class LoadingCell: UICollectionViewCell {
+    
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.color = .darkGray
+        indicator.hidesWhenStopped = false
+        return indicator
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupViews() {
+        contentView.addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+        ])
+        
+        activityIndicator.startAnimating()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        activityIndicator.startAnimating()
+    }
+}

--- a/Examples/Examples-iOS/IGListKitExamples/Views/PostCell.swift
+++ b/Examples/Examples-iOS/IGListKitExamples/Views/PostCell.swift
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import UIKit
+
+// MARK: - UICollectionViewCell
+
+// In IGListKit, cells are regular UICollectionViewCells
+// There's no special base class - IGListKit works with standard UIKit components
+final class PostCell: UICollectionViewCell {
+
+    // MARK: - UI Components
+
+    private let headerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let avatarImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 20
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray5
+        return imageView
+    }()
+    
+    private let usernameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.boldSystemFont(ofSize: 15)
+        return label
+    }()
+    
+    private let optionsButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        button.tintColor = .darkGray
+        return button
+    }()
+    
+    private let postImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .systemGray6
+        return imageView
+    }()
+    
+    private let actionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        return stackView
+    }()
+    
+    private let likeButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "heart"), for: .normal)
+        button.tintColor = .label
+        return button
+    }()
+    
+    private let commentButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "message"), for: .normal)
+        button.tintColor = .label
+        return button
+    }()
+    
+    private let shareButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "paperplane"), for: .normal)
+        button.tintColor = .label
+        return button
+    }()
+    
+    private let likesLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        return label
+    }()
+    
+    private let captionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 5
+        return stackView
+    }()
+    
+    private let captionUsernameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.boldSystemFont(ofSize: 14)
+        label.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        return label
+    }()
+    
+    private let captionLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.numberOfLines = 3
+        return label
+    }()
+    
+    private let timestampLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 12)
+        label.textColor = .gray
+        return label
+    }()
+    
+    // MARK: - Properties
+    
+    // Closure for handling the options button tap
+    // This allows the section controller to respond to UI events in the cell
+    var optionsButtonTapped: ((UIButton) -> Void)?
+    
+    // MARK: - Initialization
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // Clean up cell for reuse - important for efficient cell recycling
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        avatarImageView.image = nil
+        postImageView.image = nil
+        usernameLabel.text = nil
+        captionUsernameLabel.text = nil
+        captionLabel.text = nil
+        likesLabel.text = nil
+        timestampLabel.text = nil
+    }
+    
+    // MARK: - Setup
+    
+    private func setupViews() {
+        
+        optionsButton.accessibilityIdentifier = "optionsButton"
+        
+        contentView.backgroundColor = .systemBackground
+        
+        // Add subviews
+        contentView.addSubview(headerView)
+        headerView.addSubview(avatarImageView)
+        headerView.addSubview(usernameLabel)
+        headerView.addSubview(optionsButton)
+        
+        contentView.addSubview(postImageView)
+        
+        contentView.addSubview(actionStackView)
+        actionStackView.addArrangedSubview(likeButton)
+        actionStackView.addArrangedSubview(commentButton)
+        actionStackView.addArrangedSubview(shareButton)
+        
+        contentView.addSubview(likesLabel)
+        
+        contentView.addSubview(captionStackView)
+        captionStackView.addArrangedSubview(captionUsernameLabel)
+        captionStackView.addArrangedSubview(captionLabel)
+        
+        contentView.addSubview(timestampLabel)
+        
+        // Layout constraints
+        NSLayoutConstraint.activate([
+            
+            // Header view
+            headerView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            headerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            headerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            headerView.heightAnchor.constraint(equalToConstant: 50),
+            
+            avatarImageView.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 10),
+            avatarImageView.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            avatarImageView.widthAnchor.constraint(equalToConstant: 40),
+            avatarImageView.heightAnchor.constraint(equalToConstant: 40),
+            
+            usernameLabel.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: 10),
+            usernameLabel.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            
+            optionsButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -10),
+            optionsButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+            optionsButton.widthAnchor.constraint(equalToConstant: 30),
+            optionsButton.heightAnchor.constraint(equalToConstant: 30),
+            
+            // Post image
+            postImageView.topAnchor.constraint(equalTo: headerView.bottomAnchor),
+            postImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            postImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            postImageView.heightAnchor.constraint(equalTo: contentView.widthAnchor), // Square aspect ratio
+            
+            // Action buttons
+            actionStackView.topAnchor.constraint(equalTo: postImageView.bottomAnchor, constant: 8),
+            actionStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
+            
+            likeButton.widthAnchor.constraint(equalToConstant: 30),
+            likeButton.heightAnchor.constraint(equalToConstant: 30),
+            
+            commentButton.widthAnchor.constraint(equalToConstant: 30),
+            commentButton.heightAnchor.constraint(equalToConstant: 30),
+            
+            shareButton.widthAnchor.constraint(equalToConstant: 30),
+            shareButton.heightAnchor.constraint(equalToConstant: 30),
+            
+            // Likes
+            likesLabel.topAnchor.constraint(equalTo: actionStackView.bottomAnchor, constant: 5),
+            likesLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
+            
+            // Caption
+            captionStackView.topAnchor.constraint(equalTo: likesLabel.bottomAnchor, constant: 5),
+            captionStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
+            captionStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
+            
+            // Timestamp
+            timestampLabel.topAnchor.constraint(equalTo: captionStackView.bottomAnchor, constant: 5),
+            timestampLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 10),
+            timestampLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10)
+        ])
+    }
+    
+    private func setupActions() {
+        optionsButton.addTarget(self, action: #selector(handleOptionsButtonTap), for: .touchUpInside)
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func handleOptionsButtonTap() {
+        optionsButtonTapped?(optionsButton)
+    }
+    
+    // MARK: - Configuration
+    
+    // Configure the cell with data from a Post model
+    // In IGListKit, cells are configured by their section controllers
+    func configure(with post: Post) {
+        usernameLabel.text = post.username
+        captionUsernameLabel.text = post.username
+        captionLabel.text = post.description
+        likesLabel.text = "\(post.likes) likes"
+        
+        // Format timestamp
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        timestampLabel.text = formatter.localizedString(for: post.timeStamp, relativeTo: Date())
+        
+        if let avatarURL = post.userAvatarURL {
+            URLSession.shared.dataTask(with: avatarURL) { [weak self] data, _, _ in
+                if let data = data, let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.avatarImageView.image = image
+                    }
+                }
+            }.resume()
+        }
+        
+        if let imageURL = post.imageURL {
+            URLSession.shared.dataTask(with: imageURL) { [weak self] data, _, _ in
+                if let data = data, let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.postImageView.image = image
+                    }
+                }
+            }.resume()
+        }
+    }
+}


### PR DESCRIPTION
## Changes in this pull request

This PR adds a new "ListoGram" demo to the IGListKit example app, showcasing how to implement a social media feed with IGListKit. The demo features infinite scrolling with pagination, post deletion, and interactive elements. Also, I've improved the UI testing infrastructure by adding helper methods for more reliable tests across different device types. The new helpers make the tests more resilient when dealing with iPad split views and ensure elements are properly visible before interacting with them. 

### Checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I added tests, an experiment, or detailed why my change isn't tested.
- [X] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [X] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/main/.github/CONTRIBUTING.md)
