### PR TITLE
Revert the header import changes

### DIFF
--- a/Source/IGListKit/IGListAdapter.h
+++ b/Source/IGListKit/IGListAdapter.h
@@ -8,19 +8,19 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListExperiments.h>
-#import <IGListKit/IGListMacros.h>
+#import "IGListExperiments.h"
+#import "IGListMacros.h"
 #else
 #import <IGListDiffKit/IGListExperiments.h>
 #import <IGListDiffKit/IGListMacros.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListAdapterDataSource.h>
-#import <IGListKit/IGListAdapterDelegate.h>
-#import <IGListKit/IGListAdapterMoveDelegate.h>
-#import <IGListKit/IGListAdapterPerformanceDelegate.h>
-#import <IGListKit/IGListAdapterUpdateListener.h>
+#import "IGListAdapterDataSource.h"
+#import "IGListAdapterDelegate.h"
+#import "IGListAdapterMoveDelegate.h"
+#import "IGListAdapterPerformanceDelegate.h"
+#import "IGListAdapterUpdateListener.h"
 #else
 #import <IGListKit/IGListAdapterDataSource.h>
 #import <IGListKit/IGListAdapterDelegate.h>

--- a/Source/IGListKit/IGListAdapterDataSource.h
+++ b/Source/IGListKit/IGListAdapterDataSource.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListDiffable.h>
+#import "IGListDiffable.h"
 #else
 #import <IGListDiffKit/IGListDiffable.h>
 #endif

--- a/Source/IGListKit/IGListAdapterDelegateAnnouncer.h
+++ b/Source/IGListKit/IGListAdapterDelegateAnnouncer.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListAdapterDelegate.h>
+#import "IGListAdapterDelegate.h"
 #else
 #import <IGListKit/IGListAdapterDelegate.h>
 #endif

--- a/Source/IGListKit/IGListAdapterUpdater.h
+++ b/Source/IGListKit/IGListAdapterUpdater.h
@@ -8,16 +8,16 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListMacros.h>
-#import <IGListKit/IGListExperiments.h>
+#import "IGListMacros.h"
+#import "IGListExperiments.h"
 #else
 #import <IGListDiffKit/IGListMacros.h>
 #import <IGListDiffKit/IGListExperiments.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListUpdatingDelegate.h>
-#import <IGListKit/IGListAdapterUpdaterDelegate.h>
+#import "IGListUpdatingDelegate.h"
+#import "IGListAdapterUpdaterDelegate.h"
 #else
 #import <IGListKit/IGListUpdatingDelegate.h>
 #import <IGListKit/IGListAdapterUpdaterDelegate.h>

--- a/Source/IGListKit/IGListAdapterUpdaterDelegate.h
+++ b/Source/IGListKit/IGListAdapterUpdaterDelegate.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListBatchUpdateData.h>
+#import "IGListBatchUpdateData.h"
 #else
 #import <IGListDiffKit/IGListBatchUpdateData.h>
 #endif

--- a/Source/IGListKit/IGListBindingSectionController.h
+++ b/Source/IGListKit/IGListBindingSectionController.h
@@ -8,15 +8,15 @@
 #import <Foundation/Foundation.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListMacros.h>
+#import "IGListMacros.h"
 #else
 #import <IGListDiffKit/IGListMacros.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListBindingSectionControllerDataSource.h>
-#import <IGListKit/IGListBindingSectionControllerSelectionDelegate.h>
-#import <IGListKit/IGListSectionController.h>
+#import "IGListBindingSectionControllerDataSource.h"
+#import "IGListBindingSectionControllerSelectionDelegate.h"
+#import "IGListSectionController.h"
 #else
 #import <IGListKit/IGListBindingSectionControllerDataSource.h>
 #import <IGListKit/IGListBindingSectionControllerSelectionDelegate.h>

--- a/Source/IGListKit/IGListBindingSingleSectionController.h
+++ b/Source/IGListKit/IGListBindingSingleSectionController.h
@@ -8,7 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListSectionController.h>
+#import "IGListSectionController.h"
 #else
 #import <IGListKit/IGListSectionController.h>
 #endif

--- a/Source/IGListKit/IGListCollectionContext.h
+++ b/Source/IGListKit/IGListCollectionContext.h
@@ -8,14 +8,14 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListExperiments.h>
+#import "IGListExperiments.h"
 #else
 #import <IGListDiffKit/IGListExperiments.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListBatchContext.h>
