### PR TITLE
Disable assertions in release builds for SPM targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The changelog for `IGListKit`. Also see the [releases](https://github.com/instag
 
 ### Fixes
 
+- Assertions are no longer compiled into release builds when integrating via Swift Package Manager. `NS_BLOCK_ASSERTIONS` is now defined for the `IGListDiffKit` and `IGListKit` targets in the release configuration, matching the behaviour of the Xcode project and CocoaPods. [Desmond Zhong](https://github.com/DesmondLime)
+
 - Fixed public compilation failure on macOS (SPM, CocoaPods) by conditionally importing METAUIKitBridge only when available. [Cameron Roth](https://github.com/camroth)
 
 - An infinite recursion crash when VoiceOver is enabled and `scrollViewDelegate` or `collectionViewDelegate` is set to the adapter's own `UICollectionView`. [Cameron Roth](https://github.com/camroth) [(#1658)](https://github.com/Instagram/IGListKit/issues/1658)

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,15 @@ let package = Package(
         .target(
             name: "IGListDiffKit",
             path: "spm/Sources/IGListDiffKit",
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            cSettings: [.define("NS_BLOCK_ASSERTIONS", .when(configuration: .release))]
         ),
         .target(
             name: "IGListKit",
             dependencies: ["IGListDiffKit"],
             path: "spm/Sources/IGListKit",
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            cSettings: [.define("NS_BLOCK_ASSERTIONS", .when(configuration: .release))]
         ),
         .target(
             name: "IGListSwiftKit",


### PR DESCRIPTION
## Changes in this pull request

**Disable assertions in release builds for SPM targets.**

Our app has used IGListKit for years via CocoaPods, and recently switched to Swift Package Manager. Shortly after, we started seeing a meaningful number of production crashes originating from assertions inside IGListKit.

The cause turned out to be a difference in how the two integration methods are built. Both the `IGListKit.xcodeproj` and the project CocoaPods generates set `ENABLE_NS_ASSERTIONS = NO` in their release configurations, which makes Xcode pass `-DNS_BLOCK_ASSERTIONS` and compile out the `NSCAssert` calls behind `IGAssert` and friends. SwiftPM has no equivalent build setting for C and Objective-C targets, so release builds of the package ship with every assertion still live — debug-only checks become production crashes.

This is not something consumers can work around on their own: build settings such as `OTHER_CFLAGS` and `GCC_PREPROCESSOR_DEFINITIONS` set in the app project do not propagate into a Swift package's targets.

This PR defines `NS_BLOCK_ASSERTIONS` for the `IGListDiffKit` and `IGListKit` targets in the release configuration, so that SPM matches the behaviour the Xcode project and CocoaPods have always had. Debug builds are unaffected, so the assertions keep doing their job during development and in the test suite.

We do recognise that finding and fixing the root cause of each assertion would be the better outcome. In practice these failures are tied to specific device models and hard-to-reach states, and as a small team we have not been able to reproduce them locally. Regardless of that, we think release builds behaving differently depending on the integration method is a bug worth fixing on its own.

Issue fixed: N/A

### Checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I added tests, an experiment, or detailed why my change isn't tested.
- [x] I added an entry to the `CHANGELOG.md` for any breaking changes, enhancements, or bug fixes.
- [x] I have reviewed the [contributing guide](https://github.com/Instagram/IGListKit/blob/main/.github/CONTRIBUTING.md)