-#import <IGListKit/IGListCollectionScrollingTraits.h>
+#import "IGListBatchContext.h"
+#import "IGListCollectionScrollingTraits.h"
 #else
 #import <IGListKit/IGListBatchContext.h>
 #import <IGListKit/IGListCollectionScrollingTraits.h>

--- a/Source/IGListKit/IGListCollectionViewLayout.h
+++ b/Source/IGListKit/IGListCollectionViewLayout.h
@@ -8,13 +8,13 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListMacros.h>
+#import "IGListMacros.h"
 #else
 #import <IGListDiffKit/IGListMacros.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListCollectionViewLayoutCompatible.h>
+#import "IGListCollectionViewLayoutCompatible.h"
 #else
 #import <IGListKit/IGListCollectionViewLayoutCompatible.h>
 #endif

--- a/Source/IGListKit/IGListGenericSectionController.h
+++ b/Source/IGListKit/IGListGenericSectionController.h
@@ -6,7 +6,7 @@
  */
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListSectionController.h>
+#import "IGListSectionController.h"
 #else
 #import <IGListKit/IGListSectionController.h>
 #endif

--- a/Source/IGListKit/IGListKit.h
+++ b/Source/IGListKit/IGListKit.h
@@ -6,7 +6,7 @@
  */
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListCompatibility.h>
+#import "IGListCompatibility.h"
 #else
 #import <IGListDiffKit/IGListCompatibility.h>
 #endif
@@ -26,36 +26,36 @@ FOUNDATION_EXPORT const unsigned char IGListKitVersionString[];
 // iOS and tvOS only:
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListAdapter.h>
-#import <IGListKit/IGListAdapterDataSource.h>
-#import <IGListKit/IGListAdapterDelegate.h>
-#import <IGListKit/IGListAdapterDelegateAnnouncer.h>
-#import <IGListKit/IGListAdapterUpdateListener.h>
-#import <IGListKit/IGListAdapterUpdater.h>
-#import <IGListKit/IGListAdapterUpdaterDelegate.h>
-#import <IGListKit/IGListBatchContext.h>
-#import <IGListKit/IGListBindable.h>
-#import <IGListKit/IGListBindingSectionController.h>
-#import <IGListKit/IGListBindingSectionControllerDataSource.h>
-#import <IGListKit/IGListBindingSectionControllerSelectionDelegate.h>
-#import <IGListKit/IGListBindingSingleSectionController.h>
-#import <IGListKit/IGListCollectionContext.h>
-#import <IGListKit/IGListCollectionView.h>
-#import <IGListKit/IGListCollectionViewLayout.h>
-#import <IGListKit/IGListCollectionViewLayoutInvalidationContext.h>
-#import <IGListKit/IGListDisplayDelegate.h>
-#import <IGListKit/IGListGenericSectionController.h>
-#import <IGListKit/IGListCollectionViewDelegateLayout.h>
-#import <IGListKit/IGListReloadDataUpdater.h>
-#import <IGListKit/IGListScrollDelegate.h>
-#import <IGListKit/IGListSectionController.h>
-#import <IGListKit/IGListSingleSectionController.h>
-#import <IGListKit/IGListSupplementaryViewSource.h>
-#import <IGListKit/IGListTransitionData.h>
-#import <IGListKit/IGListTransitionDelegate.h>
-#import <IGListKit/IGListUpdatingDelegate.h>
-#import <IGListKit/IGListWorkingRangeDelegate.h>
-#import <IGListKit/UIViewController+IGListAdapter.h>
+#import "IGListAdapter.h"
+#import "IGListAdapterDataSource.h"
+#import "IGListAdapterDelegate.h"
+#import "IGListAdapterDelegateAnnouncer.h"
+#import "IGListAdapterUpdateListener.h"
+#import "IGListAdapterUpdater.h"
+#import "IGListAdapterUpdaterDelegate.h"
+#import "IGListBatchContext.h"
+#import "IGListBindable.h"
+#import "IGListBindingSectionController.h"
+#import "IGListBindingSectionControllerDataSource.h"
+#import "IGListBindingSectionControllerSelectionDelegate.h"
+#import "IGListBindingSingleSectionController.h"
+#import "IGListCollectionContext.h"
+#import "IGListCollectionView.h"
+#import "IGListCollectionViewLayout.h"
+#import "IGListCollectionViewLayoutInvalidationContext.h"
+#import "IGListDisplayDelegate.h"
+#import "IGListGenericSectionController.h"
+#import "IGListCollectionViewDelegateLayout.h"
+#import "IGListReloadDataUpdater.h"
+#import "IGListScrollDelegate.h"
+#import "IGListSectionController.h"
+#import "IGListSingleSectionController.h"
+#import "IGListSupplementaryViewSource.h"
+#import "IGListTransitionData.h"
+#import "IGListTransitionDelegate.h"
+#import "IGListUpdatingDelegate.h"
+#import "IGListWorkingRangeDelegate.h"
+#import "UIViewController+IGListAdapter.h"
 #else
 #import <IGListKit/IGListAdapter.h>
 #import <IGListKit/IGListAdapterDataSource.h>
@@ -94,17 +94,17 @@ FOUNDATION_EXPORT const unsigned char IGListKitVersionString[];
 // Shared (iOS, tvOS, macOS compatible):
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListAssert.h>
-#import <IGListKit/IGListBatchUpdateData.h>
-#import <IGListKit/IGListDiff.h>
-#import <IGListKit/IGListDiffable.h>
-#import <IGListKit/IGListExperiments.h>
-#import <IGListKit/IGListIndexPathResult.h>
-#import <IGListKit/IGListIndexSetResult.h>
-#import <IGListKit/IGListMoveIndex.h>
-#import <IGListKit/IGListMoveIndexPath.h>
-#import <IGListKit/NSNumber+IGListDiffable.h>
-#import <IGListKit/NSString+IGListDiffable.h>
+#import "IGListAssert.h"
+#import "IGListBatchUpdateData.h"
+#import "IGListDiff.h"
+#import "IGListDiffable.h"
+#import "IGListExperiments.h"
+#import "IGListIndexPathResult.h"
+#import "IGListIndexSetResult.h"
+#import "IGListMoveIndex.h"
+#import "IGListMoveIndexPath.h"
+#import "NSNumber+IGListDiffable.h"
+#import "NSString+IGListDiffable.h"
 #else
 #import <IGListDiffKit/IGListAssert.h>
 #import <IGListDiffKit/IGListBatchUpdateData.h>

--- a/Source/IGListKit/IGListReloadDataUpdater.h
+++ b/Source/IGListKit/IGListReloadDataUpdater.h
@@ -8,13 +8,13 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListMacros.h>
+#import "IGListMacros.h"
 #else
 #import <IGListDiffKit/IGListMacros.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListUpdatingDelegate.h>
+#import "IGListUpdatingDelegate.h"
 #else
 #import <IGListKit/IGListUpdatingDelegate.h>
 #endif

--- a/Source/IGListKit/IGListSectionController.h
+++ b/Source/IGListKit/IGListSectionController.h
@@ -8,12 +8,12 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListCollectionContext.h>
-#import <IGListKit/IGListDisplayDelegate.h>
-#import <IGListKit/IGListScrollDelegate.h>
-#import <IGListKit/IGListSupplementaryViewSource.h>
-#import <IGListKit/IGListTransitionDelegate.h>
-#import <IGListKit/IGListWorkingRangeDelegate.h>
+#import "IGListCollectionContext.h"
+#import "IGListDisplayDelegate.h"
+#import "IGListScrollDelegate.h"
+#import "IGListSupplementaryViewSource.h"
+#import "IGListTransitionDelegate.h"
+#import "IGListWorkingRangeDelegate.h"
 #else
 #import <IGListKit/IGListCollectionContext.h>
 #import <IGListKit/IGListDisplayDelegate.h>

--- a/Source/IGListKit/IGListSingleSectionController.h
+++ b/Source/IGListKit/IGListSingleSectionController.h
@@ -8,13 +8,13 @@
 #import <UIKit/UIKit.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListMacros.h>
+#import "IGListMacros.h"
 #else
 #import <IGListDiffKit/IGListMacros.h>
 #endif
 
 #if !__has_include(<IGListKit/IGListKit.h>)
-#import <IGListKit/IGListSectionController.h>
+#import "IGListSectionController.h"
 #else
 #import <IGListKit/IGListSectionController.h>
 #endif

--- a/Source/IGListKit/IGListTransitionData.h
+++ b/Source/IGListKit/IGListTransitionData.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #if !__has_include(<IGListDiffKit/IGListDiffKit.h>)
-#import <IGListKit/IGListMacros.h>
+#import "IGListMacros.h"
 #else
 #import <IGListDiffKit/IGListMacros.h>
 #endif


### PR DESCRIPTION
Another code automation changed the import stylings in some of the IGListKit headers. We've since updated the automation to skip IGListKit in future, so we just need to revert this commit and we should be good to go again!